### PR TITLE
Add Planning agent example

### DIFF
--- a/python/examples/planning_agent/README.md
+++ b/python/examples/planning_agent/README.md
@@ -1,0 +1,36 @@
+# Planning Agent in MoFA
+
+## 1. 功能
+Planning Agent 能够将复杂的大任务分解成小任务，并标注任务间的依赖关系以及执行方式（同步或异步）。
+
+## 2. 用例
+1. 输入一个大型任务，获取拆解后的小任务列表。
+2. 获得结构化的任务信息，包括任务描述、依赖关系和执行类型。
+
+## 3. 输出格式
+代理返回的任务采用以下 JSON 结构：
+```json
+{
+"tasks": [
+{
+"task_id": "1",
+"description": "安装必要的开发工具（如IDE、编译器）",
+"classification": "synchronous",
+"is_synchronous": true,
+"dependencies": []
+},
+// ... 更多任务 ...
+]
+}
+```
+
+## 4. 运行
+1. 安装MoFA项目包
+2. `dora up && dora build planning_agent.yml && dora start planning_agent.yml`
+3. 启动另外一个命令端,在另外一个命令端运行 terminal-input.然后提问你要分解的任务。
+4. 运行结果有两种：
+   - 默认是用户易读的输出，会直接输出在终端中。
+   - 还有一种是json格式，它可以作为下一个节点的输入，方便进行其他处理，你可以修改`scripts/planning_agent.py`文件中函数，已经写好了注释。
+
+## 参考资料
+-[agentic_patterns](https://github.com/neural-maze/agentic_patterns)

--- a/python/examples/planning_agent/README_en.md
+++ b/python/examples/planning_agent/README_en.md
@@ -3,7 +3,7 @@
 ## 1. Functionality
 The Planning Agent is capable of breaking down complex large tasks into smaller subtasks, while annotating task dependencies and execution methods (synchronous or asynchronous).
 
-## 2. 
+## 2. Use Cases
 1. Input a large task and obtain a list of decomposed smaller tasks.
 2. Get structured task information, including task descriptions, dependencies, and execution types.
 

--- a/python/examples/planning_agent/README_en.md
+++ b/python/examples/planning_agent/README_en.md
@@ -1,0 +1,38 @@
+# Planning Agent in MoFA
+
+## 1. Functionality
+The Planning Agent is capable of breaking down complex large tasks into smaller subtasks, while annotating task dependencies and execution methods (synchronous or asynchronous).
+
+## 2. 
+1. Input a large task and obtain a list of decomposed smaller tasks.
+2. Get structured task information, including task descriptions, dependencies, and execution types.
+
+## 3. Output Format
+The agent returns tasks in the following JSON structure:
+
+```json
+{
+  "tasks": [
+    {
+      "task_id": "1",
+      "description": "Install the necessary development tools (e.g., IDE, compiler)",
+      "classification": "synchronous",
+      "is_synchronous": true,
+      "dependencies": []
+    },
+    // ... more tasks ...
+  ]
+}
+```
+
+## 4. Running the Agent
+1. Install the MoFA project package.
+2. Run `dora up && dora build planning_agent.yml && dora start planning_agent.yml`
+3. Open another command terminal and run terminal-input. Then, input the task you want to decompose.
+4. There are two types of output:
+   - By default, a user-friendly output will be displayed directly in the terminal.
+   - A JSON format output is also available, which can be used as input for the next node, facilitating further processing.
+   You can modify the function in the `scripts/planning_agent.py` file; comments have already been provided.
+
+## Reference
+- [agentic_patterns](https://github.com/neural-maze/agentic_patterns)

--- a/python/examples/planning_agent/configs/planning_agent.yml
+++ b/python/examples/planning_agent/configs/planning_agent.yml
@@ -105,7 +105,7 @@ WEB:
   SEARCH_ENGINE_TIMEOUT: 5
 
 MODEL:
-  MODEL_API_KEY: sk-bzlusoncjpzlxefglrdamzefkchnnhljjwbsxafqeqpepzsn
+  MODEL_API_KEY: s
   MODEL_NAME: deepseek-ai/DeepSeek-V2-Chat
   MODEL_MAX_TOKENS: 2048
   MODEL_API_URL: https://api.siliconflow.cn/v1/chat/completions

--- a/python/examples/planning_agent/configs/planning_agent.yml
+++ b/python/examples/planning_agent/configs/planning_agent.yml
@@ -1,0 +1,122 @@
+AGENT:
+  ROLE: Project Manager
+  BACKSTORY: You are a project manager responsible for leading a large-scale software development project. The project involves multiple teams, each working on different modules. You need to manage task distribution efficiently, ensuring that large tasks are broken down into smaller, actionable tasks, and that they are correctly classified as synchronous or asynchronous. This will enable better tracking, collaboration, and resource allocation across the teams.
+  OBJECTIVE: Your objective is to decompose complex tasks into smaller, more manageable tasks. Each task must be classified as either synchronous or asynchronous. The model should output these tasks in a JSON format, ensuring clarity and a logical flow, while also identifying dependencies between tasks.
+  SPECIFICS: Each task must have a clear description of its action.
+             Tasks should be classified as either synchronous (requires waiting for completion before moving to the next) or asynchronous (can run in parallel without waiting).
+             Indicate dependencies between tasks where applicable.
+             Return the result in valid JSON format without any comments or additional non-JSON text.
+             All responses and task descriptions should be in Chinese, including the text within the JSON output.
+  TASK: >
+    Decompose the provided large task into smaller tasks.
+    Classify each task as synchronous or asynchronous.
+    Ensure that any tasks depending on the completion of others are clearly marked as such.
+    Ensure that the output is logical, with tasks following a proper order when dependencies are present.
+    Generate the tasks in the following JSON structure:
+    {
+      "tasks": [
+        {
+          "task_id": "1",
+          "description": "Task description here",
+          "classification": "synchronous",
+          "is_synchronous": true,
+          "dependencies": []
+        },
+        {
+          "task_id": "2",
+          "description": "Task description here",
+          "classification": "asynchronous",
+          "is_synchronous": false,
+          "dependencies": ["1"]
+        }
+      ]
+    }
+  ACTIONS: >
+    - Analyze the large task: Understand the overall objective and the various components of the task.
+    - Break down into subtasks: Divide the large task into smaller, logical units that can be performed independently.
+    - Classify tasks: Label each subtask as synchronous or asynchronous.
+    - Identify dependencies: Ensure that tasks which require other tasks to be completed first are clearly marked with dependencies.
+    - Output in JSON format: Return the results in the provided JSON structure, adhering strictly to the required format.
+    - Use Chinese: Ensure all task descriptions and any additional text are in Chinese.
+  EXPECTED RESULTS: >
+    - The tasks are properly decomposed, each with a clear and concise description in Chinese.
+    - Each task is correctly classified as synchronous or asynchronous, depending on its execution requirement.
+    - The dependencies between tasks are well-defined, ensuring no task is prematurely executed.
+    - The output is in valid JSON format, following the given structure, with all text in Chinese.
+
+  EXAMPLE: |
+    {
+      "tasks": [
+        {
+          "task_id": "1",
+          "description": "Install the necessary development tools (e.g., IDE, compiler)",
+          "classification": "synchronous",
+          "is_synchronous": true,
+          "dependencies": []
+        },
+        {
+          "task_id": "2",
+          "description": "Set up version control (e.g., Git)",
+          "classification": "synchronous",
+          "is_synchronous": true,
+          "dependencies": ["1"]
+        },
+        {
+          "task_id": "3",
+          "description": "Clone the project repository from the Git server",
+          "classification": "synchronous",
+          "is_synchronous": true,
+          "dependencies": ["2"]
+        },
+        {
+          "task_id": "4",
+          "description": "Configure project dependencies (e.g., libraries, SDKs)",
+          "classification": "asynchronous",
+          "is_synchronous": false,
+          "dependencies": ["3"]
+        },
+        {
+          "task_id": "5",
+          "description": "Build the project to ensure the environment is correctly set up",
+          "classification": "synchronous",
+          "is_synchronous": true,
+          "dependencies": ["4"]
+        }
+      ]
+    }
+
+# RAG:
+#   RAG_ENABLE: false
+#   MODULE_PATH: null
+#   RAG_MODEL_NAME: text-embedding-3-small
+#   COLLECTION_NAME: mofa
+#   IS_UPLOAD_FILE: true
+#   CHROMA_PATH: ./data/output/chroma_store
+#   FILES_PATH:
+#     - ./data/output/arxiv_papers
+#   ENCODING: utf-8
+#   CHUNK_SIZE: 256
+#   RAG_SEARCH_NUM: 2
+
+WEB:
+  WEB_ENABLE: false
+  SERPER_API_KEY:
+  SEARCH_NUM: 20
+  SEARCH_ENGINE_TIMEOUT: 5
+
+MODEL:
+  MODEL_API_KEY: sk-bzlusoncjpzlxefglrdamzefkchnnhljjwbsxafqeqpepzsn
+  MODEL_NAME: deepseek-ai/DeepSeek-V2-Chat
+  MODEL_MAX_TOKENS: 2048
+  MODEL_API_URL: https://api.siliconflow.cn/v1/chat/completions
+
+ENV:
+  PROXY_URL: null
+  AGENT_TYPE: reasoner
+
+LOG:
+  LOG_PATH: ./data/output/log/log.md
+  LOG_TYPE: markdown
+  LOG_STEP_NAME: planning_result
+  CHECK_LOG_PROMPT: true
+

--- a/python/examples/planning_agent/planning_agent-graph.html
+++ b/python/examples/planning_agent/planning_agent-graph.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+</head>
+
+<body>
+    <div class="mermaid">
+        flowchart TB
+  terminal-input
+  planning-agent/op[planning-agent]
+  planning-agent/op -- planning_results as planning-agent --> terminal-input
+  terminal-input -- data as task --> planning-agent/op
+
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, securityLevel: 'loose', theme: 'base' });
+    </script>
+</body>
+
+</html>

--- a/python/examples/planning_agent/planning_agent.yml
+++ b/python/examples/planning_agent/planning_agent.yml
@@ -1,0 +1,17 @@
+nodes:
+
+  - id: terminal-input
+    build: pip install -e ../../node-hub/terminal-input
+    path: dynamic
+    outputs:
+      - data
+    inputs:
+      planning-agent: planning-agent/planning_results
+
+  - id: planning-agent
+    operator:
+      python: scripts/planning_agent.py
+      inputs:
+        task: terminal-input/data
+      outputs:
+        - planning_results

--- a/python/examples/planning_agent/scripts/planning_agent.py
+++ b/python/examples/planning_agent/scripts/planning_agent.py
@@ -1,0 +1,143 @@
+import json
+import os
+from dora import Node, DoraStatus
+import pyarrow as pa
+import re
+from mofa.kernel.utils.util import load_agent_config, create_agent_output
+from mofa.run.run_agent import run_dspy_or_crewai_agent
+from mofa.utils.files.dir import get_relative_path
+from mofa.utils.log.agent import record_agent_result_log
+
+
+class Operator:
+    def on_event(
+        self,
+        dora_event,
+        send_output,
+    ) -> DoraStatus:
+        if dora_event["type"] == "INPUT":
+            agent_inputs = ['data', 'task']
+            if dora_event["id"] in agent_inputs:
+                task = dora_event["value"][0].as_py()
+
+                yaml_file_path = get_relative_path(
+                    current_file=__file__,
+                    sibling_directory_name='configs',
+                    target_file_name='planning_agent.yml'
+                )
+                inputs = load_agent_config(yaml_file_path)
+                inputs["task"] = task
+
+                agent_result = run_dspy_or_crewai_agent(agent_config=inputs)
+                # print("agent_result: ", agent_result)
+                
+                raw_result = self.extract_json_from_text(agent_result)
+                # print("raw_result", raw_result)
+
+                processed_result = self.process_llm_output(raw_result)
+                # print('processed_result:', processed_result)
+
+                record_agent_result_log(
+                    agent_config=inputs,
+                    agent_result={
+                        "1, " + inputs.get('log_step_name', "Step_one"): {task: processed_result}
+                    }
+                )
+
+                send_output(
+                    "planning_results",
+                    pa.array([create_agent_output(
+                        step_name='keyword_results',
+                        output_data=processed_result,
+                        dataflow_status=os.getenv('IS_DATAFLOW_END', True)
+                    )]),
+                    dora_event['metadata']
+                )
+                print('planning_results:', processed_result)
+
+        return DoraStatus.CONTINUE
+
+    def extract_json_from_text(self,raw_input):
+        try:
+            json_match = re.search(r'\{.*\}', raw_input, re.DOTALL)
+            if json_match:
+                json_content = json_match.group(0)
+                result_data = json.loads(json_content)
+                return result_data
+            else:
+                print("No JSON structure found in input.")
+                return {"error": "No JSON found"}
+
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON: {e}")
+            return {"error": "Invalid JSON structure"}
+
+    # return small tasks in json format
+    # def process_llm_output(self, agent_result):
+    #     try:
+    #         if isinstance(agent_result, dict):
+    #             result_data = agent_result
+    #         else:
+    #             result_data = json.loads(agent_result)
+            
+    #         if 'tasks' in result_data:
+    #             for task in result_data['tasks']:
+    #                 if 'task_id' in task:
+    #                     task['task_id'] = str(task['task_id'])
+            
+    #         tasks = result_data.get('tasks', [])
+            
+    #         processed_tasks = []
+    #         for task in tasks:
+    #             task_info = {
+    #                 "task_id": task.get("task_id"),
+    #                 "description": task.get("description"),
+    #                 "classification": task.get("classification"),
+    #                 "is_synchronous": task.get("is_synchronous"),
+    #                 "dependencies": task.get("dependencies", [])
+    #             }
+    #             processed_tasks.append(task_info)
+            
+    #         return processed_tasks
+        
+    #     except json.JSONDecodeError as e:
+    #         print(f"Error decoding LLM result: {e}")
+    #         return {"error": "Invalid LLM response"}
+    #     except Exception as e:
+    #         print(f"Unexpected error processing LLM result: {e}")
+    #         return {"error": f"Unexpected error: {str(e)}"}
+    
+    
+    # return small tasks in a more readable way
+    def process_llm_output(self, agent_result):
+        try:
+            if isinstance(agent_result, str):
+                result_data = json.loads(agent_result)
+            else:
+                result_data = agent_result
+            
+            tasks = result_data.get('tasks', [])
+            
+            valid_tasks = [
+                task for task in tasks 
+                if task.get("task_id") is not None and task.get("description") is not None
+            ]
+
+            if not valid_tasks:
+                return {"error": "No valid tasks found in the response"}
+
+            formatted_tasks = []
+            for task in valid_tasks:
+                task_info = (
+                    f"Task ID: {task['task_id']}\n"
+                    f"Description: {task['description']}\n"
+                    f"Type: {'Synchronous' if task['is_synchronous'] else 'Asynchronous'}\n"
+                    f"Dependencies: {', '.join(task['dependencies']) if task['dependencies'] else 'None'}\n"
+                )
+                formatted_tasks.append(task_info)
+            
+            return "\n".join(formatted_tasks)
+        
+        except json.JSONDecodeError as e:
+            print(f"Error decoding LLM result: {e}")
+            return {"error": "Invalid LLM response"}


### PR DESCRIPTION
# 提交内容
- 添加了`python/examples/planning_agent`文件夹
- 完成了大任务分解的功能

# 逻辑说明
- `planning_agent/scripts/planning_agent.py`读取`planning_agent/configs/planning_agent.yml`配置文件的内容，然后带`prompt`向大模型发送大任务并获得分解后的小任务，在之后进行相应的处理形成输出结果。