### PR TITLE
update readme &  cli command new-agent syntax

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -50,6 +50,41 @@ Then, install Dora-CLI:
 cargo install dora-cli --locked
 ```
 
+### Create Agent Template
+
+Command format:
+```sh
+mofa new-agent agent-name --version x.y.z --output ../ --authors "Tom, Jack"
+```
+Where:
+- `mofa` is the command itself.
+- `new-agent` is the subcommand.
+- `agent-name` is the positional parameter, representing the name of the agent to be created.
+- `--version x.y.z` is an option, specifying the version number of the agent.
+- `--output ../` is an option, specifying the output directory.
+- `--authors "Tom, Jack"` is an option, specifying the author information.
+
+Examples:
+
+(1) Create an agent template named `agent-name` in the current directory
+
+```sh
+mofa new-agent agent-name
+```
+
+(2) Create an agent template with a specified version number and directory
+
+```sh
+mofa new-agent agent-name --version 1.0.0 --output ../
+```
+
+(3) Create an agent template with a specified version number and author information
+
+```sh
+mofa new-agent agent-name --version 1.0.0 --output ../ --authors "Tom, Jack"
+```
+
+
 ### 2. Configuration
 
 In the `examples` directory, we provide some available agent examples. Before use, you need to configure the `.yml` files in the `configs` directory of the agent. If the `node` was installed via pip, locate the node's name in the `agent-hub` and modify the `.yml` file accordingly.

--- a/python/README_cn.md
+++ b/python/README_cn.md
@@ -48,6 +48,40 @@ https://www.rust-lang.org/tools/install
 
 然后安装 `cargo install dora-cli --locked`
 
+### 创建agent模板
+
+命令格式：
+```sh
+mofa new-agent agent-name --version x.y.z --output ../ --authors "Tom, Jack"
+```
+其中：
+- mofa 是命令本身。
+- new-agent 是子命令。
+- agent-name 是位置参数，表示要创建的代理名称。
+- --version x.y.z 是选项，指定代理的版本号。
+- --output ../ 是选项，指定输出目录。
+- --authors "Tom, Jack" 是选项，指定作者信息。
+
+示例：
+
+（1）在当前目录下创建名为agent-name的agent模板
+
+```sh
+mofa new-agent agent-name
+```
+
+（2）创建指定版本号和目录的agent模板
+
+```sh
+mofa new-agent agent-name --version 1.0.0 --output ../
+```
+
+（3）创建指定版本号和作者信息的agent模板
+
+```sh
+mofa new-agent agent-name --version 1.0.0 --output ../ --authors "Tom, Jack"
+```
+
 ### 2. 配置
 
 在 `examples` 这个目录下, 我们提供一些可用的智能体案例。在使用时，首先需要对智能体的configs目录下面的yml文件进行配置。 

--- a/python/agent-hub/agent-template/cookiecutter.json
+++ b/python/agent-hub/agent-template/cookiecutter.json
@@ -1,7 +1,7 @@
 {
-    "user_agent_dir": "user-new-agent-dir",
-    "agent_name": "user-new-agent",
+    "user_agent_dir": "user-new-agent",
+    "agent_name": "new-agent-name",
     "description": "A user new agent template",
 	"version": "0.0.1",
-    "authors": "Author1, Author2"
+    "authors": "Zonghuan Wu, Cheng Chen"
 }

--- a/python/mofa/cli.py
+++ b/python/mofa/cli.py
@@ -124,8 +124,9 @@ def run(agent_name: str = 'reasoner'):
 @mofa_cli_group.command()
 @click.argument('agent_name', required=True)
 @click.option('--version', default='0.0.1', help='Version of the new agent')
-@click.option('--output', default=os.getcwd(), help='agent output path')
-def new_agent(agent_name: str, version: str, output: str):
+@click.option('--output', default=os.getcwd()+"/", help='agent output path')
+@click.option('--authors', default='Zonghuan Wu', help='authors')
+def new_agent(agent_name: str, version: str, output: str, authors: str):
     """Create a new agent from the template with configuration options using Cookiecutter."""
 
     # Define the template directory
@@ -148,7 +149,8 @@ def new_agent(agent_name: str, version: str, output: str):
             extra_context={
                 'user_agent_dir': agent_name,
                 'agent_name': agent_name,  # Use the provided agent_name
-                'version': version  # Use the provided version
+                'version': version,  # Use the provided version
+                'authors': authors
             }
         )
         click.echo(f"Successfully created new agent in {output}{agent_name}")

--- a/python/mofa/cli.py
+++ b/python/mofa/cli.py
@@ -124,7 +124,8 @@ def run(agent_name: str = 'reasoner'):
 @mofa_cli_group.command()
 @click.argument('agent_name', required=True)
 @click.option('--version', default='0.0.1', help='Version of the new agent')
-def new_agent(agent_name: str, version: str):
+@click.option('--output', default=os.getcwd(), help='agent output path')
+def new_agent(agent_name: str, version: str, output: str):
     """Create a new agent from the template with configuration options using Cookiecutter."""
 
     # Define the template directory
@@ -138,21 +139,19 @@ def new_agent(agent_name: str, version: str):
         click.echo(f"Template directory must contain a cookiecutter.json file: {template_dir}")
         return
 
-    # Define the output directory
-    output_dir = os.path.join(os.path.dirname(agent_dir_path), 'agent-hub')
-
     # Use Cookiecutter to generate the new agent from the template
     try:
         cookiecutter(
             template=template_dir,
-            output_dir=output_dir,
-            no_input=False,  # Enable interactive input
+            output_dir=output,
+            no_input=True,  # Enable interactive input
             extra_context={
+                'user_agent_dir': agent_name,
                 'agent_name': agent_name,  # Use the provided agent_name
                 'version': version  # Use the provided version
             }
         )
-        click.echo(f"Successfully created new agent in {output_dir}/{agent_name}")
+        click.echo(f"Successfully created new agent in {output}{agent_name}")
     except Exception as e:
         click.echo(f"Failed to create new agent: {e}")
         return


### PR DESCRIPTION
### 创建agent模板

命令格式：
```sh
mofa new-agent agent-name --version x.y.z --output ../ --authors "Tom, Jack"
```
其中：
- mofa 是命令本身。
- new-agent 是子命令。
- agent-name 是位置参数，表示要创建的代理名称。
- --version x.y.z 是选项，指定代理的版本号。
- --output ../ 是选项，指定输出目录。
- --authors "Tom, Jack" 是选项，指定作者信息。

示例：

（1）在当前目录下创建名为agent-name的agent模板

```sh
mofa new-agent agent-name
```

（2）创建指定版本号和目录的agent模板

```sh
mofa new-agent agent-name --version 1.0.0 --output ../
```

（3）创建指定版本号和作者信息的agent模板

```sh
mofa new-agent agent-name --version 1.0.0 --output ../ --authors "Tom, Jack"
```