### PR TITLE
Increase input queue_size for DeepInquire completions

### DIFF
--- a/python/examples/deep-inquire/deep-inquire-dataflow.yml
+++ b/python/examples/deep-inquire/deep-inquire-dataflow.yml
@@ -5,7 +5,9 @@ nodes:
     outputs:
       - v3/chat/completions
     inputs:      
-      v3/chat/completions: deep-inquire-agent/deep_inquire_result
+      v3/chat/completions:
+        source: deep-inquire-agent/deep_inquire_result
+        queue_size: 1000
 
   - id: deep-inquire-agent
     build: pip install -e ../../agent-hub/deep-inquire


### PR DESCRIPTION
Increase the size of the queue to 1000 to prevent issues with high frequency messages being dropped.