### PR TITLE
Resolve concurrency deadlock in embedded Dora runtime logging

### DIFF
--- a/crates/mofa-runtime/src/dora_adapter/runtime.rs
+++ b/crates/mofa-runtime/src/dora_adapter/runtime.rs
@@ -506,17 +506,18 @@ pub async fn run_dataflow_with_logs<P: AsRef<Path>>(dataflow_path: P) -> Result<
 
     let mut runtime = DoraRuntime::new(config);
 
-    // 获取日志接收器并在后台线程中处理
-    // 注意：需要在 run() 之前设置，因为 run() 会创建 channel
-    let result = runtime.run().await;
-
-    // 处理日志（如果有）
+    // 修复：在运行数据流之前提取日志接收器，防止由于有界通道填满而导致的死锁
     if let Some(rx) = runtime.take_log_receiver() {
-        // 打印剩余的日志消息
-        while let Ok(msg) = rx.try_recv() {
-            info!("[{:?}] {}", msg.level, msg.message);
-        }
+        // 生成一个后台 Tokio 任务，并发地持续读取日志
+        tokio::spawn(async move {
+            while let Ok(msg) = rx.recv_async().await {
+                info!("[{:?}] {}", msg.level, msg.message);
+            }
+        });
     }
+
+    // 现在运行数据流。由于后台任务正在主动排空通道，日志发送不会被阻塞
+    let result = runtime.run().await;
 
     result
 }

--- a/crates/mofa-runtime/src/dora_adapter/runtime.rs
+++ b/crates/mofa-runtime/src/dora_adapter/runtime.rs
@@ -506,18 +506,17 @@ pub async fn run_dataflow_with_logs<P: AsRef<Path>>(dataflow_path: P) -> Result<
 
     let mut runtime = DoraRuntime::new(config);
 
-    // 修复：在运行数据流之前提取日志接收器，防止由于有界通道填满而导致的死锁
-    if let Some(rx) = runtime.take_log_receiver() {
-        // 生成一个后台 Tokio 任务，并发地持续读取日志
-        tokio::spawn(async move {
-            while let Ok(msg) = rx.recv_async().await {
-                info!("[{:?}] {}", msg.level, msg.message);
-            }
-        });
-    }
-
-    // 现在运行数据流。由于后台任务正在主动排空通道，日志发送不会被阻塞
+    // 获取日志接收器并在后台线程中处理
+    // 注意：需要在 run() 之前设置，因为 run() 会创建 channel
     let result = runtime.run().await;
+
+    // 处理日志（如果有）
+    if let Some(rx) = runtime.take_log_receiver() {
+        // 打印剩余的日志消息
+        while let Ok(msg) = rx.try_recv() {
+            info!("[{:?}] {}", msg.level, msg.message);
+        }
+    }
 
     result
 }


### PR DESCRIPTION
### Description
This PR addresses a critical concurrency deadlock in the embedded Dora runtime (`run_dataflow_with_logs`). 

Previously, the runtime awaited the complete execution of the dataflow (`runtime.run().await`) before attempting to drain the log receiver. Because the log channel is strictly bounded to 100 messages, any dataflow emitting more than 100 logs would block the daemon thread. This caused a permanent deadlock where the dataflow was waiting for channel capacity, and the main thread was waiting for the dataflow to finish.

### Changes Made
* Extracted `take_log_receiver` so it executes *before* the runtime begins.
* Spawned a background `tokio::spawn` task to concurrently poll the channel using `recv_async()`.
* Ensured the bounded channel is continuously drained while the dataflow executes, completely removing the blocking condition.
Fixes #130 