### PR TITLE
fix(monitoring): use shared MetricsCollector in WebSocket handler

### DIFF
--- a/crates/mofa-monitoring/src/dashboard/server.rs
+++ b/crates/mofa-monitoring/src/dashboard/server.rs
@@ -180,11 +180,8 @@ impl DashboardServer {
 
         // Start WebSocket updates
         if let Some(ws_handler) = &self.ws_handler {
-            let _handler = ws_handler.clone();
+            let handler = ws_handler.clone();
             tokio::spawn(async move {
-                let handler = Arc::new(WebSocketHandler::new(Arc::new(MetricsCollector::new(
-                    MetricsConfig::default(),
-                ))));
                 handler.start_updates();
             });
         }


### PR DESCRIPTION
Fixes #158 

## What changed
- Removed duplicate `WebSocketHandler` creation in `server.rs`
- WebSocket handler now uses `ws_handler.clone()` (already correctly 
  initialized with `self.collector`) instead of creating a new empty collector

## Testing
- `cargo check -p mofa-monitoring` ✅
- `cargo test -p mofa-monitoring -- server` ✅ (4/4 passing)