### PR TITLE
feat: rhai PluginStats atomic counters + stats(), execute() timing + stats recording, FunctionCallingAdapter + OpenAI schema

### DIFF
--- a/crates/mofa-extra/src/rhai/rules.rs
+++ b/crates/mofa-extra/src/rhai/rules.rs
@@ -255,7 +255,8 @@ pub struct RuleGroupExecutionResult {
 // ============================================================================
 // Rule Engine
 // ============================================================================
-pub type HandlerMap = Arc<RwLock<HashMap<String, Vec<Box<dyn Fn(&str, &serde_json::Value) + Send + Sync>>>>>;
+pub type HandlerMap =
+    Arc<RwLock<HashMap<String, Vec<Box<dyn Fn(&str, &serde_json::Value) + Send + Sync>>>>>;
 /// Rule engine
 pub struct RuleEngine {
     /// Script engine

--- a/crates/mofa-kernel/src/bus/mod.rs
+++ b/crates/mofa-kernel/src/bus/mod.rs
@@ -15,7 +15,8 @@ pub enum CommunicationMode {
     /// 订阅-发布通信（基于主题）
     PubSub(String),
 }
-pub type AgentChannelMap = Arc<RwLock<HashMap<String, HashMap<CommunicationMode, broadcast::Sender<Vec<u8>>>>>>;
+pub type AgentChannelMap =
+    Arc<RwLock<HashMap<String, HashMap<CommunicationMode, broadcast::Sender<Vec<u8>>>>>>;
 /// 通信总线核心结构体
 #[derive(Clone)]
 pub struct AgentBus {

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -140,11 +140,20 @@ impl LLMClient for OpenAIClient {
         prompt: &str,
         callback: Box<dyn Fn(String) + Send + Sync>,
     ) -> PluginResult<String> {
-        // 模拟流式生成 TODO
+        // Stub: simulates word-level streaming with inter-token spacing.
+        // Replace with a real SSE/delta streaming call (e.g. via `async-openai`)
+        // once live credentials and an HTTP client are wired in.
         let response = format!("[{}] Stream response to: {}", self.config.model, prompt);
-        for chunk in response.as_str().split_whitespace() {
-            callback(chunk.to_string());
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let words: Vec<&str> = response.split_whitespace().collect();
+        let len = words.len();
+        for (i, word) in words.iter().enumerate() {
+            let chunk = if i + 1 < len {
+                format!("{} ", word) // preserve trailing space between tokens
+            } else {
+                word.to_string()
+            };
+            callback(chunk);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
         Ok(response)
     }

--- a/crates/mofa-plugins/src/rhai_runtime/function_calling.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/function_calling.rs
@@ -1,0 +1,335 @@
+//! Function-calling bridge between LLM tool-use responses and the Rhai engine.
+//!
+//! [`FunctionCallingAdapter`] performs two jobs:
+//!
+//! 1. **Schema export** — converts registered [`ToolDefinition`]s into the
+//!    OpenAI function-calling JSON schema so they can be attached to a chat
+//!    completion request.
+//!
+//! 2. **Call routing** — when the LLM responds with a [`ToolCall`], the adapter
+//!    dispatches it to the corresponding Rhai function inside the loaded script
+//!    and returns a [`ToolResult`] that can be fed back to the conversation.
+//!
+//! # Wiring a Rhai plugin script
+//!
+//! The Rhai script must expose a function whose name matches every registered
+//! tool name and that accepts a single JSON-encoded argument map:
+//!
+//! ```rhai
+//! fn search_web(params) {
+//!     // params.query is the value the LLM passed
+//!     "Results for: " + params.query
+//! }
+//! ```
+
+use mofa_extra::rhai::{RhaiScriptEngine, ScriptContext};
+use mofa_kernel::plugin::PluginResult;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::{ToolCall, ToolDefinition, ToolResult};
+
+// ============================================================================
+// FunctionCallingAdapter
+// ============================================================================
+
+/// Bridges LLM function-calling with the Rhai scripting engine.
+///
+/// Register one [`ToolDefinition`] per Rhai function you want the LLM to be
+/// able to invoke.  Then:
+///
+/// * Call [`to_openai_tools`](Self::to_openai_tools) to get the `tools` array
+///   to include in the OpenAI request.
+/// * Call [`route_tool_call`](Self::route_tool_call) for every
+///   `tool_calls` entry the LLM returns to execute the matching Rhai function
+///   and obtain the `ToolResult` to append to the message history.
+pub struct FunctionCallingAdapter {
+    /// Registered tools, keyed by name.
+    tools: HashMap<String, ToolDefinition>,
+    /// Shared Rhai script engine.
+    engine: Arc<RhaiScriptEngine>,
+    /// Cache key for the compiled plugin script.
+    script_id: String,
+}
+
+impl FunctionCallingAdapter {
+    /// Create a new adapter backed by the given engine and script cache entry.
+    ///
+    /// `script_id` must match the id used when the script was compiled with
+    /// [`RhaiScriptEngine::compile_and_cache`]; the adapter does **not**
+    /// compile the script itself.
+    pub fn new(engine: Arc<RhaiScriptEngine>, script_id: impl Into<String>) -> Self {
+        Self {
+            tools: HashMap::new(),
+            engine,
+            script_id: script_id.into(),
+        }
+    }
+
+    /// Register a tool definition.
+    ///
+    /// The adapter will include it in the OpenAI schema and route calls for it
+    /// to the Rhai function of the same name.
+    pub fn register_tool(&mut self, def: ToolDefinition) {
+        self.tools.insert(def.name.clone(), def);
+    }
+
+    /// Remove a previously registered tool by name.
+    pub fn unregister_tool(&mut self, name: &str) {
+        self.tools.remove(name);
+    }
+
+    /// Return all registered [`ToolDefinition`]s.
+    pub fn registered_tools(&self) -> impl Iterator<Item = &ToolDefinition> {
+        self.tools.values()
+    }
+
+    // -------------------------------------------------------------------------
+    // Schema helpers
+    // -------------------------------------------------------------------------
+
+    /// Convert all registered tools into the OpenAI `tools` array format.
+    ///
+    /// The returned value can be serialised directly as the `tools` field of an
+    /// OpenAI chat completion request body.
+    ///
+    /// ```json
+    /// [
+    ///   {
+    ///     "type": "function",
+    ///     "function": {
+    ///       "name": "search_web",
+    ///       "description": "Search the web for a query",
+    ///       "parameters": { "type": "object", "properties": { ... } }
+    ///     }
+    ///   }
+    /// ]
+    /// ```
+    pub fn to_openai_tools(&self) -> serde_json::Value {
+        let schemas: Vec<serde_json::Value> = self
+            .tools
+            .values()
+            .map(Self::tool_to_openai_schema)
+            .collect();
+        serde_json::json!(schemas)
+    }
+
+    /// Convert a single [`ToolDefinition`] to the OpenAI function schema object.
+    pub fn tool_to_openai_schema(def: &ToolDefinition) -> serde_json::Value {
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": def.name,
+                "description": def.description,
+                "parameters": def.parameters,
+            }
+        })
+    }
+
+    /// Full JSON-Schema representation of a tool (includes all definition fields).
+    pub fn definition_to_json_schema(def: &ToolDefinition) -> serde_json::Value {
+        serde_json::json!({
+            "name": def.name,
+            "description": def.description,
+            "parameters": def.parameters,
+            "requires_confirmation": def.requires_confirmation,
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Call routing
+    // -------------------------------------------------------------------------
+
+    /// Dispatch an LLM [`ToolCall`] to the matching Rhai function and return
+    /// the [`ToolResult`] to feed back into the conversation.
+    ///
+    /// The Rhai function receives `call.arguments` as its sole argument and
+    /// must return a JSON-serialisable value.
+    ///
+    /// If the tool is **not registered**, or the Rhai function is **not found**
+    /// in the script, a [`ToolResult`] with `success: false` is returned
+    /// (no `Err` is propagated) so the conversation can continue gracefully.
+    pub async fn route_tool_call(&self, call: &ToolCall) -> PluginResult<ToolResult> {
+        // Verify the tool is known.
+        if !self.tools.contains_key(&call.name) {
+            return Ok(ToolResult {
+                call_id: call.call_id.clone(),
+                success: false,
+                result: serde_json::Value::Null,
+                error: Some(format!(
+                    "Tool '{}' is not registered in this adapter",
+                    call.name
+                )),
+            });
+        }
+
+        let context = ScriptContext::new();
+        let args = vec![call.arguments.clone()];
+
+        match self
+            .engine
+            .call_function::<serde_json::Value>(&self.script_id, &call.name, args, &context)
+            .await
+        {
+            Ok(result) => Ok(ToolResult {
+                call_id: call.call_id.clone(),
+                success: true,
+                result,
+                error: None,
+            }),
+            Err(e) => {
+                // Distinguish "function not found" (script author omission) from
+                // genuine runtime errors so callers can decide how to handle each.
+                let msg = e.to_string().to_lowercase();
+                let is_missing = msg.contains("function not found")
+                    || msg.contains("not found in module")
+                    || msg.contains("undefined");
+
+                Ok(ToolResult {
+                    call_id: call.call_id.clone(),
+                    success: false,
+                    result: serde_json::Value::Null,
+                    error: Some(if is_missing {
+                        format!(
+                            "Rhai function '{}' not found in script '{}' \
+                             — add `fn {}(params){{}}` to the script",
+                            call.name, self.script_id, call.name
+                        )
+                    } else {
+                        e.to_string()
+                    }),
+                })
+            }
+        }
+    }
+
+    /// Compile the plugin script into the engine cache under `script_id`.
+    ///
+    /// Call this once after constructing the adapter (or after hot-reloading
+    /// the script content) so that [`route_tool_call`](Self::route_tool_call)
+    /// can find the compiled AST.
+    pub async fn compile_script(&self, script_content: &str) -> PluginResult<()> {
+        self.engine
+            .compile_and_cache(&self.script_id, "function_calling_script", script_content)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to compile script '{}': {}", self.script_id, e))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_extra::rhai::ScriptEngineConfig;
+
+    fn make_tool(name: &str, description: &str) -> ToolDefinition {
+        ToolDefinition {
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Search query" }
+                },
+                "required": ["query"]
+            }),
+            requires_confirmation: false,
+        }
+    }
+
+    #[test]
+    fn test_tool_to_openai_schema() {
+        let tool = make_tool("search_web", "Search the web");
+        let schema = FunctionCallingAdapter::tool_to_openai_schema(&tool);
+
+        assert_eq!(schema["type"], "function");
+        assert_eq!(schema["function"]["name"], "search_web");
+        assert_eq!(schema["function"]["description"], "Search the web");
+        // parameters should be forwarded verbatim
+        assert_eq!(schema["function"]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn test_definition_to_json_schema_includes_confirmation() {
+        let mut tool = make_tool("delete_file", "Delete a file");
+        tool.requires_confirmation = true;
+        let schema = FunctionCallingAdapter::definition_to_json_schema(&tool);
+
+        assert_eq!(schema["requires_confirmation"], true);
+    }
+
+    #[test]
+    fn test_to_openai_tools_multiple() {
+        let engine =
+            Arc::new(RhaiScriptEngine::new(ScriptEngineConfig::default()).expect("engine"));
+        let mut adapter = FunctionCallingAdapter::new(engine, "test_script");
+        adapter.register_tool(make_tool("tool_a", "A"));
+        adapter.register_tool(make_tool("tool_b", "B"));
+
+        let tools = adapter.to_openai_tools();
+        let arr = tools.as_array().expect("array");
+        assert_eq!(arr.len(), 2);
+        let names: Vec<&str> = arr
+            .iter()
+            .map(|t| t["function"]["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"tool_a"));
+        assert!(names.contains(&"tool_b"));
+    }
+
+    #[tokio::test]
+    async fn test_route_unknown_tool_returns_error_result() {
+        let engine =
+            Arc::new(RhaiScriptEngine::new(ScriptEngineConfig::default()).expect("engine"));
+        let adapter = FunctionCallingAdapter::new(engine, "test_script");
+
+        let call = ToolCall {
+            name: "nonexistent".to_string(),
+            arguments: serde_json::json!({}),
+            call_id: "call-1".to_string(),
+        };
+
+        let result = adapter.route_tool_call(&call).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_route_registered_tool_calls_rhai_function() {
+        let script = r#"
+            fn greet(params) {
+                "Hello, " + params.name
+            }
+        "#;
+
+        let engine =
+            Arc::new(RhaiScriptEngine::new(ScriptEngineConfig::default()).expect("engine"));
+        let mut adapter = FunctionCallingAdapter::new(engine, "greet_script");
+        adapter.register_tool(ToolDefinition {
+            name: "greet".to_string(),
+            description: "Greet someone".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            }),
+            requires_confirmation: false,
+        });
+
+        adapter.compile_script(script).await.unwrap();
+
+        let call = ToolCall {
+            name: "greet".to_string(),
+            arguments: serde_json::json!({ "name": "World" }),
+            call_id: "call-2".to_string(),
+        };
+
+        let result = adapter.route_tool_call(&call).await.unwrap();
+        assert!(result.success, "expected success, got: {:?}", result.error);
+        assert_eq!(result.result, serde_json::json!("Hello, World"));
+    }
+}

--- a/crates/mofa-plugins/src/rhai_runtime/mod.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/mod.rs
@@ -48,8 +48,11 @@
 //! }
 //! ```
 
+pub mod function_calling;
 mod plugin;
 mod types;
 
+pub use function_calling::FunctionCallingAdapter;
+pub use plugin::PluginStats;
 pub use plugin::{RhaiPlugin, RhaiPluginConfig, RhaiPluginState};
 pub use types::{PluginMetadata, RhaiPluginError, RhaiPluginResult};


### PR DESCRIPTION
## 📋 Summary

Implements two missing pieces in the Rhai plugin runtime (`mofa-plugins`), additive to and non-overlapping with issue#157 (which owns `call_script_function`):

1. **`PluginStats`** — atomic counters (`calls_total`, `calls_failed`, `avg_latency_ms`) that replace the `HashMap::new() // TODO` stub in `AgentPlugin::stats()`, enabling the monitoring dashboard to observe Rhai plugin health in real time.
2. **`FunctionCallingAdapter`** — a new type that converts registered `ToolDefinition`s into OpenAI function-calling JSON schema and routes LLM `ToolCall` responses back to named Rhai functions, unblocking LLM tool-use workflows for Rhai-backed plugins.

Also fixes the word-splitting bug in `OpenAIClient::generate_stream` (spaces were dropped between tokens).

> **Scope boundary with issue#157**: `call_script_function` implementation is deliberately left as a stub here — that dispatch logic (compilation, `Dynamic` ↔ `serde_json` marshalling, error classification) is owned by PR #157. This PR only adds the stats and function-calling adapter layers on top.

---

## 🔗 Related Issues

Closes #173

Related to #157

---

## 🧠 Context

Two TODOs in `crates/mofa-plugins/src/rhai_runtime/plugin.rs` left the Rhai plugin subsystem in a half-implemented state:

- `stats()` always returned an empty map, so the monitoring dashboard had no visibility into Rhai plugin invocations.
- There was no bridge between LLM tool-use responses and Rhai script functions, blocking any agent that needs to expose tools to an LLM.

The `generate_stream` stub in `lib.rs` also discarded inter-word spaces, producing malformed streamed output.

`call_script_function` itself (the function dispatch stub) is being addressed separately in issue #157 and is intentionally not touched here to avoid merge conflicts.

---

## 🛠️ Changes

- **`crates/mofa-plugins/src/rhai_runtime/plugin.rs`**
  - Added `PluginStats` struct with `AtomicU64` fields (`calls_total`, `calls_failed`, `total_latency_ms`), `record()`, `avg_latency_ms()`, and `to_map()` methods
  - Added `stats: Arc<PluginStats>` field to `RhaiPlugin`
  - Split `execute()` into a timing wrapper (records wall-clock latency + success/failure in `PluginStats`) and `execute_script(&self)` (inherent method containing the actual dispatch logic via `engine.call_function` directly — independent of `call_script_function`)
  - `AgentPlugin::stats()` now returns `self.stats.to_map()` instead of an empty map
  - `call_script_function` kept as stub with original `&[Dynamic]` signature — implementation deferred to issue #157

- **`crates/mofa-plugins/src/rhai_runtime/function_calling.rs`** *(new file)*
  - `FunctionCallingAdapter`: register/unregister `ToolDefinition`s, export OpenAI `tools` schema array (`to_openai_tools()`), route `ToolCall` → Rhai function → `ToolResult` (`route_tool_call()`)
  - `compile_script()` helper to load script content into the engine cache before routing
  - 5 unit tests

- **`crates/mofa-plugins/src/rhai_runtime/mod.rs`**
  - Re-exports `FunctionCallingAdapter` and `PluginStats`

- **`crates/mofa-plugins/src/lib.rs`**
  - Fixed `OpenAIClient::generate_stream`: tokens now include trailing space; delay reduced from 50 ms → 20 ms; stub comment clarified

---

## 🧪 How you Tested

1. `cargo check -p mofa-plugins` — verifies the crate compiles clean with no errors
2. `cargo test -p mofa-plugins` — all 85 library tests pass
3. `cargo test -p mofa-plugins rhai_runtime` — all 8 rhai_runtime tests pass, including 5 new `function_calling` tests and the 3 pre-existing plugin lifecycle/execute tests
4. `cargo clippy -p mofa-plugins` — 14 warnings, all pre-existing in files untouched by this PR; zero warnings introduced by new code

---

## 📸 Screenshots / Logs (if applicable)

```
running 8 tests
test rhai_runtime::function_calling::tests::test_definition_to_json_schema_includes_confirmation ... ok
test rhai_runtime::function_calling::tests::test_tool_to_openai_schema ... ok
test rhai_runtime::function_calling::tests::test_to_openai_tools_multiple ... ok
test rhai_runtime::function_calling::tests::test_route_unknown_tool_returns_error_result ... ok
test rhai_runtime::plugin::tests::test_rhai_plugin_from_content ... ok
test rhai_runtime::function_calling::tests::test_route_registered_tool_calls_rhai_function ... ok
test rhai_runtime::plugin::tests::test_rhai_plugin_execute ... ok
test rhai_runtime::plugin::tests::test_rhai_plugin_lifecycle ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 77 filtered out; finished in 0.00s
```

---

## ⚠️ Breaking Changes

- [x] No breaking changes

`PluginStats` and `FunctionCallingAdapter` are additive. The `stats()` return value changes from an empty map to a populated one — consumers that already iterate the map are unaffected.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings (no new warnings introduced)

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🧩 Additional Notes for Reviewers

- `execute_script` is an inherent `&self` method (not part of the `AgentPlugin` trait) — this is intentional so the borrow checker allows `execute(&mut self)` to time the call without fighting the mutable borrow.
- `execute_script` calls `engine.call_function` **directly** and does not go through `call_script_function`. This keeps the stats/timing path independent of PR #157's changes.
- After PR related to issue #157 merges, lifecycle hooks (`init`, `start`, `stop`, `unload`) will automatically start using the real dispatch; no changes needed in this PR's code.
- `FunctionCallingAdapter` deliberately does **not** validate JSON Schema against `parameters` at routing time — that responsibility belongs to the LLM / caller, keeping the adapter lightweight.
