### PR TITLE
fix(stability): add retry limit with exponential backoff to run_agent decorator

### DIFF
--- a/mofa/agent_build/base/base_agent.py
+++ b/mofa/agent_build/base/base_agent.py
@@ -3,6 +3,7 @@ import json
 import os
 from functools import wraps
 import traceback
+import time
 from os import mkdir
 import pyarrow as pa
 from attrs import define, field
@@ -258,10 +259,16 @@ class BaseMofaAgent:
 def run_agent(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        while True:
+        max_retries = 3
+        retry_count = 0
+        while retry_count < max_retries:
             try:
-                func(*args, **kwargs)
+                return func(*args, **kwargs)
             except Exception as e:
+                retry_count += 1
                 print(f"Error occurred: {e}")
                 traceback.print_exc()
+                if retry_count >= max_retries:
+                    raise
+                time.sleep(2 ** retry_count)
     return wrapper


### PR DESCRIPTION
## Summary

Fixes critical infinite retry loop in `mofa/agent_build/base/base_agent.py` where the `run_agent` decorator would loop forever on persistent errors.

## Changes

- `mofa/agent_build/base/base_agent.py`: Replace infinite `while True` loop with bounded retry logic (3 attempts) and exponential backoff (`2^n` seconds). Re-raises the exception after exhausting retries.

## Test Plan

- [ ] Verify agents using `@run_agent` still recover from transient errors
- [ ] Verify agents terminate after 3 failed attempts instead of looping forever
- [ ] Verify exponential backoff delays are applied between retries

Closes #189