### PR TITLE
fix(security): replace os.system() with subprocess.run() in UVR5 audio separation

### DIFF
--- a/agents/primespeech/dora_primespeech/moyoyo_tts/tools/uvr5/vr.py
+++ b/agents/primespeech/dora_primespeech/moyoyo_tts/tools/uvr5/vr.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 parent_directory = os.path.dirname(os.path.abspath(__file__))
 import logging
@@ -150,7 +151,7 @@ class AudioPre:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    subprocess.run(['ffmpeg', '-i', path, '-vn', opt_format_path, '-q:a', '2', '-y'], check=True)
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -191,7 +192,7 @@ class AudioPre:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    subprocess.run(['ffmpeg', '-i', path, '-vn', opt_format_path, '-q:a', '2', '-y'], check=True)
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -327,7 +328,7 @@ class AudioPreDeEcho:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    subprocess.run(['ffmpeg', '-i', path, '-vn', opt_format_path, '-q:a', '2', '-y'], check=True)
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)
@@ -364,7 +365,7 @@ class AudioPreDeEcho:
                 )
                 if os.path.exists(path):
                     opt_format_path = path[:-4] + ".%s" % format
-                    os.system("ffmpeg -i %s -vn %s -q:a 2 -y" % (path, opt_format_path))
+                    subprocess.run(['ffmpeg', '-i', path, '-vn', opt_format_path, '-q:a', '2', '-y'], check=True)
                     if os.path.exists(opt_format_path):
                         try:
                             os.remove(path)


### PR DESCRIPTION
## Summary

Fixes CRITICAL command injection vulnerability in PrimeSpeech UVR5 audio separation tool.

- Replace all four `os.system()` calls with `subprocess.run()` using argument lists
- Prevents command injection via shell metacharacters in filenames
- Affected lines: 153, 194, 330, 367 in `vr.py`

## Changes

- `agents/primespeech/dora_primespeech/moyoyo_tts/tools/uvr5/vr.py`: Replace `os.system()` with `subprocess.run()` at 4 locations

## Test Plan

- [ ] Verify ffmpeg conversion still works with normal filenames
- [ ] Verify filenames with special characters no longer cause command injection
- [ ] Test audio separation output quality is unchanged

Closes #186