### PR TITLE
fix(security): use environment variable reference in generated code template

### DIFF
--- a/mofa/vibe/llm_client.py
+++ b/mofa/vibe/llm_client.py
@@ -187,21 +187,18 @@ Guidelines:
         base_url = os.getenv('OPENAI_API_BASE', 'https://api.openai.com/v1')
         model = os.getenv('MOFA_VIBE_MODEL', 'gpt-4o-mini')
 
-        # Build LLM integration example with actual values
-        llm_example = ""
-        if api_key:
-            llm_example = f"""
+        llm_example = f"""
 
 ## LLM Integration (if needed)
 If the requirement involves LLM/AI calls, you can use this pre-configured OpenAI client:
 
 ```python
+import os
 from openai import OpenAI
 
-# Pre-configured with your .env settings
 client = OpenAI(
-    api_key="{api_key}",
-    base_url="{base_url}"
+    api_key=os.getenv('OPENAI_API_KEY'),
+    base_url=os.getenv('OPENAI_API_BASE', 'https://api.openai.com/v1')
 )
 
 response = client.chat.completions.create(
@@ -216,7 +213,7 @@ response = client.chat.completions.create(
 result = response.choices[0].message.content
 ```
 
-Note: The API key, base URL, and model are from your .env configuration.
+Note: Set OPENAI_API_KEY and OPENAI_API_BASE in your environment before running.
 """
 
         # Build reference section if base code provided


### PR DESCRIPTION
## Summary

Fixes API key exposure in `mofa/vibe/llm_client.py` where the `generate_code()` method embedded the actual `OPENAI_API_KEY` value into generated code output.

## Changes

- `mofa/vibe/llm_client.py`: Replace literal `{api_key}` in the generated code template with `os.getenv('OPENAI_API_KEY')` so generated code never contains real credentials

## Test Plan

- [ ] Verify generated code now shows `os.getenv('OPENAI_API_KEY')` instead of actual key
- [ ] Verify generated code is still functional when run with env vars set

Closes #187