### PR TITLE
fix(runtime): avoid lock-across-await in SimpleMessageBus send paths

### DIFF
--- a/crates/mofa-runtime/src/builder.rs
+++ b/crates/mofa-runtime/src/builder.rs
@@ -12,19 +12,19 @@ use crate::dora_adapter::{
     DoraNodeConfig, DoraResult, MessageEnvelope,
 };
 use crate::interrupt::AgentInterrupt;
-#[cfg(feature = "dora")]
-use mofa_kernel::message::AgentMessage;
 use crate::{AgentConfig, AgentMetadata, MoFAAgent};
+#[cfg(feature = "dora")]
+use ::tracing::{debug, info};
 use mofa_kernel::AgentPlugin;
 use mofa_kernel::message::AgentEvent;
+#[cfg(feature = "dora")]
+use mofa_kernel::message::AgentMessage;
 use std::collections::HashMap;
 #[cfg(feature = "dora")]
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(feature = "dora")]
 use tokio::sync::RwLock;
-#[cfg(feature = "dora")]
-use ::tracing::{debug, info};
 
 /// 智能体构建器 - 提供流式 API
 pub struct AgentBuilder {
@@ -588,38 +588,54 @@ impl SimpleMessageBus {
 
     /// 发送点对点消息
     pub async fn send_to(&self, target_id: &str, event: AgentEvent) -> anyhow::Result<()> {
-        let subs = self.subscribers.read().await;
-        if let Some(senders) = subs.get(target_id) {
-            for tx in senders {
-                let _ = tx.send(event.clone()).await;
-            }
+        let senders = {
+            let subs = self.subscribers.read().await;
+            subs.get(target_id).cloned().unwrap_or_default()
+        };
+
+        for tx in senders {
+            let _ = tx.send(event.clone()).await;
         }
         Ok(())
     }
 
     /// 广播消息给所有智能体
     pub async fn broadcast(&self, event: AgentEvent) -> anyhow::Result<()> {
-        let subs = self.subscribers.read().await;
-        for senders in subs.values() {
-            for tx in senders {
-                let _ = tx.send(event.clone()).await;
-            }
+        let senders = {
+            let subs = self.subscribers.read().await;
+            subs.values()
+                .flat_map(|agent_senders| agent_senders.iter().cloned())
+                .collect::<Vec<_>>()
+        };
+
+        for tx in senders {
+            let _ = tx.send(event.clone()).await;
         }
         Ok(())
     }
 
     /// 发布到主题
     pub async fn publish(&self, topic: &str, event: AgentEvent) -> anyhow::Result<()> {
-        let topics = self.topic_subscribers.read().await;
-        if let Some(agent_ids) = topics.get(topic) {
+        let agent_ids = {
+            let topics = self.topic_subscribers.read().await;
+            topics.get(topic).cloned().unwrap_or_default()
+        };
+
+        let senders = {
             let subs = self.subscribers.read().await;
-            for agent_id in agent_ids {
-                if let Some(senders) = subs.get(agent_id) {
-                    for tx in senders {
-                        let _ = tx.send(event.clone()).await;
+            let mut senders = Vec::new();
+            for agent_id in &agent_ids {
+                if let Some(agent_senders) = subs.get(agent_id) {
+                    for tx in agent_senders {
+                        senders.push(tx.clone());
                     }
                 }
             }
+            senders
+        };
+
+        for tx in senders {
+            let _ = tx.send(event.clone()).await;
         }
         Ok(())
     }
@@ -723,6 +739,89 @@ impl SimpleRuntime {
 impl Default for SimpleRuntime {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, not(feature = "dora")))]
+mod tests {
+    use super::SimpleMessageBus;
+    use mofa_kernel::message::AgentEvent;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio::time::{Duration, timeout};
+
+    #[tokio::test]
+    async fn send_to_does_not_block_register_on_backpressure() {
+        let bus = Arc::new(SimpleMessageBus::new());
+        let (slow_tx, mut slow_rx) = mpsc::channel(1);
+        bus.register("slow", slow_tx.clone()).await;
+
+        slow_tx.send(AgentEvent::Shutdown).await.unwrap();
+
+        let bus_for_send = Arc::clone(&bus);
+        let send_task =
+            tokio::spawn(async move { bus_for_send.send_to("slow", AgentEvent::Shutdown).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (new_tx, _new_rx) = mpsc::channel(1);
+        timeout(Duration::from_millis(200), bus.register("new", new_tx))
+            .await
+            .expect("register should not block while send_to waits");
+
+        let _ = slow_rx.recv().await;
+        send_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn broadcast_does_not_block_register_on_backpressure() {
+        let bus = Arc::new(SimpleMessageBus::new());
+        let (slow_tx, mut slow_rx) = mpsc::channel(1);
+        bus.register("slow", slow_tx.clone()).await;
+
+        slow_tx.send(AgentEvent::Shutdown).await.unwrap();
+
+        let bus_for_send = Arc::clone(&bus);
+        let send_task =
+            tokio::spawn(async move { bus_for_send.broadcast(AgentEvent::Shutdown).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (new_tx, _new_rx) = mpsc::channel(1);
+        timeout(Duration::from_millis(200), bus.register("new", new_tx))
+            .await
+            .expect("register should not block while broadcast waits");
+
+        let _ = slow_rx.recv().await;
+        send_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn publish_does_not_block_subscribe_on_backpressure() {
+        let bus = Arc::new(SimpleMessageBus::new());
+        let (slow_tx, mut slow_rx) = mpsc::channel(1);
+        bus.register("slow", slow_tx.clone()).await;
+        bus.subscribe("slow", "topic-a").await;
+
+        slow_tx.send(AgentEvent::Shutdown).await.unwrap();
+
+        let bus_for_send = Arc::clone(&bus);
+        let send_task =
+            tokio::spawn(
+                async move { bus_for_send.publish("topic-a", AgentEvent::Shutdown).await },
+            );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        timeout(
+            Duration::from_millis(200),
+            bus.subscribe("other", "topic-b"),
+        )
+        .await
+        .expect("subscribe should not block while publish waits");
+
+        let _ = slow_rx.recv().await;
+        send_task.await.unwrap().unwrap();
     }
 }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4144,6 +4144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime_message_bus_backpressure"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mofa-sdk",
+ "tokio",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -22,7 +22,8 @@ members = [
     "llm_tts_streaming",
     "agent_from_database_streaming",
     "workflow_dsl",
-    "tool_routing"
+    "tool_routing",
+    "runtime_message_bus_backpressure"
 ]
 
 [workspace.package]

--- a/examples/runtime_message_bus_backpressure/Cargo.toml
+++ b/examples/runtime_message_bus_backpressure/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "runtime_message_bus_backpressure"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+tokio.workspace = true
+
+# Local dependencies
+mofa-sdk = { path = "../../crates/mofa-sdk" }

--- a/examples/runtime_message_bus_backpressure/README.md
+++ b/examples/runtime_message_bus_backpressure/README.md
@@ -1,0 +1,23 @@
+# Runtime Message Bus Backpressure Example
+
+This example demonstrates that `SimpleMessageBus` remains responsive under backpressure after the lock-scope fix.
+
+## What it verifies
+
+1. `register_agent` completes quickly while `send_to` is waiting on a full channel.
+2. `subscribe_topic` completes quickly while `publish` is waiting on a full channel.
+
+These are practical user-facing checks for the non-Dora runtime path.
+
+## Run
+
+From the `examples` workspace:
+
+```bash
+cargo run -p runtime_message_bus_backpressure
+```
+
+Expected output includes:
+
+- `register_agent completed quickly while send_to was pending`
+- `subscribe_topic completed quickly while publish was pending`

--- a/examples/runtime_message_bus_backpressure/src/main.rs
+++ b/examples/runtime_message_bus_backpressure/src/main.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use mofa_sdk::kernel::AgentEvent;
+use mofa_sdk::runtime::{AgentBuilder, SimpleRuntime};
+use tokio::time::{Duration, sleep, timeout};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let runtime = SimpleRuntime::new();
+
+    let slow_builder = AgentBuilder::new("slow-agent", "SlowAgent");
+    let slow_meta = slow_builder.build_metadata();
+    let slow_cfg = slow_builder.build_config();
+    let mut slow_rx = runtime
+        .register_agent(slow_meta, slow_cfg, "worker")
+        .await?;
+    runtime.subscribe_topic("slow-agent", "topic-a").await?;
+
+    let bus = runtime.message_bus().clone();
+
+    println!("Scenario 1: register remains responsive while send_to is backpressured");
+
+    // Fill the slow receiver queue (capacity = 1 in SimpleRuntime::register_agent).
+    runtime
+        .send_to_agent(
+            "slow-agent",
+            AgentEvent::Custom("warmup".to_string(), vec![]),
+        )
+        .await?;
+
+    let send_task = tokio::spawn({
+        let bus = bus.clone();
+        async move {
+            bus.send_to(
+                "slow-agent",
+                AgentEvent::Custom("blocked-send".to_string(), vec![]),
+            )
+            .await
+        }
+    });
+
+    sleep(Duration::from_millis(50)).await;
+
+    let observer_builder = AgentBuilder::new("observer-agent", "ObserverAgent");
+    let observer_meta = observer_builder.build_metadata();
+    let observer_cfg = observer_builder.build_config();
+    timeout(
+        Duration::from_millis(300),
+        runtime.register_agent(observer_meta, observer_cfg, "observer"),
+    )
+    .await??;
+    println!("  register_agent completed quickly while send_to was pending");
+
+    // Drain one event to unblock the pending send task.
+    let _ = slow_rx.recv().await;
+    send_task.await??;
+    let _ = slow_rx.recv().await;
+
+    println!("Scenario 2: subscribe remains responsive while publish is backpressured");
+
+    runtime
+        .send_to_agent(
+            "slow-agent",
+            AgentEvent::Custom("warmup-2".to_string(), vec![]),
+        )
+        .await?;
+
+    let publish_task = tokio::spawn({
+        let bus = bus.clone();
+        async move {
+            bus.publish(
+                "topic-a",
+                AgentEvent::Custom("blocked-publish".to_string(), vec![]),
+            )
+            .await
+        }
+    });
+
+    sleep(Duration::from_millis(50)).await;
+
+    timeout(
+        Duration::from_millis(300),
+        runtime.subscribe_topic("observer-agent", "topic-b"),
+    )
+    .await??;
+    println!("  subscribe_topic completed quickly while publish was pending");
+
+    // Drain one event to unblock publish and consume the publish message.
+    let _ = slow_rx.recv().await;
+    publish_task.await??;
+    let _ = slow_rx.recv().await;
+
+    println!("Done: message bus remained responsive under backpressure.");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Fixes lock-across-await contention in non-Dora `SimpleMessageBus` send paths.

Fixes #216

## Root Cause
`send_to`, `broadcast`, and `publish` awaited `tx.send(...).await` while holding `RwLock` read guards.

## Changes
- Clone sender handles / topic IDs in a short lock scope.
- Drop lock guards before awaiting sends.
- Add 3 regression tests for backpressure contention:
  - `send_to_does_not_block_register_on_backpressure`
  - `broadcast_does_not_block_register_on_backpressure`
  - `publish_does_not_block_subscribe_on_backpressure`

## Testing
```bash
cargo test -p mofa-runtime -- \
  builder::tests::send_to_does_not_block_register_on_backpressure \
  builder::tests::broadcast_does_not_block_register_on_backpressure \
  builder::tests::publish_does_not_block_subscribe_on_backpressure
```
Note
Related to #202 / PR #212, but this PR fixes a different path:
`SimpleMessageBus` in `crates/mofa-runtime/src/builder.rs` (non-Dora runtime).

