### PR TITLE
fix(monitoring): implement real system metrics collection

### DIFF
--- a/crates/mofa-monitoring/Cargo.toml
+++ b/crates/mofa-monitoring/Cargo.toml
@@ -40,5 +40,8 @@ mime_guess = "2.0"
 mofa-kernel = { path = "../mofa-kernel", version = "0.1" }
 futures = "0.3.31"
 
+# System metrics
+sysinfo = "0.32"
+
 [lints]
 workspace = true

--- a/crates/mofa-monitoring/src/dashboard/metrics.rs
+++ b/crates/mofa-monitoring/src/dashboard/metrics.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::RwLock as StdRwLock;
 use std::time::{Duration, Instant};
+use sysinfo::{Pid, System};
 use tokio::sync::RwLock;
 use tracing::{debug, info};
 
@@ -482,6 +484,8 @@ pub struct MetricsCollector {
     plugin_metrics: Arc<RwLock<HashMap<String, PluginMetrics>>>,
     /// LLM metrics storage (model-specific inference metrics)
     llm_metrics: Arc<RwLock<HashMap<String, LLMMetrics>>>,
+    /// Cached system info (using std sync RwLock for sync access)
+    system: Arc<StdRwLock<System>>,
 }
 
 impl MetricsCollector {
@@ -496,6 +500,7 @@ impl MetricsCollector {
             workflow_metrics: Arc::new(RwLock::new(HashMap::new())),
             plugin_metrics: Arc::new(RwLock::new(HashMap::new())),
             llm_metrics: Arc::new(RwLock::new(HashMap::new())),
+            system: Arc::new(StdRwLock::new(System::new_all())),
         }
     }
 
@@ -546,12 +551,21 @@ impl MetricsCollector {
             .unwrap_or_default()
             .as_secs();
 
+        let mut system = self.system.write().unwrap();
+        system.refresh_all();
+
+        let pid = Pid::from_u32(std::process::id());
+        let (cpu_usage, memory_used, thread_count) = system
+            .process(pid)
+            .map(|p| (p.cpu_usage() as f64, p.memory(), p.tasks().iter().count() as u32))
+            .unwrap_or((0.0, 0, 0));
+
         SystemMetrics {
-            cpu_usage: 0.0,
-            memory_used: 0,
-            memory_total: 0,
+            cpu_usage,
+            memory_used,
+            memory_total: system.total_memory(),
             uptime_secs: self.start_time.elapsed().as_secs(),
-            thread_count: 0,
+            thread_count,
             timestamp: now,
         }
     }


### PR DESCRIPTION
### Summary
Replace hardcoded zero values in `collect_system_metrics()` with real system data using the `sysinfo` crate.

### Problem
`collect_system_metrics()` was returning hardcoded zeros for all system metrics, making the entire monitoring pipeline output useless data. Reported in #152.

### Solution
- Added `sysinfo` dependency for cross-platform system metrics
- Cached `System` instance on `MetricsCollector` using `std::sync::RwLock` to avoid expensive re-initialization on every collection cycle
- Collects real per-process CPU usage, memory, and thread count via `Pid::from_u32(std::process::id())`

### Changes
| File | Changes |
|------|---------|
| Cargo.toml | Added `sysinfo = "0.32"` |
| metrics.rs | Implemented real `collect_system_metrics()`, added cached `system` field |

### Testing
Verified that all test failures are pre-existing issues in `mofa-plugins` and `mofa-foundation` unrelated to this change. The `mofa-monitoring` crate builds and passes clippy cleanly.
```bash
cargo build -p mofa-monitoring
```

Fixes #152