### PR TITLE
feat(examples): add CLI production smoke workflow ,black-box tests and also updating Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,46 @@ The runtime provides comprehensive:
 
 Suitable for building production applications that need stable operation, rather than simple plugin testing or prototype development.
 
+## CLI Production Smoke Example
+
+To verify CLI production readiness from a user perspective, MoFA includes a
+black-box smoke example:
+
+- Path: `examples/cli_production_smoke`
+- Runner: invokes the built `mofa` binary in isolated `XDG_*` directories
+- Validation: exit codes + stable output tokens (no brittle full snapshots)
+
+Coverage in this smoke run:
+
+- Top-level commands: `info`, `config path`, `config list`
+- Agent commands: `start`, `status`, `list`, `restart`, `stop`
+- Session commands: `list`, `show`, `export`, `delete`
+- Plugin commands: `list`, `info`, `uninstall`
+- Tool commands: `list`, `info`
+
+Run it:
+
+```bash
+# repo root
+cargo build -p mofa-cli
+
+# examples workspace
+cd examples
+cargo run -p cli_production_smoke
+cargo test -p cli_production_smoke
+```
+
+Optional binary override:
+
+```bash
+export MOFA_BIN=/absolute/path/to/mofa
+```
+
+Limitations:
+
+- This smoke flow is manually run (not CI-gated in this PR).
+- Assertions focus on behavior and persistence effects, not exact formatting.
+
 ## Documentation
 
 - [API Documentation](https://docs.rs/mofa-sdk)

--- a/README_cn.md
+++ b/README_cn.md
@@ -326,6 +326,46 @@ mofa-sdk = "0.1.0"
 - 错误处理机制
 
 适合构建需要稳定运行的生产级应用，而不是简单的插件测试或原型开发。
+
+## CLI 生产级冒烟示例
+
+为了从用户视角验证 CLI 是否可用于生产，MoFA 提供了黑盒冒烟示例：
+
+- 路径：`examples/cli_production_smoke`
+- 方式：在隔离的 `XDG_*` 目录中调用已构建的 `mofa` 二进制
+- 校验：基于退出码与稳定输出关键字（不做脆弱的全量快照）
+
+当前覆盖命令：
+
+- 顶层命令：`info`、`config path`、`config list`
+- Agent：`start`、`status`、`list`、`restart`、`stop`
+- Session：`list`、`show`、`export`、`delete`
+- Plugin：`list`、`info`、`uninstall`
+- Tool：`list`、`info`
+
+运行方式：
+
+```bash
+# 仓库根目录
+cargo build -p mofa-cli
+
+# examples 工作区
+cd examples
+cargo run -p cli_production_smoke
+cargo test -p cli_production_smoke
+```
+
+可选：覆盖二进制路径
+
+```bash
+export MOFA_BIN=/absolute/path/to/mofa
+```
+
+说明：
+
+- 本次 PR 中该冒烟流程为手动验证（尚未接入 CI 必选项）。
+- 断言重点是行为与持久化效果，而不是固定输出格式。
+
 ## 文档
 
 - [API 文档](https://docs.rs/mofa-sdk)

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -18,9 +18,13 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub verbose: bool,
 
-    /// Output format (text, json, table)
-    #[arg(short = 'o', long, global = true)]
-    pub output: Option<OutputFormat>,
+    /// Global output format (text, json, table)
+    #[arg(long = "output-format", global = true)]
+    pub output_format: Option<OutputFormat>,
+
+    /// Deprecated alias for `--output-format` (root-level only for compatibility)
+    #[arg(long = "output", global = false, hide = true)]
+    pub output_legacy: Option<OutputFormat>,
 
     /// Configuration file path
     #[arg(short = 'c', long, global = true)]
@@ -232,6 +236,10 @@ pub enum AgentCommands {
     Stop {
         /// Agent ID
         agent_id: String,
+
+        /// Allow persisted state transition when runtime registry is unavailable
+        #[arg(long)]
+        force_persisted_stop: bool,
     },
 
     /// Restart an agent
@@ -355,7 +363,7 @@ pub enum SessionCommands {
         session_id: String,
 
         /// Output format
-        #[arg(short = 'o', long)]
+        #[arg(short = 'f', long, visible_short_alias = 'o')]
         format: Option<SessionFormat>,
     },
 
@@ -375,8 +383,8 @@ pub enum SessionCommands {
         session_id: String,
 
         /// Output file
-        #[arg(short, long)]
-        output: PathBuf,
+        #[arg(id = "session_export_output", short = 'o', long = "output")]
+        output_path: PathBuf,
 
         /// Export format
         #[arg(short, long)]
@@ -442,4 +450,71 @@ pub enum ToolCommands {
         /// Tool name
         name: String,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn test_legacy_output_flag_parses_for_backwards_compatibility() {
+        let parsed = Cli::try_parse_from(["mofa", "--output", "json", "info"]);
+        assert!(parsed.is_ok(), "legacy --output flag should parse");
+    }
+
+    #[test]
+    fn test_agent_stop_force_persisted_stop_flag_parses() {
+        let parsed =
+            Cli::try_parse_from(["mofa", "agent", "stop", "agent-1", "--force-persisted-stop"]);
+        assert!(
+            parsed.is_ok(),
+            "agent stop should accept --force-persisted-stop"
+        );
+    }
+
+    #[test]
+    fn test_session_show_format_json_parses() {
+        let parsed = Cli::try_parse_from(["mofa", "session", "show", "s1", "--format", "json"]);
+        assert!(parsed.is_ok(), "session show --format json should parse");
+    }
+
+    #[test]
+    fn test_session_show_legacy_short_output_flag_still_parses() {
+        let parsed = Cli::try_parse_from(["mofa", "session", "show", "s1", "-o", "json"]);
+        assert!(parsed.is_ok(), "session show -o json should still parse");
+    }
+
+    #[test]
+    fn test_session_export_output_and_format_parse_together() {
+        let parsed = Cli::try_parse_from([
+            "mofa",
+            "session",
+            "export",
+            "s1",
+            "--output",
+            "/tmp/s1.json",
+            "--format",
+            "json",
+        ]);
+        assert!(
+            parsed.is_ok(),
+            "session export --output ... --format ... should parse"
+        );
+    }
+
+    #[test]
+    fn test_session_export_legacy_short_output_flag_still_parses() {
+        let parsed = Cli::try_parse_from([
+            "mofa",
+            "session",
+            "export",
+            "s1",
+            "-o",
+            "/tmp/s1.json",
+            "--format",
+            "json",
+        ]);
+        assert!(parsed.is_ok(), "session export -o ... should still parse");
+    }
 }

--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -363,7 +363,7 @@ pub enum SessionCommands {
         session_id: String,
 
         /// Output format
-        #[arg(short = 'f', long, visible_short_alias = 'o')]
+        #[arg(short = 'f', long, short_alias = 'o')]
         format: Option<SessionFormat>,
     },
 

--- a/crates/mofa-cli/src/commands/agent/restart.rs
+++ b/crates/mofa-cli/src/commands/agent/restart.rs
@@ -13,7 +13,7 @@ pub async fn run(
 
     // Stop the agent if it's running
     if ctx.agent_registry.contains(agent_id).await {
-        super::stop::run(ctx, agent_id).await?;
+        super::stop::run(ctx, agent_id, false).await?;
     } else {
         println!("  Agent was not running");
     }
@@ -41,7 +41,7 @@ mod tests {
         start::run(&ctx, "chain-agent", None, None, false)
             .await
             .unwrap();
-        stop::run(&ctx, "chain-agent").await.unwrap();
+        stop::run(&ctx, "chain-agent", false).await.unwrap();
         run(&ctx, "chain-agent", None).await.unwrap();
 
         assert!(ctx.agent_registry.contains("chain-agent").await);

--- a/crates/mofa-cli/src/commands/agent/status.rs
+++ b/crates/mofa-cli/src/commands/agent/status.rs
@@ -31,12 +31,29 @@ pub async fn run(ctx: &CliContext, agent_id: Option<&str>) -> anyhow::Result<()>
                 }
             }
             None => {
-                println!("  Agent '{}' not found in registry", id);
-                println!();
-                println!(
-                    "  Use {} to see available agents.",
-                    "mofa agent list".cyan()
-                );
+                let persisted = ctx.agent_store.get(id).map_err(|e| {
+                    anyhow::anyhow!("Failed to load persisted agent '{}': {}", id, e)
+                })?;
+
+                if let Some(entry) = persisted {
+                    println!("  ID:           {}", entry.id.cyan());
+                    println!("  Name:         {}", entry.name.white());
+                    println!(
+                        "  State:        {}",
+                        format!("{} (persisted)", entry.state).yellow()
+                    );
+                    if let Some(desc) = entry.description {
+                        println!("  Description:  {}", desc.white());
+                    }
+                    println!("  Source:       persisted store (not active in runtime)");
+                } else {
+                    println!("  Agent '{}' not found in registry or persisted store", id);
+                    println!();
+                    println!(
+                        "  Use {} to see available agents.",
+                        "mofa agent list".cyan()
+                    );
+                }
             }
         }
     } else {

--- a/crates/mofa-cli/src/commands/agent/stop.rs
+++ b/crates/mofa-cli/src/commands/agent/stop.rs
@@ -71,16 +71,16 @@ pub async fn run(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to unregister agent: {}", e))?;
 
-    if !removed && persisted_updated {
-        if let Some(previous) = previous_entry {
-            ctx.agent_store.save(agent_id, &previous).map_err(|e| {
-                anyhow::anyhow!(
-                    "Agent '{}' remained registered and failed to restore persisted state: {}",
-                    agent_id,
-                    e
-                )
-            })?;
-        }
+    if !removed && persisted_updated
+        && let Some(previous) = previous_entry
+    {
+        ctx.agent_store.save(agent_id, &previous).map_err(|e| {
+            anyhow::anyhow!(
+                "Agent '{}' remained registered and failed to restore persisted state: {}",
+                agent_id,
+                e
+            )
+        })?;
     }
 
     if removed {

--- a/crates/mofa-cli/src/commands/agent/stop.rs
+++ b/crates/mofa-cli/src/commands/agent/stop.rs
@@ -71,7 +71,8 @@ pub async fn run(
         .await
         .map_err(|e| anyhow::anyhow!("Failed to unregister agent: {}", e))?;
 
-    if !removed && persisted_updated
+    if !removed
+        && persisted_updated
         && let Some(previous) = previous_entry
     {
         ctx.agent_store.save(agent_id, &previous).map_err(|e| {

--- a/crates/mofa-cli/src/commands/plugin/uninstall.rs
+++ b/crates/mofa-cli/src/commands/plugin/uninstall.rs
@@ -46,7 +46,8 @@ pub async fn run(ctx: &CliContext, name: &str, force: bool) -> anyhow::Result<()
         .unregister(name)
         .map_err(|e| anyhow::anyhow!("Failed to unregister plugin: {}", e))?;
 
-    if !removed && persisted_updated
+    if !removed
+        && persisted_updated
         && let Some(previous) = previous_spec
     {
         ctx.plugin_store.save(name, &previous).map_err(|e| {

--- a/crates/mofa-cli/src/commands/plugin/uninstall.rs
+++ b/crates/mofa-cli/src/commands/plugin/uninstall.rs
@@ -46,16 +46,16 @@ pub async fn run(ctx: &CliContext, name: &str, force: bool) -> anyhow::Result<()
         .unregister(name)
         .map_err(|e| anyhow::anyhow!("Failed to unregister plugin: {}", e))?;
 
-    if !removed && persisted_updated {
-        if let Some(previous) = previous_spec {
-            ctx.plugin_store.save(name, &previous).map_err(|e| {
-                anyhow::anyhow!(
-                    "Plugin '{}' remained registered and failed to restore persisted state: {}",
-                    name,
-                    e
-                )
-            })?;
-        }
+    if !removed && persisted_updated
+        && let Some(previous) = previous_spec
+    {
+        ctx.plugin_store.save(name, &previous).map_err(|e| {
+            anyhow::anyhow!(
+                "Plugin '{}' remained registered and failed to restore persisted state: {}",
+                name,
+                e
+            )
+        })?;
     }
 
     if removed {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -629,6 +629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
+name = "cli_production_smoke"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2818,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
@@ -3035,6 +3045,15 @@ dependencies = [
  "serde",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4997,6 +5016,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "cli_production_smoke",
     "plugin_system",
     "workflow_orchestration",
     "wasm_plugin",

--- a/examples/cli_production_smoke/Cargo.toml
+++ b/examples/cli_production_smoke/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cli_production_smoke"
+version.workspace = true
+edition.workspace = true
+description = "User-perspective CLI production smoke checks for MoFA"
+
+[dependencies]
+anyhow.workspace = true
+tempfile.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/examples/cli_production_smoke/README.md
+++ b/examples/cli_production_smoke/README.md
@@ -1,0 +1,41 @@
+# CLI Production Smoke Example
+
+This example validates MoFA CLI behavior from a user perspective by invoking the
+`mofa` binary as a subprocess and checking command outcomes.
+
+## What it validates
+
+- Top-level smoke commands: `info`, `config path`, `config list`
+- Agent lifecycle: `start`, `status`, `list`, `restart`, `stop`
+- Session lifecycle: `list`, `show`, `export`, `delete`
+- Plugin lifecycle: `list`, `info`, `uninstall`
+- Tool commands: `list`, `info`
+
+## Prerequisites
+
+Build the CLI binary from repo root:
+
+```bash
+cargo build -p mofa-cli
+```
+
+If needed, override binary path:
+
+```bash
+export MOFA_BIN=/absolute/path/to/mofa
+```
+
+## Run
+
+From `examples/`:
+
+```bash
+cargo run -p cli_production_smoke
+cargo test -p cli_production_smoke
+```
+
+## Notes
+
+- The runner uses isolated `XDG_*` directories in a temporary folder.
+- Assertions are based on stable output tokens and exit codes (not full snapshots).
+- This is a manual smoke workflow; CI wiring can be added in a follow-up PR.

--- a/examples/cli_production_smoke/src/lib.rs
+++ b/examples/cli_production_smoke/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -462,7 +462,7 @@ fn binary_name(base: &str) -> String {
     if cfg!(windows) {
         format!("{base}.exe")
     } else {
-        base.to_string()
+        base.to_owned()
     }
 }
 

--- a/examples/cli_production_smoke/src/lib.rs
+++ b/examples/cli_production_smoke/src/lib.rs
@@ -1,0 +1,475 @@
+#![allow(missing_docs)]
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+use tempfile::TempDir;
+
+pub const DEFAULT_AGENT_ID: &str = "smoke-agent-1";
+pub const DEFAULT_SESSION_ID: &str = "smoke-session-1";
+
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub args: Vec<String>,
+    pub status: ExitStatus,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CommandOutput {
+    pub fn success(&self) -> bool {
+        self.status.success()
+    }
+
+    pub fn command_line(&self) -> String {
+        self.args.join(" ")
+    }
+}
+
+#[derive(Debug)]
+pub struct SmokeEnvironment {
+    _temp_dir: TempDir,
+    pub mofa_bin: PathBuf,
+    pub xdg_config_home: PathBuf,
+    pub xdg_data_home: PathBuf,
+    pub xdg_cache_home: PathBuf,
+}
+
+impl SmokeEnvironment {
+    pub fn new() -> Result<Self> {
+        let mofa_bin = resolve_mofa_bin()?;
+        Self::new_with_bin(mofa_bin)
+    }
+
+    pub fn new_with_bin(mofa_bin: PathBuf) -> Result<Self> {
+        validate_mofa_bin(&mofa_bin)?;
+
+        let temp_dir = TempDir::new().context("Failed to create temp directory for smoke run")?;
+        let xdg_config_home = temp_dir.path().join("xdg-config");
+        let xdg_data_home = temp_dir.path().join("xdg-data");
+        let xdg_cache_home = temp_dir.path().join("xdg-cache");
+
+        fs::create_dir_all(&xdg_config_home)
+            .with_context(|| format!("Failed to create {}", xdg_config_home.display()))?;
+        fs::create_dir_all(&xdg_data_home)
+            .with_context(|| format!("Failed to create {}", xdg_data_home.display()))?;
+        fs::create_dir_all(&xdg_cache_home)
+            .with_context(|| format!("Failed to create {}", xdg_cache_home.display()))?;
+
+        Ok(Self {
+            _temp_dir: temp_dir,
+            mofa_bin,
+            xdg_config_home,
+            xdg_data_home,
+            xdg_cache_home,
+        })
+    }
+
+    pub fn temp_root(&self) -> &Path {
+        self._temp_dir.path()
+    }
+
+    pub fn mofa_data_dir(&self) -> PathBuf {
+        self.xdg_data_home.join("mofa")
+    }
+
+    pub fn run(&self, args: &[&str]) -> Result<CommandOutput> {
+        let output = Command::new(&self.mofa_bin)
+            .args(args)
+            .current_dir(workspace_root())
+            .env("XDG_CONFIG_HOME", &self.xdg_config_home)
+            .env("XDG_DATA_HOME", &self.xdg_data_home)
+            .env("XDG_CACHE_HOME", &self.xdg_cache_home)
+            .env("NO_COLOR", "1")
+            .env("CLICOLOR", "0")
+            .output()
+            .with_context(|| format!("Failed to run '{}'", self.mofa_bin.display()))?;
+
+        Ok(CommandOutput {
+            args: args.iter().map(|s| s.to_string()).collect(),
+            status: output.status,
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SmokeReport {
+    pub steps: Vec<StepResult>,
+}
+
+impl SmokeReport {
+    pub fn passed_count(&self) -> usize {
+        self.steps.iter().filter(|s| s.passed).count()
+    }
+
+    pub fn failed_count(&self) -> usize {
+        self.steps.len().saturating_sub(self.passed_count())
+    }
+
+    pub fn all_passed(&self) -> bool {
+        self.failed_count() == 0
+    }
+
+    fn record_step(&mut self, name: &'static str, result: Result<()>) {
+        match result {
+            Ok(()) => self.steps.push(StepResult {
+                name,
+                passed: true,
+                error: None,
+            }),
+            Err(err) => self.steps.push(StepResult {
+                name,
+                passed: false,
+                error: Some(format!("{err:#}")),
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StepResult {
+    pub name: &'static str,
+    pub passed: bool,
+    pub error: Option<String>,
+}
+
+pub fn run_full_smoke() -> Result<SmokeReport> {
+    let env = SmokeEnvironment::new()?;
+    Ok(run_full_smoke_with_env(&env))
+}
+
+pub fn run_full_smoke_with_env(env: &SmokeEnvironment) -> SmokeReport {
+    let mut report = SmokeReport::default();
+
+    report.record_step("Top-level CLI commands", smoke_top_level_commands(env));
+    report.record_step("Tool commands", smoke_tool_commands(env));
+    report.record_step("Plugin lifecycle", smoke_plugin_lifecycle(env));
+    report.record_step(
+        "Agent lifecycle",
+        smoke_agent_lifecycle(env, DEFAULT_AGENT_ID),
+    );
+    report.record_step(
+        "Session lifecycle",
+        smoke_session_lifecycle(env, DEFAULT_SESSION_ID),
+    );
+    report.record_step(
+        "Negative checks",
+        smoke_deleted_session_show_fails(env, DEFAULT_SESSION_ID),
+    );
+
+    report
+}
+
+pub fn smoke_top_level_commands(env: &SmokeEnvironment) -> Result<()> {
+    let info = env.run(&["info"])?;
+    expect_ok(&info, "mofa info")?;
+    expect_stdout_contains(&info, "MoFA", "mofa info")?;
+
+    let config_path = env.run(&["config", "path"])?;
+    expect_ok(&config_path, "mofa config path")?;
+    expect_stdout_contains(&config_path, "mofa", "mofa config path")?;
+
+    let config_list = env.run(&["config", "list"])?;
+    expect_ok(&config_list, "mofa config list")?;
+    expect_stdout_contains(&config_list, "Global configuration", "mofa config list")?;
+
+    Ok(())
+}
+
+pub fn smoke_tool_commands(env: &SmokeEnvironment) -> Result<()> {
+    let list = env.run(&["tool", "list"])?;
+    expect_ok(&list, "mofa tool list")?;
+    expect_stdout_contains(&list, "echo", "mofa tool list")?;
+
+    let info = env.run(&["tool", "info", "echo"])?;
+    expect_ok(&info, "mofa tool info echo")?;
+    expect_stdout_contains(&info, "Tool information", "mofa tool info echo")?;
+    expect_stdout_contains(&info, "echo", "mofa tool info echo")?;
+
+    Ok(())
+}
+
+pub fn smoke_plugin_lifecycle(env: &SmokeEnvironment) -> Result<()> {
+    let initial_list = env.run(&["plugin", "list"])?;
+    expect_ok(&initial_list, "mofa plugin list")?;
+    expect_stdout_contains(&initial_list, "http-plugin", "mofa plugin list")?;
+
+    let info = env.run(&["plugin", "info", "http-plugin"])?;
+    expect_ok(&info, "mofa plugin info http-plugin")?;
+    expect_stdout_contains(&info, "Plugin information", "mofa plugin info http-plugin")?;
+
+    let uninstall = env.run(&["plugin", "uninstall", "http-plugin", "--force"])?;
+    expect_ok(&uninstall, "mofa plugin uninstall http-plugin --force")?;
+
+    let after_uninstall = env.run(&["plugin", "list"])?;
+    expect_ok(&after_uninstall, "mofa plugin list (after uninstall)")?;
+    expect_stdout_not_contains(
+        &after_uninstall,
+        "http-plugin",
+        "mofa plugin list (after uninstall)",
+    )?;
+
+    Ok(())
+}
+
+pub fn smoke_agent_lifecycle(env: &SmokeEnvironment, agent_id: &str) -> Result<()> {
+    let start = env.run(&["agent", "start", agent_id, "--type", "cli-base"])?;
+    expect_ok(&start, "mofa agent start")?;
+    expect_output_contains(&start, "started", "mofa agent start")?;
+
+    let status = env.run(&["agent", "status", agent_id])?;
+    expect_ok(&status, "mofa agent status")?;
+    expect_output_contains(&status, "State:", "mofa agent status")?;
+    expect_output_not_contains(&status, "not found", "mofa agent status")?;
+
+    let list = env.run(&["agent", "list"])?;
+    expect_ok(&list, "mofa agent list")?;
+    expect_stdout_contains(&list, agent_id, "mofa agent list")?;
+
+    let restart = env.run(&["agent", "restart", agent_id])?;
+    expect_ok(&restart, "mofa agent restart")?;
+    expect_output_contains(&restart, "restarted", "mofa agent restart")?;
+
+    let stop = env.run(&["agent", "stop", agent_id, "--force-persisted-stop"])?;
+    expect_ok(&stop, "mofa agent stop --force-persisted-stop")?;
+    if !(stop.stdout.contains("stopped and unregistered")
+        || stop.stdout.contains("updated persisted state to Stopped"))
+    {
+        bail!(
+            "mofa agent stop output did not confirm stopped transition.\nstdout:\n{}\nstderr:\n{}",
+            stop.stdout,
+            stop.stderr
+        );
+    }
+
+    let running_only = env.run(&["agent", "list", "--running"])?;
+    expect_ok(&running_only, "mofa agent list --running")?;
+    expect_stdout_not_contains(&running_only, agent_id, "mofa agent list --running")?;
+
+    Ok(())
+}
+
+pub fn smoke_session_lifecycle(env: &SmokeEnvironment, session_id: &str) -> Result<()> {
+    write_session_fixture(env, session_id)?;
+
+    let list = env.run(&["session", "list"])?;
+    expect_ok(&list, "mofa session list")?;
+    expect_stdout_contains(&list, session_id, "mofa session list")?;
+
+    let show = env.run(&["session", "show", session_id, "--format", "json"])?;
+    expect_ok(&show, "mofa session show --format json")?;
+    let shown_json =
+        extract_json_payload(&show).context("Failed to parse session show JSON output")?;
+    let shown_id = shown_json
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if shown_id != session_id {
+        bail!(
+            "mofa session show returned unexpected session_id: expected '{session_id}', got '{shown_id}'"
+        );
+    }
+
+    let export_file = env.temp_root().join("session-export.json");
+    let export_file_arg = export_file.to_string_lossy().to_string();
+    let export = env.run(&[
+        "session",
+        "export",
+        session_id,
+        "--output",
+        &export_file_arg,
+        "--format",
+        "json",
+    ])?;
+    expect_ok(&export, "mofa session export")?;
+
+    let exported_raw = fs::read_to_string(&export_file)
+        .with_context(|| format!("Failed to read {}", export_file.display()))?;
+    let exported_json: Value = serde_json::from_str(&exported_raw)
+        .with_context(|| format!("Failed to parse {} as JSON", export_file.display()))?;
+    let exported_id = exported_json
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if exported_id != session_id {
+        bail!(
+            "mofa session export returned unexpected session_id: expected '{session_id}', got '{exported_id}'"
+        );
+    }
+
+    let delete = env.run(&["session", "delete", session_id, "--force"])?;
+    expect_ok(&delete, "mofa session delete --force")?;
+
+    Ok(())
+}
+
+pub fn smoke_deleted_session_show_fails(env: &SmokeEnvironment, session_id: &str) -> Result<()> {
+    let deleted_show = env.run(&["session", "show", session_id])?;
+    expect_fail(&deleted_show, "mofa session show (after delete)")?;
+    expect_output_contains(
+        &deleted_show,
+        "not found",
+        "mofa session show (after delete)",
+    )?;
+    Ok(())
+}
+
+pub fn write_session_fixture(env: &SmokeEnvironment, session_id: &str) -> Result<PathBuf> {
+    let sessions_dir = env.mofa_data_dir().join("sessions");
+    fs::create_dir_all(&sessions_dir)
+        .with_context(|| format!("Failed to create {}", sessions_dir.display()))?;
+
+    let fixture_path = sessions_dir.join(format!("{session_id}.jsonl"));
+    let fixture = format!(
+        concat!(
+            "{{\"key\":\"{session_id}\",\"created_at\":\"2026-01-01T00:00:00Z\",\"updated_at\":\"2026-01-01T00:00:01Z\",\"metadata\":{{}}}}\n",
+            "{{\"role\":\"user\",\"content\":\"hello from smoke test\",\"timestamp\":\"2026-01-01T00:00:01Z\"}}\n",
+            "{{\"role\":\"assistant\",\"content\":\"hello back\",\"timestamp\":\"2026-01-01T00:00:02Z\"}}\n"
+        ),
+        session_id = session_id
+    );
+
+    fs::write(&fixture_path, fixture)
+        .with_context(|| format!("Failed to write {}", fixture_path.display()))?;
+
+    Ok(fixture_path)
+}
+
+pub fn expect_ok(output: &CommandOutput, label: &str) -> Result<()> {
+    if output.success() {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} failed unexpectedly (cmd: {}).\nstdout:\n{}\nstderr:\n{}",
+        output.command_line(),
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn expect_fail(output: &CommandOutput, label: &str) -> Result<()> {
+    if !output.success() {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} succeeded unexpectedly (cmd: {}).\nstdout:\n{}\nstderr:\n{}",
+        output.command_line(),
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn expect_stdout_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
+    if output.stdout.contains(needle) {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} output did not contain '{needle}'.\nstdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn expect_stdout_not_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
+    if !output.stdout.contains(needle) {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} output unexpectedly contained '{needle}'.\nstdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn expect_output_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
+    if output.stdout.contains(needle) || output.stderr.contains(needle) {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} output did not contain '{needle}' in stdout/stderr.\nstdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn expect_output_not_contains(output: &CommandOutput, needle: &str, label: &str) -> Result<()> {
+    if !output.stdout.contains(needle) && !output.stderr.contains(needle) {
+        return Ok(());
+    }
+
+    bail!(
+        "{label} output unexpectedly contained '{needle}' in stdout/stderr.\nstdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    )
+}
+
+pub fn extract_json_payload(output: &CommandOutput) -> Result<Value> {
+    let start = output
+        .stdout
+        .find('{')
+        .ok_or_else(|| anyhow::anyhow!("Could not find JSON object in output"))?;
+    let payload = &output.stdout[start..];
+    serde_json::from_str(payload).context("Invalid JSON payload")
+}
+
+pub fn resolve_mofa_bin() -> Result<PathBuf> {
+    if let Ok(raw) = std::env::var("MOFA_BIN") {
+        let raw = raw.trim();
+        if !raw.is_empty() {
+            return validate_mofa_bin(Path::new(raw));
+        }
+    }
+
+    let fallback = workspace_root()
+        .join("target")
+        .join("debug")
+        .join(binary_name("mofa"));
+
+    if fallback.exists() {
+        return Ok(fallback);
+    }
+
+    bail!(
+        "Could not find mofa binary. Build it with `cargo build -p mofa-cli` from repo root, \
+         or set MOFA_BIN to the binary path. Expected fallback: {}",
+        fallback.display()
+    )
+}
+
+fn validate_mofa_bin(path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+    if path.is_file() {
+        return Ok(path.to_path_buf());
+    }
+
+    bail!(
+        "Could not find mofa binary at '{}'. Build with `cargo build -p mofa-cli` or set MOFA_BIN to a valid binary path.",
+        path.display()
+    )
+}
+
+fn binary_name(base: &str) -> String {
+    if cfg!(windows) {
+        format!("{base}.exe")
+    } else {
+        base.to_string()
+    }
+}
+
+pub fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}

--- a/examples/cli_production_smoke/src/main.rs
+++ b/examples/cli_production_smoke/src/main.rs
@@ -1,0 +1,33 @@
+#![allow(missing_docs)]
+
+use anyhow::{Result, bail};
+use cli_production_smoke::run_full_smoke;
+
+fn main() -> Result<()> {
+    println!("=== MoFA CLI Production Smoke Check ===\n");
+
+    let report = run_full_smoke()?;
+    let total = report.steps.len();
+
+    for (idx, step) in report.steps.iter().enumerate() {
+        let status = if step.passed { "OK" } else { "FAIL" };
+        println!("[{}/{}] {} ... {}", idx + 1, total, step.name, status);
+        if let Some(err) = &step.error {
+            println!("  {}", err.replace('\n', "\n  "));
+        }
+    }
+
+    println!();
+    println!(
+        "Summary: {} passed, {} failed",
+        report.passed_count(),
+        report.failed_count()
+    );
+
+    if report.all_passed() {
+        println!("All CLI smoke checks passed.");
+        Ok(())
+    } else {
+        bail!("CLI smoke checks failed")
+    }
+}

--- a/examples/cli_production_smoke/tests/smoke.rs
+++ b/examples/cli_production_smoke/tests/smoke.rs
@@ -1,0 +1,94 @@
+#![allow(missing_docs)]
+
+use anyhow::{Result, bail};
+use cli_production_smoke::{
+    DEFAULT_AGENT_ID, DEFAULT_SESSION_ID, SmokeEnvironment, expect_ok, expect_stdout_contains,
+    expect_stdout_not_contains, run_full_smoke, smoke_agent_lifecycle,
+    smoke_deleted_session_show_fails, smoke_plugin_lifecycle, smoke_session_lifecycle,
+};
+use std::path::PathBuf;
+
+#[test]
+fn full_workflow_passes() -> Result<()> {
+    let report = run_full_smoke()?;
+    if !report.all_passed() {
+        let failures = report
+            .steps
+            .iter()
+            .filter(|s| !s.passed)
+            .map(|s| {
+                format!(
+                    "- {}: {}",
+                    s.name,
+                    s.error
+                        .clone()
+                        .unwrap_or_else(|| "unknown error".to_string())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!("Smoke report has failing steps:\n{}", failures);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn plugin_uninstall_persists_across_process_calls() -> Result<()> {
+    let env = SmokeEnvironment::new()?;
+    smoke_plugin_lifecycle(&env)?;
+
+    let list_after = env.run(&["plugin", "list"])?;
+    expect_ok(
+        &list_after,
+        "mofa plugin list after uninstall (extra check)",
+    )?;
+    expect_stdout_not_contains(
+        &list_after,
+        "http-plugin",
+        "mofa plugin list after uninstall (extra check)",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn agent_lifecycle_roundtrip_passes() -> Result<()> {
+    let env = SmokeEnvironment::new()?;
+    smoke_agent_lifecycle(&env, DEFAULT_AGENT_ID)?;
+
+    let status_after_stop = env.run(&["agent", "status", DEFAULT_AGENT_ID])?;
+    expect_ok(&status_after_stop, "mofa agent status after stop")?;
+    expect_stdout_contains(
+        &status_after_stop,
+        "Stopped (persisted)",
+        "mofa agent status after stop",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn deleted_session_show_fails() -> Result<()> {
+    let env = SmokeEnvironment::new()?;
+    smoke_session_lifecycle(&env, DEFAULT_SESSION_ID)?;
+    smoke_deleted_session_show_fails(&env, DEFAULT_SESSION_ID)?;
+    Ok(())
+}
+
+#[test]
+fn missing_binary_error_is_actionable() {
+    let missing = PathBuf::from("/tmp/definitely-missing-mofa-binary");
+    let err = SmokeEnvironment::new_with_bin(missing)
+        .expect_err("new_with_bin should fail for missing binary")
+        .to_string();
+
+    assert!(
+        err.contains("Could not find mofa binary"),
+        "missing actionable error text: {err}"
+    );
+    assert!(
+        err.contains("MOFA_BIN") || err.contains("cargo build -p mofa-cli"),
+        "missing remediation guidance: {err}"
+    );
+}


### PR DESCRIPTION
Delivers end-to-end CLI production readiness verification: a black-box smoke crate, legacy flag compatibility, safer agent stop semantics, and TDD-style test hardening. Resolves two `clippy::collapsible_if` warnings introduced in the feature commit.

### follow up for #219 to fix the add CLI production smoke workflow and black-box tests and also adding suitable readme bilingually

## 📋 Summary
Adds `examples/cli_production_smoke` as a runnable, subprocess-based smoke suite for the `mofa` binary. Restores legacy `--output`/`-o` compatibility with normalization logic. Hardens `mofa agent stop` to require `--force-persisted-stop` when the runtime registry is absent. Fixes `clippy::collapsible_if` warnings in `stop.rs` and `uninstall.rs`.

## 🧠 Context
CLI commands run in separate processes, so the runtime registry is empty on fresh startup. Without an explicit guard, `mofa agent stop` could silently mutate persisted state in ambiguous situations. Legacy `--output`/`-o` flags were also at risk after introducing `--output-format`, which could break existing scripts.

## 🛠️ Changes
- `examples/cli_production_smoke`: new workspace crate; `lib.rs` exposes 6 composable smoke steps; `main.rs` provides runnable reporting; `tests/smoke.rs` includes subprocess-based integration tests with isolated `XDG_*` dirs
- `crates/mofa-cli/src/main.rs`: `normalize_legacy_output_flags()` rewrites legacy `--output`/`-o <format>` to `--output-format` before clap parsing
- `crates/mofa-cli/src/main.rs`: intentionally excludes rewriting `-o` under `session show` and `session export`, because those are local subcommand flags
- `crates/mofa-cli/src/commands/agent/stop.rs`: requires `--force-persisted-stop` to mark persisted state as `Stopped` when the agent is absent from runtime registry; otherwise returns actionable error
- `crates/mofa-cli/src/commands/agent/stop.rs` and `crates/mofa-cli/src/commands/plugin/uninstall.rs`: collapsed nested `if { if let }` into let-chain form to satisfy `clippy::collapsible_if`
- `README.md` and `README_cn.md`: added "CLI Production Smoke Example" section with coverage and run instructions

## 🧪 How you Tested
1. `cargo test -p mofa-cli`  
   `50` unit + `4` integration tests passed.
2. `cargo clippy -p mofa-cli --no-deps -- -D warnings`  
   Zero warnings for the `mofa-cli` crate.
3. `cargo check --manifest-path examples/Cargo.toml -p cli_production_smoke`  
   Example crate compiles cleanly.
4. `cargo test --manifest-path examples/Cargo.toml -p cli_production_smoke --test smoke`  
   Smoke integration tests passed.

## Logs (if applicable)
```
test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## ⚠️ Breaking Changes
- [x] No breaking changes
- [x] Breaking change (describe below)

`mofa agent stop <id>` without `--force-persisted-stop` now errors when the agent exists only in persisted store (not runtime registry). Scripts relying on silent persisted-state mutation must add `--force-persisted-stop`.

## 🧹 Checklist
### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

## 🧩 Additional Notes for Reviewers
- Smoke tests require the `mofa` binary to be prebuilt (`cargo build -p mofa-cli`) when `MOFA_BIN` is not provided.
- `normalize_legacy_output_flags` intentionally does not rewrite `-o` under `session show` or `session export` because those flags are local aliases, not global output format.
- Let-chain style (`if x && let Some(y) = z`) is used for clippy compliance; workspace edition is already `2024`.
