### PR TITLE
fix(plugins): replace expect() panic with unwrap_or_default() in Rhai hot-reload path

### DIFF
--- a/crates/mofa-plugins/src/rhai_runtime/plugin.rs
+++ b/crates/mofa-plugins/src/rhai_runtime/plugin.rs
@@ -291,7 +291,7 @@ impl RhaiPlugin {
             RhaiPluginSource::File(path) => std::fs::metadata(path)?
                 .modified()?
                 .duration_since(std::time::UNIX_EPOCH)
-                .expect("时间转换失败")
+                .unwrap_or_default()
                 .as_secs(),
             _ => std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
## Summary
Replaced `.expect("时间转换失败")` with `.unwrap_or_default()` in the Rhai plugin
hot-reload path. Single line change, eliminates a production panic.

## Motivation
`duration_since(UNIX_EPOCH)` can return an error if the file's `modified()` time
is before the Unix epoch — possible on some filesystems and virtual machines.
The `.expect()` would crash the entire agent process in that case. Additionally,
the error message was in Chinese, which violates the project convention of
English-only code comments and messages (CONTRIBUTING.md).

The fix is consistent with existing patterns in the same file — lines 238 and 298
already use `.unwrap_or_default()` for the same reason. `Duration::ZERO` as a
fallback treats the file as unmodified, so hot-reload continues gracefully.

## Changes
- **`mofa-plugins/src/rhai_runtime/plugin.rs:294`** — replaced
  `.expect("时间转换失败")` with `.unwrap_or_default()`

## Testing
- `cargo check -p mofa-plugins` — ✅
- `cargo test -p mofa-plugins` — ✅
- No remaining `expect()` or `panic!()` outside tests in the file — ✅

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] Architecture layer rules respected
- [x] Relevant documentation updated