### PR TITLE
fix(cli): return error for unsupported INI and RON config validation instead of silently skipping

### DIFF
--- a/crates/mofa-cli/src/commands/config_cmd.rs
+++ b/crates/mofa-cli/src/commands/config_cmd.rs
@@ -214,12 +214,14 @@ fn validate_config_file(path: &PathBuf) -> anyhow::Result<()> {
                         .map_err(|e| anyhow::anyhow!("JSON5 parsing error: {}", e))
                 }
                 "ini" => {
-                    // INI validation is more relaxed
-                    Ok(Value::Null)
+                    return Err(anyhow::anyhow!(
+                        "INI format validation is not yet supported. Please use YAML, TOML, or JSON format for validated configuration."
+                    ));
                 }
                 "ron" => {
-                    // RON validation (simplified)
-                    Ok(Value::Null)
+                    return Err(anyhow::anyhow!(
+                        "RON format validation is not yet supported. Please use YAML, TOML, or JSON format for validated configuration."
+                    ));
                 }
                 _ => {
                     return Err(anyhow::anyhow!("Unsupported config format: {}", ext));


### PR DESCRIPTION
## 📋 Summary

Fixes mofa config validate silently reporting INI and RON config files as valid without actually parsing them. Now returns an explicit error informing users these formats are not yet supported for validation.

## 🔗 Related Issues

Closes #252

---

## 🧠 Context

The validate_config_file() function had placeholder branches for INI and RON that returned Ok(Value::Null) without doing any actual parsing. This meant any .ini or .ron file — even one containing complete garbage — would be reported as valid, giving users false confidence and leading to hard-to-debug runtime failures.

Since mofa-cli does not currently include INI or RON parsing crate dependencies, adding full parsing support would require adding new dependencies (e.g., rust-ini, ron). This fix takes the conservative approach of returning a clear error instead, which can be upgraded to full parsing in a future PR.

---

## 🛠️ Changes

- Replaced Ok(Value::Null) stub for INI format with an explicit error message
- Replaced Ok(Value::Null) stub for RON format with an explicit error message
- Error messages suggest using YAML, TOML, or JSON as supported alternatives

---

## 🧪 How you Tested

1. cargo build compiles successfully with no warnings
2. Verified that .ini files now return "INI format validation is not yet supported" error
3. Verified that .ron files now return "RON format validation is not yet supported" error
4. Verified that YAML, TOML, and JSON validation continues to work as before

---

## ⚠️ Breaking Changes

- [x] Breaking change (describe below)

Users who previously ran mofa config validate on .ini or .ron files and received a false "valid" result will now receive an error. This is intentional — the previous behavior was a bug that could lead to runtime failures.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] cargo fmt run
- [x] cargo clippy passes without warnings

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with main
- [x] No unrelated commits
- [x] Commit messages explain why, not only what

---

## 🧩 Additional Notes for Reviewers

A future PR could add the rust-ini and ron crates as dependencies to enable full parsing validation for these formats. This fix ensures users are not misled in the meantime.