### PR TITLE
feat(runtime): add cron scheduling and policy controls to AgentRunner (Task 16 phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1629,6 +1629,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -2132,7 +2143,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2464,7 +2475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3329,7 +3340,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3695,7 +3706,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4544,7 +4555,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode 1.3.3",
+ "chrono",
  "config",
+ "cron",
  "dora-core",
  "dora-daemon",
  "dora-message",
@@ -4801,7 +4814,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5844,7 +5857,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5883,9 +5896,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6566,7 +6579,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6633,7 +6646,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7780,7 +7793,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9663,7 +9676,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -42,6 +42,8 @@ serde_yaml = { workspace = true }
 toml = "0.8"
 config.workspace = true
 regex.workspace = true
+chrono.workspace = true
+cron = "0.12"
 
 [lints]
 workspace = true

--- a/crates/mofa-runtime/src/agent/mod.rs
+++ b/crates/mofa-runtime/src/agent/mod.rs
@@ -22,7 +22,9 @@ pub mod registry;
 
 // 重新导出常用类型
 // Re-export commonly used types
-pub use crate::runner::{AgentRunner, AgentRunnerBuilder, RunnerState, RunnerStats, run_agents};
+pub use crate::runner::{
+    AgentRunner, AgentRunnerBuilder, PeriodicRunConfig, RunnerState, RunnerStats, run_agents,
+};
 pub use execution::{ExecutionEngine, ExecutionOptions, ExecutionResult, ExecutionStatus};
 pub use mofa_kernel::agent::registry::AgentFactory;
 pub use registry::{AgentRegistry, RegistryStats};

--- a/crates/mofa-runtime/src/agent/mod.rs
+++ b/crates/mofa-runtime/src/agent/mod.rs
@@ -23,7 +23,8 @@ pub mod registry;
 // 重新导出常用类型
 // Re-export commonly used types
 pub use crate::runner::{
-    AgentRunner, AgentRunnerBuilder, PeriodicRunConfig, RunnerState, RunnerStats, run_agents,
+    AgentRunner, AgentRunnerBuilder, CronMisfirePolicy, CronRunConfig, PeriodicMissedTickPolicy,
+    PeriodicRunConfig, RunnerState, RunnerStats, run_agents,
 };
 pub use execution::{ExecutionEngine, ExecutionOptions, ExecutionResult, ExecutionStatus};
 pub use mofa_kernel::agent::registry::AgentFactory;

--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -88,6 +88,9 @@ use crate::agent::context::{AgentContext, AgentEvent};
 use crate::agent::core::{AgentLifecycle, AgentMessage, AgentMessaging, MoFAAgent};
 use crate::agent::error::{AgentError, AgentResult};
 use crate::agent::types::{AgentInput, AgentOutput, AgentState, InterruptResult};
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::{Duration, MissedTickBehavior};
@@ -174,6 +177,96 @@ impl PeriodicRunConfig {
             ));
         }
         Ok(())
+    }
+}
+
+/// 间隔调度的补偿策略
+/// Missed tick policy for interval scheduling
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PeriodicMissedTickPolicy {
+    /// 尽快补跑遗漏 tick
+    /// Try to catch up missed ticks as fast as possible
+    Burst,
+    /// 将后续 tick 向后平移
+    /// Delay subsequent ticks to preserve spacing
+    Delay,
+    /// 跳过遗漏 tick（推荐）
+    /// Skip missed ticks (recommended)
+    #[default]
+    Skip,
+}
+
+impl From<PeriodicMissedTickPolicy> for MissedTickBehavior {
+    fn from(value: PeriodicMissedTickPolicy) -> Self {
+        match value {
+            PeriodicMissedTickPolicy::Burst => MissedTickBehavior::Burst,
+            PeriodicMissedTickPolicy::Delay => MissedTickBehavior::Delay,
+            PeriodicMissedTickPolicy::Skip => MissedTickBehavior::Skip,
+        }
+    }
+}
+
+/// Cron 调度错过触发点时的策略
+/// Misfire policy for cron scheduling
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CronMisfirePolicy {
+    /// 丢弃错过的触发点，继续等待下一次计划触发
+    /// Drop missed triggers and wait for the next scheduled trigger
+    #[default]
+    Skip,
+    /// 如果错过至少一次触发点，立即补跑一次
+    /// Execute one immediate catch-up run when at least one trigger was missed
+    RunOnce,
+}
+
+/// Cron 周期执行配置
+/// Cron periodic run configuration
+#[derive(Debug, Clone)]
+pub struct CronRunConfig {
+    /// Cron 表达式（支持秒级）
+    /// Cron expression (second-level supported)
+    pub expression: String,
+    /// 最大执行次数（必须大于 0）
+    /// Maximum number of runs (must be > 0)
+    pub max_runs: u64,
+    /// 是否立即执行第一轮（true: 立即执行；false: 等待下一次 cron 触发）
+    /// Whether to execute the first run immediately
+    pub run_immediately: bool,
+    /// 错过触发点时的处理策略
+    /// Handling policy when cron triggers are missed
+    pub misfire_policy: CronMisfirePolicy,
+}
+
+impl Default for CronRunConfig {
+    fn default() -> Self {
+        Self {
+            expression: "*/1 * * * * * *".to_string(),
+            max_runs: 1,
+            run_immediately: true,
+            misfire_policy: CronMisfirePolicy::Skip,
+        }
+    }
+}
+
+impl CronRunConfig {
+    fn parse_schedule(&self) -> AgentResult<Schedule> {
+        if self.expression.trim().is_empty() {
+            return Err(AgentError::ValidationFailed(
+                "Cron expression must not be empty".to_string(),
+            ));
+        }
+        if self.max_runs == 0 {
+            return Err(AgentError::ValidationFailed(
+                "Cron max_runs must be greater than 0".to_string(),
+            ));
+        }
+
+        Schedule::from_str(self.expression.trim()).map_err(|e| {
+            AgentError::ValidationFailed(format!(
+                "Invalid cron expression '{}': {}",
+                self.expression, e
+            ))
+        })
     }
 }
 
@@ -367,19 +460,30 @@ impl<T: MoFAAgent> AgentRunner<T> {
 
     /// 按固定间隔周期执行同一输入
     ///
-    /// 说明：
-    /// - 使用 `MissedTickBehavior::Skip` 避免执行落后时“补跑风暴”
-    /// - 执行串行进行，不允许同一 runner 内部重叠执行
+    /// 默认策略使用 `PeriodicMissedTickPolicy::Skip`，避免执行落后时“补跑风暴”。
     pub async fn run_periodic(
         &mut self,
         input: AgentInput,
         config: PeriodicRunConfig,
     ) -> AgentResult<Vec<AgentOutput>> {
+        self.run_periodic_with_policy(input, config, PeriodicMissedTickPolicy::Skip)
+            .await
+    }
+
+    /// 按固定间隔周期执行同一输入（可配置补偿策略）
+    ///
+    /// 执行串行进行，不允许同一 runner 内部重叠执行。
+    pub async fn run_periodic_with_policy(
+        &mut self,
+        input: AgentInput,
+        config: PeriodicRunConfig,
+        missed_tick_policy: PeriodicMissedTickPolicy,
+    ) -> AgentResult<Vec<AgentOutput>> {
         config.validate()?;
 
         let mut outputs = Vec::with_capacity(config.max_runs as usize);
         let mut ticker = tokio::time::interval(config.interval);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        ticker.set_missed_tick_behavior(missed_tick_policy.into());
 
         // interval 首次 tick 立即返回。若不希望立即执行，先消费这次即时 tick。
         if !config.run_immediately {
@@ -389,6 +493,57 @@ impl<T: MoFAAgent> AgentRunner<T> {
         for _ in 0..config.max_runs {
             ticker.tick().await;
             outputs.push(self.execute(input.clone()).await?);
+        }
+
+        Ok(outputs)
+    }
+
+    /// 使用 Cron 表达式周期执行同一输入
+    ///
+    /// 与 interval 版本一致，执行串行进行，不允许同一 runner 内部重叠执行。
+    pub async fn run_periodic_cron(
+        &mut self,
+        input: AgentInput,
+        config: CronRunConfig,
+    ) -> AgentResult<Vec<AgentOutput>> {
+        let schedule = config.parse_schedule()?;
+        let mut outputs = Vec::with_capacity(config.max_runs as usize);
+        let mut remaining = config.max_runs;
+        let mut upcoming = schedule.upcoming(Utc);
+
+        if config.run_immediately {
+            outputs.push(self.execute(input.clone()).await?);
+            remaining -= 1;
+            if remaining == 0 {
+                return Ok(outputs);
+            }
+        }
+
+        while remaining > 0 {
+            let now = Utc::now();
+            let (next_fire_at, missed_any) = next_cron_fire_at(&mut upcoming, now)?;
+
+            if missed_any && matches!(config.misfire_policy, CronMisfirePolicy::RunOnce) {
+                outputs.push(self.execute(input.clone()).await?);
+                remaining -= 1;
+                if remaining == 0 {
+                    break;
+                }
+            }
+
+            let now = Utc::now();
+            if next_fire_at > now {
+                let wait = (next_fire_at - now).to_std().map_err(|e| {
+                    AgentError::Other(format!("Failed to convert cron duration: {}", e))
+                })?;
+
+                if !wait.is_zero() {
+                    tokio::time::sleep(wait).await;
+                }
+            }
+
+            outputs.push(self.execute(input.clone()).await?);
+            remaining -= 1;
         }
 
         Ok(outputs)
@@ -488,6 +643,25 @@ impl<T: MoFAAgent> AgentRunner<T> {
     pub fn agent_state(&self) -> AgentState {
         self.agent.state()
     }
+}
+
+fn next_cron_fire_at<I>(upcoming: &mut I, now: DateTime<Utc>) -> AgentResult<(DateTime<Utc>, bool)>
+where
+    I: Iterator<Item = DateTime<Utc>>,
+{
+    let mut missed_any = false;
+
+    for candidate in upcoming.by_ref() {
+        if candidate <= now {
+            missed_any = true;
+            continue;
+        }
+        return Ok((candidate, missed_any));
+    }
+
+    Err(AgentError::Other(
+        "Cron schedule has no upcoming execution time".to_string(),
+    ))
 }
 
 /// 为支持消息处理的 Agent 提供的扩展方法
@@ -647,6 +821,99 @@ mod tests {
         }
     }
 
+    struct MisfireProbeAgent {
+        id: String,
+        name: String,
+        state: AgentState,
+        capabilities: AgentCapabilities,
+        run_count: u64,
+        first_run_delay: StdDuration,
+        started_at: Instant,
+    }
+
+    impl MisfireProbeAgent {
+        fn new(id: &str, name: &str, first_run_delay: StdDuration) -> Self {
+            Self {
+                id: id.to_string(),
+                name: name.to_string(),
+                state: AgentState::Created,
+                capabilities: AgentCapabilitiesBuilder::new().build(),
+                run_count: 0,
+                first_run_delay,
+                started_at: Instant::now(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MoFAAgent for MisfireProbeAgent {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn capabilities(&self) -> &AgentCapabilities {
+            &self.capabilities
+        }
+
+        async fn initialize(&mut self, _ctx: &AgentContext) -> AgentResult<()> {
+            self.state = AgentState::Ready;
+            Ok(())
+        }
+
+        async fn execute(
+            &mut self,
+            _input: AgentInput,
+            _ctx: &AgentContext,
+        ) -> AgentResult<AgentOutput> {
+            self.state = AgentState::Executing;
+            self.run_count += 1;
+
+            if self.run_count == 1 {
+                tokio::time::sleep(self.first_run_delay).await;
+            }
+
+            let elapsed_ms = self.started_at.elapsed().as_millis();
+            self.state = AgentState::Ready;
+            Ok(AgentOutput::text(format!(
+                "run={} elapsed_ms={}",
+                self.run_count, elapsed_ms
+            )))
+        }
+
+        async fn shutdown(&mut self) -> AgentResult<()> {
+            self.state = AgentState::Shutdown;
+            Ok(())
+        }
+
+        fn state(&self) -> AgentState {
+            self.state.clone()
+        }
+    }
+
+    fn every_second_cron_expression() -> String {
+        for expression in ["*/1 * * * * * *", "*/1 * * * * *"] {
+            if Schedule::from_str(expression).is_ok() {
+                return expression.to_string();
+            }
+        }
+
+        panic!("No supported every-second cron expression format found");
+    }
+
+    fn parse_elapsed_ms(output: &AgentOutput) -> u128 {
+        let text = output.to_text();
+        text.split("elapsed_ms=")
+            .nth(1)
+            .expect("output should contain elapsed_ms marker")
+            .trim()
+            .parse::<u128>()
+            .expect("elapsed_ms should be a valid integer")
+    }
+
     #[tokio::test]
     async fn test_agent_runner_new() {
         let agent = TestAgent::new("test-001", "Test Agent");
@@ -760,5 +1027,146 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, AgentError::ValidationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn test_agent_runner_run_periodic_cron_executes_max_runs() {
+        let agent = TestAgent::new("test-007", "Cron Agent");
+        let mut runner = AgentRunner::new(agent).await.unwrap();
+        let expression = every_second_cron_expression();
+
+        let outputs = runner
+            .run_periodic_cron(
+                AgentInput::text("TickCron"),
+                CronRunConfig {
+                    expression,
+                    max_runs: 2,
+                    run_immediately: true,
+                    misfire_policy: CronMisfirePolicy::Skip,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outputs.len(), 2);
+        assert!(outputs.iter().all(|o| o.to_text() == "Echo: TickCron"));
+
+        let stats = runner.stats().await;
+        assert_eq!(stats.total_executions, 2);
+        assert_eq!(stats.successful_executions, 2);
+    }
+
+    #[tokio::test]
+    async fn test_agent_runner_run_periodic_cron_rejects_invalid_config() {
+        let agent = TestAgent::new("test-008", "Cron Invalid Config Agent");
+        let mut runner = AgentRunner::new(agent).await.unwrap();
+
+        let err = runner
+            .run_periodic_cron(
+                AgentInput::text("x"),
+                CronRunConfig {
+                    expression: "".to_string(),
+                    max_runs: 1,
+                    run_immediately: true,
+                    misfire_policy: CronMisfirePolicy::Skip,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgentError::ValidationFailed(_)));
+
+        let err = runner
+            .run_periodic_cron(
+                AgentInput::text("x"),
+                CronRunConfig {
+                    expression: "not-a-cron".to_string(),
+                    max_runs: 1,
+                    run_immediately: true,
+                    misfire_policy: CronMisfirePolicy::Skip,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgentError::ValidationFailed(_)));
+
+        let err = runner
+            .run_periodic_cron(
+                AgentInput::text("x"),
+                CronRunConfig {
+                    expression: every_second_cron_expression(),
+                    max_runs: 0,
+                    run_immediately: true,
+                    misfire_policy: CronMisfirePolicy::Skip,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgentError::ValidationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn test_agent_runner_run_periodic_cron_misfire_policy_run_once() {
+        let expression = every_second_cron_expression();
+
+        let mut skip_runner = AgentRunner::new(MisfireProbeAgent::new(
+            "test-009-skip",
+            "Cron Misfire Skip",
+            StdDuration::from_millis(2200),
+        ))
+        .await
+        .unwrap();
+
+        let skip_outputs = skip_runner
+            .run_periodic_cron(
+                AgentInput::text("skip"),
+                CronRunConfig {
+                    expression: expression.clone(),
+                    max_runs: 2,
+                    run_immediately: false,
+                    misfire_policy: CronMisfirePolicy::Skip,
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut run_once_runner = AgentRunner::new(MisfireProbeAgent::new(
+            "test-009-run-once",
+            "Cron Misfire RunOnce",
+            StdDuration::from_millis(2200),
+        ))
+        .await
+        .unwrap();
+
+        let run_once_outputs = run_once_runner
+            .run_periodic_cron(
+                AgentInput::text("run-once"),
+                CronRunConfig {
+                    expression,
+                    max_runs: 2,
+                    run_immediately: false,
+                    misfire_policy: CronMisfirePolicy::RunOnce,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(skip_outputs.len(), 2);
+        assert_eq!(run_once_outputs.len(), 2);
+
+        let skip_gap =
+            parse_elapsed_ms(&skip_outputs[1]).saturating_sub(parse_elapsed_ms(&skip_outputs[0]));
+        let run_once_gap = parse_elapsed_ms(&run_once_outputs[1])
+            .saturating_sub(parse_elapsed_ms(&run_once_outputs[0]));
+
+        assert!(
+            skip_gap >= 500,
+            "skip policy should wait for a future cron slot, gap={}ms",
+            skip_gap
+        );
+        assert!(
+            run_once_gap < 400,
+            "run-once policy should catch up immediately, gap={}ms",
+            run_once_gap
+        );
     }
 }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1089,6 +1089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,7 +1337,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1441,7 +1452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2979,7 +2990,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode 1.3.3",
+ "chrono",
  "config 0.14.1",
+ "cron",
  "eyre",
  "flume 0.10.14",
  "mofa-kernel",
@@ -3167,7 +3180,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3752,7 +3765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4356,6 +4369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "runtime_periodic_runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cron",
+ "mofa-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,7 +4446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5283,7 +5307,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6618,7 +6642,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "secretary_agent",
     "react_agent",
     "rhai_scripting",
+    "runtime_periodic_runner",
     "runtime_example",
     "hitl_secretary",
     "streaming_persistence",

--- a/examples/runtime_periodic_runner/Cargo.toml
+++ b/examples/runtime_periodic_runner/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "runtime_periodic_runner"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+cron = "0.12"
+tokio.workspace = true
+
+# Local dependencies
+mofa-runtime = { path = "../../crates/mofa-runtime" }

--- a/examples/runtime_periodic_runner/README.md
+++ b/examples/runtime_periodic_runner/README.md
@@ -1,0 +1,23 @@
+# Runtime Periodic Runner Example
+
+This example demonstrates practical periodic scheduling with `AgentRunner`:
+
+1. Interval scheduling (`run_periodic`) with bounded runs.
+2. Cron scheduling (`run_periodic_cron`) with real cron expressions.
+3. Policy controls:
+   - `PeriodicMissedTickPolicy` for interval tick behavior.
+   - `CronMisfirePolicy` for cron misfire behavior.
+
+## Run
+
+From the `examples` workspace:
+
+```bash
+cargo run -p runtime_periodic_runner
+```
+
+You should see:
+
+- interval runs with output payloads
+- cron runs with output payloads
+- stats summary at the end

--- a/examples/runtime_periodic_runner/src/main.rs
+++ b/examples/runtime_periodic_runner/src/main.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use mofa_runtime::agent::capabilities::{AgentCapabilities, AgentCapabilitiesBuilder};
+use mofa_runtime::agent::context::AgentContext;
+use mofa_runtime::agent::core::MoFAAgent;
+use mofa_runtime::agent::error::AgentResult;
+use mofa_runtime::agent::types::{AgentInput, AgentOutput, AgentState};
+use mofa_runtime::agent::{
+    AgentRunner, CronMisfirePolicy, CronRunConfig, PeriodicMissedTickPolicy, PeriodicRunConfig,
+};
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+struct HeartbeatAgent {
+    id: String,
+    name: String,
+    state: AgentState,
+    capabilities: AgentCapabilities,
+    run_count: u64,
+}
+
+impl HeartbeatAgent {
+    fn new(id: &str, name: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            state: AgentState::Created,
+            capabilities: AgentCapabilitiesBuilder::new()
+                .tags(vec!["periodic".to_string(), "heartbeat".to_string()])
+                .build(),
+            run_count: 0,
+        }
+    }
+}
+
+#[async_trait]
+impl MoFAAgent for HeartbeatAgent {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> &AgentCapabilities {
+        &self.capabilities
+    }
+
+    async fn initialize(&mut self, _ctx: &AgentContext) -> AgentResult<()> {
+        self.state = AgentState::Ready;
+        Ok(())
+    }
+
+    async fn execute(
+        &mut self,
+        input: AgentInput,
+        _ctx: &AgentContext,
+    ) -> AgentResult<AgentOutput> {
+        self.state = AgentState::Executing;
+        self.run_count += 1;
+
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let payload = format!(
+            "run={} ts={} task={}",
+            self.run_count,
+            timestamp,
+            input.to_text()
+        );
+
+        self.state = AgentState::Ready;
+        Ok(AgentOutput::text(payload))
+    }
+
+    async fn shutdown(&mut self) -> AgentResult<()> {
+        self.state = AgentState::Shutdown;
+        Ok(())
+    }
+
+    fn state(&self) -> AgentState {
+        self.state.clone()
+    }
+}
+
+fn every_second_cron_expression() -> String {
+    for expression in ["*/1 * * * * * *", "*/1 * * * * *"] {
+        if cron::Schedule::from_str(expression).is_ok() {
+            return expression.to_string();
+        }
+    }
+
+    // Fallback; this should work for cron crate formats that support seconds.
+    "*/1 * * * * * *".to_string()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("=== Runtime Periodic Runner (Phase 2) Example ===");
+
+    let cron_expression = every_second_cron_expression();
+
+    let mut runner =
+        AgentRunner::new(HeartbeatAgent::new("periodic-heartbeat", "Heartbeat")).await?;
+
+    println!("\nScenario 1: interval scheduling with policy control");
+    let interval_outputs = runner
+        .run_periodic_with_policy(
+            AgentInput::text("collect-interval-metrics"),
+            PeriodicRunConfig {
+                interval: Duration::from_millis(300),
+                max_runs: 3,
+                run_immediately: true,
+            },
+            PeriodicMissedTickPolicy::Skip,
+        )
+        .await?;
+
+    for (idx, output) in interval_outputs.iter().enumerate() {
+        println!("  interval run {} -> {}", idx + 1, output.to_text());
+    }
+
+    println!("\nScenario 2: cron scheduling (skip misfires)");
+    let cron_skip_outputs = runner
+        .run_periodic_cron(
+            AgentInput::text("collect-cron-metrics-skip"),
+            CronRunConfig {
+                expression: cron_expression.clone(),
+                max_runs: 2,
+                run_immediately: true,
+                misfire_policy: CronMisfirePolicy::Skip,
+            },
+        )
+        .await?;
+
+    for (idx, output) in cron_skip_outputs.iter().enumerate() {
+        println!("  cron(skip) run {} -> {}", idx + 1, output.to_text());
+    }
+
+    println!("\nScenario 3: cron scheduling (run-once misfire policy)");
+    let cron_run_once_outputs = runner
+        .run_periodic_cron(
+            AgentInput::text("collect-cron-metrics-run-once"),
+            CronRunConfig {
+                expression: cron_expression,
+                max_runs: 2,
+                run_immediately: true,
+                misfire_policy: CronMisfirePolicy::RunOnce,
+            },
+        )
+        .await?;
+
+    for (idx, output) in cron_run_once_outputs.iter().enumerate() {
+        println!("  cron(run-once) run {} -> {}", idx + 1, output.to_text());
+    }
+
+    let stats = runner.stats().await;
+    println!(
+        "\nRunner stats: total={}, success={}, failed={}, avg_ms={:.2}",
+        stats.total_executions,
+        stats.successful_executions,
+        stats.failed_executions,
+        stats.avg_execution_time_ms
+    );
+
+    runner.shutdown().await?;
+    println!("Done.");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Implements Task 16 Phase 2 by extending `AgentRunner` periodic scheduling with cron support and policy controls.

## Changes
- Added `PeriodicMissedTickPolicy` (Burst/Delay/Skip)
- Added `CronMisfirePolicy` (Skip/RunOnce)
- Added `CronRunConfig`
- Added `run_periodic_with_policy(...)`
- Added `run_periodic_cron(...)`
- Kept `run_periodic(...)` as compatibility wrapper (default Skip)
- Added cron scheduling helper and validation
- Added tests for cron execution, invalid config, and misfire policy behavior
- Added practical example: `examples/runtime_periodic_runner`

## Testing
```bash
cargo test -p mofa-runtime
cargo test -p mofa-runtime test_agent_runner_run_periodic
cargo check --manifest-path examples/Cargo.toml -p runtime_periodic_runner
```
## Related
Closes #259
Supersedes #260

