### PR TITLE
fix(runtime): prevent deadlock in AgentRegistry lifecycle methods

### DIFF
--- a/crates/mofa-runtime/src/agent/registry.rs
+++ b/crates/mofa-runtime/src/agent/registry.rs
@@ -362,14 +362,23 @@ impl AgentRegistry {
 
     /// 初始化所有 Agent
     pub async fn initialize_all(&self, ctx: &AgentContext) -> AgentResult<Vec<String>> {
-        let agents = self.agents.read().await;
-        let mut initialized = Vec::new();
+        // Collect agent refs and drop the read lock before any .await to prevent
+        // deadlock when an agent's initialize() calls back into the registry
+        // (e.g., to register sub-agents).
+        let entries: Vec<(String, Arc<RwLock<dyn MoFAAgent>>)> = {
+            let agents = self.agents.read().await;
+            agents
+                .iter()
+                .map(|(id, entry)| (id.clone(), entry.agent.clone()))
+                .collect()
+        };
 
-        for (id, entry) in agents.iter() {
-            let mut agent = entry.agent.write().await;
+        let mut initialized = Vec::new();
+        for (id, agent_arc) in entries {
+            let mut agent = agent_arc.write().await;
             if agent.state() == AgentState::Created {
                 agent.initialize(ctx).await?;
-                initialized.push(id.clone());
+                initialized.push(id);
             }
         }
 
@@ -378,15 +387,24 @@ impl AgentRegistry {
 
     /// 关闭所有 Agent
     pub async fn shutdown_all(&self) -> AgentResult<Vec<String>> {
-        let agents = self.agents.read().await;
-        let mut shutdown = Vec::new();
+        // Collect agent refs and drop the read lock before any .await to prevent
+        // deadlock when an agent's shutdown() calls back into the registry
+        // (e.g., to unregister sub-agents).
+        let entries: Vec<(String, Arc<RwLock<dyn MoFAAgent>>)> = {
+            let agents = self.agents.read().await;
+            agents
+                .iter()
+                .map(|(id, entry)| (id.clone(), entry.agent.clone()))
+                .collect()
+        };
 
-        for (id, entry) in agents.iter() {
-            let mut agent = entry.agent.write().await;
+        let mut shutdown = Vec::new();
+        for (id, agent_arc) in entries {
+            let mut agent = agent_arc.write().await;
             let state = agent.state();
             if state != AgentState::Shutdown && state != AgentState::Failed {
                 agent.shutdown().await?;
-                shutdown.push(id.clone());
+                shutdown.push(id);
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes a critical async deadlock in
`crates/mofa-runtime/src/agent/registry.rs`
within:

* `AgentRegistry::initialize_all()`
* `AgentRegistry::shutdown_all()`

Previously, both methods held a `self.agents.read()` lock across `.await` calls into agent lifecycle methods. If an agent attempted to register or unregister another agent during `initialize()` or `shutdown()`, the system would deadlock permanently.

This change restructures the lifecycle flow to **collect agent references first, drop the registry lock immediately, and then perform async lifecycle calls safely**.

---

## The Problem

Original pattern (simplified):

```rust
let agents = self.agents.read().await;

for (id, entry) in agents.iter() {
    let mut agent = entry.agent.write().await;

    if agent.state() == AgentState::Created {
        agent.initialize(ctx).await?;  // ← await while holding registry read lock
    }
}
```

The issue:

* `self.agents.read()` is held for the entire loop.
* `agent.initialize(ctx).await` can call back into `registry.register()`.
* `register()` requires `self.agents.write().await`.
* Tokio’s `RwLock` does not allow write acquisition while a read lock is active.

Result: **hard async deadlock** with no panic and no error.

The same pattern existed in `shutdown_all()`.

---

## Steps to Reproduce

1. Create an agent whose `initialize()` registers a sub-agent:

```rust
async fn initialize(&mut self, ctx: &AgentContext) -> AgentResult<()> {
    self.registry.register(sub_agent).await?;
    Ok(())
}
```

2. Register this agent.
3. Call:

```rust
registry.initialize_all(&ctx).await;
```

4. Observe:

   * `initialize_all()` suspends indefinitely.
   * `registry.register()` blocks waiting for a write lock.
   * No error, no panic, runtime appears hung.

This also occurs in `shutdown_all()` when agents unregister during cleanup.

---

## Impact

* Hard deadlock in production multi-agent workflows.
* Registry operations (`register`, `unregister`, `clear`) permanently blocked.
* Plugin reload or dynamic agent orchestration can freeze the runtime.
* No recovery path without process restart.

This affects any MoFA deployment using hierarchical or supervisor-style agents.

---

## The Fix

We now **stage the lifecycle process**:

1. Collect agent references while holding the read lock.
2. Drop the read lock immediately.
3. Perform async lifecycle calls without holding registry locks.

Updated pattern:

```rust
let entries: Vec<(String, Arc<RwLock<dyn MoFAAgent>>)> = {
    let agents = self.agents.read().await;
    agents.iter()
        .map(|(id, e)| (id.clone(), e.agent.clone()))
        .collect()
}; // ← read lock dropped here

for (id, agent_arc) in entries {
    let mut agent = agent_arc.write().await;
    if agent.state() == AgentState::Created {
        agent.initialize(ctx).await?;
    }
}
```

The same restructuring was applied to `shutdown_all()`.

This ensures:

* No registry lock is held across `.await`
* Agents can safely register/unregister during lifecycle calls
* No change to public API behavior

---

## Result

After this fix:

* `initialize_all()` and `shutdown_all()` are deadlock-safe.
* Sub-agent registration during initialization works correctly.
* `clear()` no longer risks freezing the runtime.
* Registry write operations remain available during lifecycle phases.
* Async lock usage follows correct structured concurrency patterns.

A regression test can now safely assert that a self-registering agent completes `initialize_all()` within a bounded timeout.


