### PR TITLE
feat: context compression for long running agent conversations

### DIFF
--- a/crates/mofa-foundation/src/agent/builder.rs
+++ b/crates/mofa-foundation/src/agent/builder.rs
@@ -72,7 +72,7 @@ pub struct AgentBuilder {
     pub(crate) system_prompt: Option<String>,
     /// LLM provider (required)
     llm: Option<Arc<dyn LLMProvider>>,
-    /// Tools to register on the executor
+    /// Tools to register on the executor (dynamic tool objects)
     tools: Vec<Arc<dyn DynTool>>,
     /// Executor configuration (model, temperature, iterations, …)
     pub(crate) config: AgentExecutorConfig,

--- a/crates/mofa-foundation/src/agent/components/context_compressor.rs
+++ b/crates/mofa-foundation/src/agent/components/context_compressor.rs
@@ -1,0 +1,437 @@
+//! Context compressor implementations
+//!
+//! Provides two concrete [`ContextCompressor`] strategies:
+//!
+//! - [`SlidingWindowCompressor`] — keeps the system prompt and the N most
+//!   recent messages, discarding anything older.
+//! - [`SummarizingCompressor`] — asks the LLM to condense older turns into a
+//!   single summary message, preserving semantic content while reducing token
+//!   count.
+//!
+//! A [`TokenCounter`] utility is also exported for callers that want to
+//! estimate token usage without instantiating a compressor.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::components::context_compressor::{CompressionStrategy, ContextCompressor};
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::agent::types::ChatMessage;
+use std::sync::Arc;
+
+// ============================================================================
+// Token counter utility
+// ============================================================================
+
+/// Lightweight token-count estimator using the `chars / 4` heuristic.
+///
+/// This is intentionally approximate.  For production use where billing
+/// accuracy matters, replace the implementation with a tiktoken-style counter.
+pub struct TokenCounter;
+
+impl TokenCounter {
+    /// Estimate total tokens for a slice of messages.
+    pub fn count(messages: &[ChatMessage]) -> usize {
+        messages
+            .iter()
+            .filter_map(|m| m.content.as_ref())
+            .map(|c| Self::count_str(c))
+            .sum()
+    }
+
+    /// Estimate tokens for a single string.
+    pub fn count_str(s: &str) -> usize {
+        s.len() / 4 + 1
+    }
+}
+
+// ============================================================================
+// Sliding window compressor
+// ============================================================================
+
+/// Keeps the system prompt plus the `window_size` most-recent non-system
+/// messages.  Older messages are discarded entirely.
+///
+/// This is the simplest possible strategy — zero latency, no external calls —
+/// but it loses older context completely.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let compressor = SlidingWindowCompressor::new(20);
+/// let trimmed = compressor.compress(messages, 4096).await?;
+/// ```
+pub struct SlidingWindowCompressor {
+    window_size: usize,
+}
+
+impl SlidingWindowCompressor {
+    /// Create a new compressor that retains at most `window_size` non-system
+    /// messages after the system prompt.
+    pub fn new(window_size: usize) -> Self {
+        Self { window_size }
+    }
+}
+
+#[async_trait]
+impl ContextCompressor for SlidingWindowCompressor {
+    async fn compress(
+        &self,
+        messages: Vec<ChatMessage>,
+        max_tokens: usize,
+    ) -> AgentResult<Vec<ChatMessage>> {
+        // If already within budget, return unchanged.
+        if self.count_tokens(&messages) <= max_tokens {
+            return Ok(messages);
+        }
+
+        // Split system messages from the rest.
+        let (system_msgs, mut conversation): (Vec<_>, Vec<_>) =
+            messages.into_iter().partition(|m| m.role == "system");
+
+        // Keep only the most-recent window_size messages.
+        if conversation.len() > self.window_size {
+            let keep_from = conversation.len() - self.window_size;
+            conversation = conversation.split_off(keep_from);
+        }
+
+        let mut result = system_msgs;
+        result.extend(conversation);
+        Ok(result)
+    }
+
+    fn strategy(&self) -> CompressionStrategy {
+        CompressionStrategy::SlidingWindow {
+            window_size: self.window_size,
+        }
+    }
+
+    fn name(&self) -> &str {
+        "sliding_window"
+    }
+}
+
+// ============================================================================
+// Summarizing compressor
+// ============================================================================
+
+/// Compresses older conversation turns by asking the LLM to produce a concise
+/// summary, then replaces those turns with a single assistant message containing
+/// that summary.
+///
+/// The most-recent `keep_recent` non-system messages are left untouched so the
+/// LLM retains immediate context.
+///
+/// This compressor accepts any provider that implements the foundation's
+/// [`LLMProvider`](crate::llm::provider::LLMProvider) trait, which includes
+/// `OpenAIProvider`, `AnthropicProvider`, and `OllamaProvider`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let compressor = SummarizingCompressor::new(llm.clone())
+///     .with_keep_recent(8);
+/// let trimmed = compressor.compress(messages, 4096).await?;
+/// ```
+pub struct SummarizingCompressor {
+    llm: Arc<dyn crate::llm::provider::LLMProvider>,
+    keep_recent: usize,
+}
+
+impl SummarizingCompressor {
+    /// Create a new compressor using `llm` for summarisation.
+    /// Defaults to keeping the 10 most-recent non-system messages intact.
+    pub fn new(llm: Arc<dyn crate::llm::provider::LLMProvider>) -> Self {
+        Self {
+            llm,
+            keep_recent: 10,
+        }
+    }
+
+    /// Override how many recent messages to preserve without summarisation.
+    pub fn with_keep_recent(mut self, n: usize) -> Self {
+        self.keep_recent = n;
+        self
+    }
+
+    /// Build the summarisation prompt from the messages to be condensed.
+    fn build_summary_prompt(messages: &[ChatMessage]) -> String {
+        let history = messages
+            .iter()
+            .filter_map(|m| {
+                m.content
+                    .as_ref()
+                    .map(|c| format!("{}: {}", m.role, c))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            "Summarise the following conversation concisely, preserving all \
+             important facts, decisions, and context. Write in third person.\n\n\
+             ---\n{}\n---",
+            history
+        )
+    }
+}
+
+#[async_trait]
+impl ContextCompressor for SummarizingCompressor {
+    async fn compress(
+        &self,
+        messages: Vec<ChatMessage>,
+        max_tokens: usize,
+    ) -> AgentResult<Vec<ChatMessage>> {
+        // If already within budget, return unchanged.
+        if self.count_tokens(&messages) <= max_tokens {
+            return Ok(messages);
+        }
+
+        // Separate system messages from conversation turns.
+        let (system_msgs, conversation): (Vec<_>, Vec<_>) =
+            messages.into_iter().partition(|m| m.role == "system");
+
+        // Nothing to summarise if the conversation is too short.
+        if conversation.len() <= self.keep_recent {
+            let mut result = system_msgs;
+            result.extend(conversation);
+            return Ok(result);
+        }
+
+        let split_at = conversation.len() - self.keep_recent;
+        let (to_summarise, recent) = conversation.split_at(split_at);
+
+        // Ask the LLM for a summary of the older turns using the foundation's
+        // ChatCompletionRequest which is what the actual providers understand.
+        let prompt = Self::build_summary_prompt(to_summarise);
+        let summary_request = crate::llm::types::ChatCompletionRequest::new("gpt-4o-mini")
+            .user(prompt)
+            .temperature(0.3)
+            .max_tokens(512);
+
+        let summary_response = self
+            .llm
+            .chat(summary_request)
+            .await
+            .map_err(|e| AgentError::ExecutionFailed(format!("summarisation failed: {e}")))?;
+
+        let summary_text = summary_response
+            .content()
+            .map(str::to_string)
+            .unwrap_or_else(|| "[summary unavailable]".to_string());
+
+        // Reassemble: system prompt → summary → recent turns.
+        let summary_message = ChatMessage {
+            role: "assistant".to_string(),
+            content: Some(format!("[Conversation summary]\n{summary_text}")),
+            tool_call_id: None,
+            tool_calls: None,
+        };
+
+        let mut result = system_msgs;
+        result.push(summary_message);
+        result.extend_from_slice(recent);
+        Ok(result)
+    }
+
+    fn strategy(&self) -> CompressionStrategy {
+        CompressionStrategy::Summarize
+    }
+
+    fn name(&self) -> &str {
+        "summarizing"
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_kernel::agent::types::ChatMessage;
+
+    fn make_msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: Some(content.to_string()),
+            tool_call_id: None,
+            tool_calls: None,
+        }
+    }
+
+    fn system_only() -> Vec<ChatMessage> {
+        vec![make_msg("system", "You are a helpful assistant.")]
+    }
+
+    fn short_conversation() -> Vec<ChatMessage> {
+        vec![
+            make_msg("system", "You are a helpful assistant."),
+            make_msg("user", "Hello"),
+            make_msg("assistant", "Hi there!"),
+        ]
+    }
+
+    fn long_conversation(n: usize) -> Vec<ChatMessage> {
+        let mut msgs = vec![make_msg("system", "You are a helpful assistant.")];
+        for i in 0..n {
+            msgs.push(make_msg("user", &format!("Message {i}")));
+            msgs.push(make_msg("assistant", &format!("Response {i}")));
+        }
+        msgs
+    }
+
+    // A mock LLM that always returns "summary text" for testing.
+    // Implements the foundation's LLMProvider trait (which real providers use).
+    struct MockLLM;
+
+    #[async_trait]
+    impl crate::llm::provider::LLMProvider for MockLLM {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn chat(
+            &self,
+            _request: crate::llm::types::ChatCompletionRequest,
+        ) -> crate::llm::types::LLMResult<crate::llm::types::ChatCompletionResponse> {
+            Ok(crate::llm::types::ChatCompletionResponse::default())
+        }
+    }
+
+    // ---- TokenCounter -------------------------------------------------------
+
+    #[test]
+    fn token_counter_empty() {
+        assert_eq!(TokenCounter::count(&[]), 0);
+    }
+
+    #[test]
+    fn token_counter_heuristic() {
+        let msgs = vec![make_msg("user", "hello")]; // "hello" = 5 chars → 5/4+1 = 2
+        assert_eq!(TokenCounter::count(&msgs), 2);
+    }
+
+    #[test]
+    fn token_counter_no_content() {
+        let msg = ChatMessage {
+            role: "assistant".to_string(),
+            content: None,
+            tool_call_id: None,
+            tool_calls: None,
+        };
+        assert_eq!(TokenCounter::count(&[msg]), 0);
+    }
+
+    // ---- SlidingWindowCompressor -------------------------------------------
+
+    #[tokio::test]
+    async fn sliding_window_under_limit_unchanged() {
+        let compressor = SlidingWindowCompressor::new(20);
+        let msgs = short_conversation();
+        let result = compressor.compress(msgs.clone(), 100_000).await.unwrap();
+        assert_eq!(result.len(), msgs.len());
+    }
+
+    #[tokio::test]
+    async fn sliding_window_only_system_message() {
+        let compressor = SlidingWindowCompressor::new(5);
+        let msgs = system_only();
+        // Force compression by using tiny max_tokens budget.
+        // TokenCounter for this system message: "You are a helpful assistant." = 28 chars → 8 tokens
+        // Use a budget that is LESS than 8 to trigger compression.
+        let result = compressor.compress(msgs.clone(), 1).await.unwrap();
+        // System message is always kept; no conversation to drop.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].role, "system");
+    }
+
+    #[tokio::test]
+    async fn sliding_window_trims_to_window_size() {
+        // 5 user+assistant pairs = 10 conversation messages + 1 system = 11 total.
+        let compressor = SlidingWindowCompressor::new(4);
+        let msgs = long_conversation(5);
+        assert_eq!(msgs.len(), 11);
+        // Force compression.
+        let result = compressor.compress(msgs, 1).await.unwrap();
+        // 1 system + 4 recent conversation messages.
+        assert_eq!(result.len(), 5);
+        assert_eq!(result[0].role, "system");
+    }
+
+    #[tokio::test]
+    async fn sliding_window_very_long_single_message() {
+        let compressor = SlidingWindowCompressor::new(2);
+        let long_content = "a".repeat(10_000);
+        let msgs = vec![
+            make_msg("system", "sys"),
+            make_msg("user", &long_content),
+        ];
+        // Even though the single message exceeds the token budget, the window
+        // compressor keeps it because it is within window_size.
+        let result = compressor.compress(msgs, 1).await.unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn sliding_window_preserves_system_prompt() {
+        let compressor = SlidingWindowCompressor::new(2);
+        let msgs = long_conversation(10); // 21 messages
+        let result = compressor.compress(msgs, 1).await.unwrap();
+        assert_eq!(result[0].role, "system");
+    }
+
+    // ---- SummarizingCompressor ---------------------------------------------
+
+    #[tokio::test]
+    async fn summarizing_under_limit_unchanged() {
+        let llm = Arc::new(MockLLM);
+        let compressor = SummarizingCompressor::new(llm);
+        let msgs = short_conversation();
+        let result = compressor.compress(msgs.clone(), 100_000).await.unwrap();
+        assert_eq!(result.len(), msgs.len());
+    }
+
+    #[tokio::test]
+    async fn summarizing_only_system_message() {
+        let llm = Arc::new(MockLLM);
+        let compressor = SummarizingCompressor::new(llm);
+        let msgs = system_only();
+        let result = compressor.compress(msgs, 1).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].role, "system");
+    }
+
+    #[tokio::test]
+    async fn summarizing_injects_summary_message() {
+        let llm = Arc::new(MockLLM);
+        let compressor = SummarizingCompressor::new(llm).with_keep_recent(2);
+        // 1 system + 6 conversation messages (3 pairs).
+        let msgs = long_conversation(3);
+        assert_eq!(msgs.len(), 7);
+        // Force compression.
+        let result = compressor.compress(msgs, 1).await.unwrap();
+        // Result: system + summary + 2 recent = 4
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].role, "system");
+        assert!(result[1]
+            .content
+            .as_ref()
+            .unwrap()
+            .starts_with("[Conversation summary]"));
+    }
+
+    #[tokio::test]
+    async fn summarizing_very_long_single_message() {
+        let llm = Arc::new(MockLLM);
+        let compressor = SummarizingCompressor::new(llm).with_keep_recent(10);
+        let long_content = "x".repeat(50_000);
+        let msgs = vec![
+            make_msg("system", "sys"),
+            make_msg("user", &long_content),
+        ];
+        // Only 1 conversation message which is <= keep_recent=10, so no
+        // summarisation happens; messages are returned as-is even over budget.
+        let result = compressor.compress(msgs.clone(), 1).await.unwrap();
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/crates/mofa-foundation/src/agent/components/context_compressor.rs
+++ b/crates/mofa-foundation/src/agent/components/context_compressor.rs
@@ -294,7 +294,29 @@ mod tests {
             &self,
             _request: crate::llm::types::ChatCompletionRequest,
         ) -> crate::llm::types::LLMResult<crate::llm::types::ChatCompletionResponse> {
-            Ok(crate::llm::types::ChatCompletionResponse::default())
+            use crate::llm::types::{
+                ChatCompletionResponse, ChatMessage, Choice, MessageContent, Role,
+            };
+            Ok(ChatCompletionResponse {
+                id: "mock-id".to_string(),
+                object: "chat.completion".to_string(),
+                created: 0,
+                model: "mock".to_string(),
+                choices: vec![Choice {
+                    index: 0,
+                    message: ChatMessage {
+                        role: Role::Assistant,
+                        content: Some(MessageContent::Text("summary text".to_string())),
+                        name: None,
+                        tool_calls: None,
+                        tool_call_id: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                }],
+                usage: None,
+                system_fingerprint: None,
+            })
         }
     }
 

--- a/crates/mofa-foundation/src/agent/components/mod.rs
+++ b/crates/mofa-foundation/src/agent/components/mod.rs
@@ -14,6 +14,7 @@
 //! - Foundation 层提供具体实现（DirectReasoner, SequentialCoordinator, SimpleToolRegistry 等）
 //! - Foundation layer provides concrete implementations (DirectReasoner, SequentialCoordinator, SimpleToolRegistry, etc.)
 
+pub mod context_compressor;
 pub mod coordinator;
 pub mod memory;
 pub mod reasoner;
@@ -25,6 +26,14 @@ pub mod tool;
 // 重新导出 Kernel 层类型 (直接导入以确保可见性)
 // Re-export Kernel layer types (direct import to ensure visibility)
 // ============================================================================
+
+// Context compressor - Kernel trait and types
+pub use mofa_kernel::agent::components::context_compressor::{
+    CompressionStrategy, ContextCompressor,
+};
+
+// Context compressor - Foundation implementations
+pub use context_compressor::{SlidingWindowCompressor, SummarizingCompressor, TokenCounter};
 
 // Coordinator - Kernel trait 和类型
 // Coordinator - Kernel trait and types

--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use async_trait::async_trait;
+use mofa_kernel::agent::components::context_compressor::ContextCompressor;
 use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_kernel::agent::types::{ChatCompletionRequest, ChatMessage, LLMProvider, ToolDefinition};
@@ -64,6 +65,10 @@ pub struct AgentExecutorConfig {
     pub temperature: Option<f32>,
     /// Max tokens for LLM responses
     pub max_tokens: Option<u32>,
+    /// Token budget for the conversation context sent to the LLM.
+    /// When the estimated token count exceeds this value and a compressor is
+    /// configured, compression is triggered automatically.  Defaults to 4096.
+    pub max_context_tokens: usize,
 }
 
 impl Default for AgentExecutorConfig {
@@ -74,6 +79,7 @@ impl Default for AgentExecutorConfig {
             default_model: None,
             temperature: None,
             max_tokens: None,
+            max_context_tokens: 4096,
         }
     }
 }
@@ -95,6 +101,12 @@ impl AgentExecutorConfig {
 
     pub fn with_temperature(mut self, temp: f32) -> Self {
         self.temperature = Some(temp);
+        self
+    }
+
+    /// Set the maximum number of context tokens before compression is triggered.
+    pub fn with_max_context_tokens(mut self, n: usize) -> Self {
+        self.max_context_tokens = n;
         self
     }
 }
@@ -147,6 +159,9 @@ pub struct AgentExecutor {
     sessions: Arc<SessionManager>,
     /// Configuration
     config: AgentExecutorConfig,
+    /// Optional context compressor applied before each LLM call when the
+    /// estimated token count exceeds `config.max_context_tokens`.
+    compressor: Option<Arc<dyn ContextCompressor>>,
 }
 
 impl AgentExecutor {
@@ -178,6 +193,7 @@ impl AgentExecutor {
             tools,
             sessions,
             config: AgentExecutorConfig::default(),
+            compressor: None,
         })
     }
 
@@ -213,6 +229,7 @@ impl AgentExecutor {
             tools,
             sessions,
             config,
+            compressor: None,
         })
     }
 
@@ -220,6 +237,16 @@ impl AgentExecutor {
     pub async fn register_tool(&self, tool: Arc<dyn mofa_kernel::agent::components::tool::DynTool>) -> AgentResult<()> {
         let mut tools = self.tools.write().await;
         tools.register(tool)
+    }
+
+    /// Attach a context compressor.
+    ///
+    /// When set, the compressor is called automatically inside
+    /// `process_message` whenever the estimated token count for the built
+    /// message list exceeds `config.max_context_tokens`.
+    pub fn with_compressor(mut self, compressor: Arc<dyn ContextCompressor>) -> Self {
+        self.compressor = Some(compressor);
+        self
     }
 
     /// Process a user message
@@ -242,10 +269,21 @@ impl AgentExecutor {
             .build_messages(&session, &system_prompt, message)
             .await?;
 
-        // 4. Run agent loop
+        // 4. Compress context if a compressor is configured and the token
+        //    budget is exceeded.
+        if let Some(compressor) = &self.compressor {
+            let token_count = compressor.count_tokens(&messages);
+            if token_count > self.config.max_context_tokens {
+                messages = compressor
+                    .compress(messages, self.config.max_context_tokens)
+                    .await?;
+            }
+        }
+
+        // 5. Run agent loop
         let response = self.run_agent_loop(&mut messages).await?;
 
-        // 5. Update session
+        // 6. Update session
         let mut session_updated = session.clone();
         session_updated.add_message("user", message);
         session_updated.add_message("assistant", &response);

--- a/crates/mofa-foundation/src/agent/mod.rs
+++ b/crates/mofa-foundation/src/agent/mod.rs
@@ -27,6 +27,12 @@ pub use mofa_kernel::agent::types::AgentInput;
 // 重新导出组件 (从 components 模块统一导入)
 // Re-export components (unified import from components module)
 pub use components::{
+    // Context compressor trait and implementations
+    CompressionStrategy,
+    ContextCompressor,
+    SlidingWindowCompressor,
+    SummarizingCompressor,
+    TokenCounter,
     CoordinationPattern,
     // Kernel traits 和类型 (通过 components 重导出)
     // Kernel traits and types (re-exported via components)

--- a/crates/mofa-kernel/src/agent/components/context_compressor.rs
+++ b/crates/mofa-kernel/src/agent/components/context_compressor.rs
@@ -1,0 +1,83 @@
+//! Context compression component
+//!
+//! Defines the interface for managing conversation length when interacting with LLMs.
+//! When accumulated context exceeds token limits, a ContextCompressor intelligently
+//! trims or summarises the message history so agents can run indefinitely.
+//!
+//! # Architecture
+//!
+//! This module only contains the trait definition and associated data types.
+//! Concrete implementations live in `mofa-foundation`.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use mofa_kernel::agent::components::context_compressor::{ContextCompressor, CompressionStrategy};
+//!
+//! async fn ensure_fits(compressor: &dyn ContextCompressor, messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+//!     let tokens = compressor.count_tokens(&messages);
+//!     if tokens > 4096 {
+//!         compressor.compress(messages, 4096).await.unwrap()
+//!     } else {
+//!         messages
+//!     }
+//! }
+//! ```
+
+use crate::agent::error::AgentResult;
+use crate::agent::types::ChatMessage;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// The strategy a compressor uses to reduce context length.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CompressionStrategy {
+    /// Discard older messages, always keeping the system prompt and the most
+    /// recent `window_size` non-system messages.
+    SlidingWindow {
+        /// Number of recent non-system messages to retain.
+        window_size: usize,
+    },
+    /// Use the LLM itself to summarise older portions of the conversation,
+    /// replacing them with a single condensed assistant message.
+    Summarize,
+}
+
+/// Trait for context compression implementations.
+///
+/// Implementors decide *how* to shorten a message list when it grows beyond
+/// `max_tokens`.  Two strategies ship with `mofa-foundation`:
+/// - [`SlidingWindowCompressor`](mofa_foundation::agent::components::SlidingWindowCompressor)
+/// - [`SummarizingCompressor`](mofa_foundation::agent::components::SummarizingCompressor)
+#[async_trait]
+pub trait ContextCompressor: Send + Sync {
+    /// Shorten `messages` so that the estimated token count fits within
+    /// `max_tokens`.  The system prompt (role `"system"`) must always be
+    /// preserved; the most recent messages must be kept when possible.
+    ///
+    /// If the conversation is already within the budget, return it unchanged.
+    async fn compress(
+        &self,
+        messages: Vec<ChatMessage>,
+        max_tokens: usize,
+    ) -> AgentResult<Vec<ChatMessage>>;
+
+    /// Estimate the number of tokens consumed by a slice of messages.
+    ///
+    /// The default implementation uses the `chars / 4` heuristic which is a
+    /// reasonable approximation for English text with GPT-family tokenisers.
+    /// Override this method to plug in a tiktoken-style counter.
+    fn count_tokens(&self, messages: &[ChatMessage]) -> usize {
+        messages
+            .iter()
+            .filter_map(|m| m.content.as_ref())
+            .map(|c| c.len() / 4 + 1)
+            .sum()
+    }
+
+    /// The compression strategy this compressor uses.
+    fn strategy(&self) -> CompressionStrategy;
+
+    /// A short human-readable name for this compressor (used in logs).
+    fn name(&self) -> &str;
+}

--- a/crates/mofa-kernel/src/agent/components/mod.rs
+++ b/crates/mofa-kernel/src/agent/components/mod.rs
@@ -4,12 +4,14 @@
 //! 定义 Agent 的可插拔组件接口
 //! Defines the pluggable component interfaces for the Agent
 
+pub mod context_compressor;
 pub mod coordinator;
 pub mod mcp;
 pub mod memory;
 pub mod reasoner;
 pub mod tool;
 
+pub use context_compressor::{CompressionStrategy, ContextCompressor};
 pub use coordinator::{CoordinationPattern, Coordinator, DispatchResult, Task};
 pub use mcp::{McpClient, McpServerConfig, McpServerInfo, McpToolInfo, McpTransportConfig};
 pub use memory::{Memory, MemoryItem, MemoryStats, MemoryValue, Message, MessageRole};

--- a/crates/mofa-kernel/src/agent/mod.rs
+++ b/crates/mofa-kernel/src/agent/mod.rs
@@ -224,6 +224,7 @@ pub use types::{
 // 重新导出组件
 // Re-export components
 pub use components::{
+    context_compressor::{CompressionStrategy, ContextCompressor},
     coordinator::{CoordinationPattern, Coordinator},
     mcp::{McpClient, McpServerConfig, McpServerInfo, McpToolInfo, McpTransportConfig},
     memory::{Memory, MemoryItem, MemoryStats, MemoryValue, Message, MessageRole},

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,8 +29,9 @@ members = [
     "tool_routing",
     "runtime_message_bus_backpressure",
     "rag_pipeline",
-    "message_graph_validation"
-    "agent_builder"
+    "message_graph_validation",
+    "agent_builder",
+    "context_compression",
 ]
 
 [workspace.package]

--- a/examples/context_compression/Cargo.toml
+++ b/examples/context_compression/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "context_compression"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tempfile = "3.8"
+
+[lints]
+workspace = true

--- a/examples/context_compression/src/main.rs
+++ b/examples/context_compression/src/main.rs
@@ -1,0 +1,297 @@
+//! Context Compression Example
+//!
+//! Demonstrates how MoFA prevents agents from hitting LLM token limits during
+//! long conversations using the built-in context compression module.
+//!
+//! Two strategies are shown:
+//!
+//! - SlidingWindowCompressor: discards old messages, keeps the N most recent.
+//!   Zero latency, no external calls required.
+//!
+//! - SummarizingCompressor: uses the LLM to condense old turns into a summary.
+//!   Requires OPENAI_API_KEY (or a compatible endpoint via OPENAI_BASE_URL).
+//!
+//! # Running
+//!
+//! Sliding window demo (no credentials needed):
+//! ```bash
+//! cargo run -p context_compression
+//! ```
+//!
+//! Full demo including summarization:
+//! ```bash
+//! export OPENAI_API_KEY=your-key
+//! cargo run -p context_compression -- summarize
+//! ```
+
+use anyhow::Result;
+use mofa_foundation::agent::{
+    AgentExecutorConfig, ContextCompressor, SlidingWindowCompressor, SummarizingCompressor,
+    TokenCounter,
+};
+use mofa_kernel::agent::types::ChatMessage;
+use std::sync::Arc;
+use tracing::info;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn make_msg(role: &str, content: &str) -> ChatMessage {
+    ChatMessage {
+        role: role.to_string(),
+        content: Some(content.to_string()),
+        tool_call_id: None,
+        tool_calls: None,
+    }
+}
+
+/// Build a simulated long conversation with a system prompt and n back-and-forth turns.
+fn build_long_conversation(turns: usize) -> Vec<ChatMessage> {
+    let mut msgs = vec![make_msg(
+        "system",
+        "You are a helpful assistant specialising in Rust and distributed systems.",
+    )];
+
+    let topics = [
+        ("What is ownership in Rust?", "Ownership is Rust's central feature for memory management without a garbage collector. Each value has a single owner, and when the owner goes out of scope the value is dropped."),
+        ("Explain borrowing.", "Borrowing lets you reference a value without taking ownership. You can have many immutable borrows or exactly one mutable borrow at a time."),
+        ("What are lifetimes?", "Lifetimes annotate how long references are valid. The compiler uses them to ensure references never outlive the data they point to."),
+        ("How does async work in Rust?", "Rust async uses a poll-based model. Futures are state machines that yield control when waiting for I/O and are driven by an executor like Tokio."),
+        ("What is Arc?", "Arc is an atomically reference-counted smart pointer for sharing ownership across threads. When the last Arc drops, the inner value is freed."),
+    ];
+
+    for i in 0..turns {
+        let (q, a) = &topics[i % topics.len()];
+        msgs.push(make_msg("user", q));
+        msgs.push(make_msg("assistant", a));
+    }
+
+    msgs
+}
+
+// ============================================================================
+// Demo 1: Token counting
+// ============================================================================
+
+fn demo_token_counter() {
+    println!("\n========================================");
+    println!("  Demo 1: Token Counter");
+    println!("========================================\n");
+
+    let conversation = build_long_conversation(10);
+
+    let total = TokenCounter::count(&conversation);
+    println!("Conversation length:  {} messages", conversation.len());
+    println!("Estimated token count: {total}");
+
+    let single = TokenCounter::count_str(
+        "The quick brown fox jumps over the lazy dog.",
+    );
+    println!(
+        "\n'The quick brown fox...' → approximately {single} tokens (chars/4 heuristic)"
+    );
+
+    println!("\nWhen total exceeds the configured max_context_tokens, the executor");
+    println!("triggers compression automatically before calling the LLM.");
+}
+
+// ============================================================================
+// Demo 2: Sliding window compressor
+// ============================================================================
+
+async fn demo_sliding_window() -> Result<()> {
+    println!("\n========================================");
+    println!("  Demo 2: Sliding Window Compressor");
+    println!("========================================\n");
+
+    // Build a long conversation: 1 system + 30 conversation messages (15 turns).
+    let messages = build_long_conversation(15);
+    println!("Original conversation: {} messages", messages.len());
+
+    let compressor = SlidingWindowCompressor::new(6); // keep 6 most-recent non-system messages
+    let tokens_before = compressor.count_tokens(&messages);
+    println!("Estimated tokens before compression: {tokens_before}");
+
+    // Trigger compression with a tight budget.
+    let budget = tokens_before / 3;
+    let compressed = compressor.compress(messages, budget).await?;
+
+    println!("\nAfter compression (window_size=6, budget={budget} tokens):");
+    println!("Messages kept: {}", compressed.len());
+    for msg in &compressed {
+        let preview = msg
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(60)
+            .collect::<String>();
+        println!("  [{:9}] {}...", msg.role, preview);
+    }
+
+    let tokens_after = compressor.count_tokens(&compressed);
+    println!("\nEstimated tokens after: {tokens_after}");
+    println!(
+        "Token reduction: {:.0}%",
+        100.0 * (1.0 - tokens_after as f64 / tokens_before as f64)
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Demo 3: AgentExecutor with compressor attached
+// ============================================================================
+
+async fn demo_agent_executor() -> Result<()> {
+    println!("\n========================================");
+    println!("  Demo 3: AgentExecutor Integration");
+    println!("========================================\n");
+
+    // Normally you would use a real provider here.
+    // This demo shows the API surface without making actual LLM calls.
+    println!("Creating AgentExecutor with a SlidingWindowCompressor attached...\n");
+    println!(
+        r#"  let compressor = Arc::new(SlidingWindowCompressor::new(10));
+
+  let executor = AgentExecutor::with_config(
+      llm_provider,
+      workspace_path,
+      AgentExecutorConfig::new()
+          .with_max_context_tokens(3000)
+          .with_model("gpt-4o-mini"),
+  )
+  .await?
+  .with_compressor(compressor);
+
+  // Each call to process_message now automatically compresses context
+  // when estimated token count exceeds 3000.
+  let reply = executor.process_message("session-1", "Hello!").await?;"#
+    );
+
+    println!("\nThe compressor runs transparently inside process_message:");
+    println!("  1. Build messages (system prompt + history + current message)");
+    println!("  2. Count tokens using ContextCompressor::count_tokens()");
+    println!("  3. If count > max_context_tokens → call compress()");
+    println!("  4. Pass compressed messages to LLM");
+
+    // Demonstrate the config builder API directly.
+    let config = AgentExecutorConfig::new()
+        .with_max_context_tokens(3_000)
+        .with_max_iterations(10);
+
+    println!("\nConfig: max_context_tokens={}", config.max_context_tokens);
+    println!("Config: max_iterations={}", config.max_iterations);
+
+    Ok(())
+}
+
+// ============================================================================
+// Demo 4: Summarizing compressor (requires OPENAI_API_KEY)
+// ============================================================================
+
+async fn demo_summarizing_compressor() -> Result<()> {
+    println!("\n========================================");
+    println!("  Demo 4: Summarizing Compressor");
+    println!("========================================\n");
+
+    let api_key = match std::env::var("OPENAI_API_KEY") {
+        Ok(k) if !k.is_empty() => k,
+        _ => {
+            println!("OPENAI_API_KEY not set. Skipping live summarization demo.");
+            println!(
+                "\nTo try it:\n  export OPENAI_API_KEY=your-key\n  cargo run -p context_compression -- summarize"
+            );
+            return Ok(());
+        }
+    };
+
+    use mofa_foundation::llm::openai::{OpenAIConfig, OpenAIProvider};
+
+    let base_url = std::env::var("OPENAI_BASE_URL").ok();
+    let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "gpt-4o-mini".to_string());
+
+    let mut cfg = OpenAIConfig::new(api_key).with_model(&model);
+    if let Some(url) = base_url {
+        cfg = cfg.with_base_url(&url);
+    }
+    let provider = Arc::new(OpenAIProvider::with_config(cfg));
+
+    let compressor = SummarizingCompressor::new(provider).with_keep_recent(4);
+
+    let messages = build_long_conversation(8); // 1 system + 16 conversation messages
+    let tokens_before = compressor.count_tokens(&messages);
+
+    println!("Original conversation: {} messages ({tokens_before} est. tokens)", messages.len());
+
+    let budget = tokens_before / 2;
+    println!("Compressing to budget: {budget} tokens (keep_recent=4)...\n");
+
+    let compressed = compressor.compress(messages, budget).await?;
+
+    println!("After compression: {} messages", compressed.len());
+    for msg in &compressed {
+        let preview = msg
+            .content
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(80)
+            .collect::<String>();
+        println!("  [{:9}] {}", msg.role, preview);
+    }
+
+    let tokens_after = compressor.count_tokens(&compressed);
+    println!(
+        "\nTokens: {tokens_before} → {tokens_after} ({:.0}% reduction)",
+        100.0 * (1.0 - tokens_after as f64 / tokens_before as f64)
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    info!("Starting context compression demos");
+
+    let mode = std::env::args().nth(1).unwrap_or_default();
+
+    println!("==========================================");
+    println!("  MoFA Context Compression Demo");
+    println!("==========================================");
+    println!("\nAgents running long conversations eventually exceed LLM token");
+    println!("limits. MoFA's context compression module handles this automatically.");
+
+    demo_token_counter();
+    demo_sliding_window().await?;
+    demo_agent_executor().await?;
+
+    if mode == "summarize" {
+        demo_summarizing_compressor().await?;
+    } else {
+        println!("\n========================================");
+        println!("  Demo 4: Summarizing Compressor");
+        println!("========================================");
+        println!("\nRun with 'summarize' argument and OPENAI_API_KEY set to try the");
+        println!("LLM-based summarization strategy:");
+        println!("  cargo run -p context_compression -- summarize");
+    }
+
+    println!("\n==========================================");
+    println!("  Demo complete!");
+    println!("==========================================");
+
+    Ok(())
+}


### PR DESCRIPTION
When agents run long conversations or process many documents the accumulated context eventually exceeds the LLM token limit. Right now MoFA has no built in way to handle this so the conversation just gets truncated or the request fails.

This adds a ContextCompressor trait in mofa kernel following the existing pattern where traits live in kernel and implementations live in foundation. Two concrete strategies ship with this PR.

SlidingWindowCompressor keeps the system prompt and the N most recent messages, discarding everything older. Zero latency, no external calls, good for cases where older context is expendable.

SummarizingCompressor calls the LLM itself to condense older portions of the conversation into a single summary message while keeping recent turns intact. This preserves semantic content across long sessions at the cost of one extra LLM call when compression triggers.

A TokenCounter utility estimates token count using a chars divided by 4 heuristic which is a reasonable approximation for GPT family tokenizers. The trait exposes a count_tokens method with this as the default so it can be swapped for tiktoken style counting later without changing any call sites.

The compressor integrates into AgentExecutor automatically. When a compressor is attached via with_compressor and the estimated token count exceeds max_context_tokens in the config, compression runs before each LLM call. If no compressor is set everything works exactly as before.

Tests cover conversations already under the limit, conversations with only system messages, very long single messages, sliding window trimming, and summarization injection.

Closes #207 