### PR TITLE
fix(workflow): execute parallel StateGraph branches concurrently with isolated state snapshots

### DIFF
--- a/crates/mofa-foundation/src/workflow/state_graph.rs
+++ b/crates/mofa-foundation/src/workflow/state_graph.rs
@@ -14,6 +14,8 @@ use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 
 /// Type alias for node ID
@@ -274,7 +276,12 @@ impl<S: GraphState + 'static> mofa_kernel::workflow::StateGraph for StateGraphIm
         // Create compiled graph
         Ok(CompiledGraphImpl {
             id: self.id,
-            nodes: Arc::new(self.nodes),
+            nodes: Arc::new(
+                self.nodes
+                    .into_iter()
+                    .map(|(node_id, node)| (node_id, Arc::from(node)))
+                    .collect(),
+            ),
             edges: Arc::new(self.edges),
             reducers: Arc::new(self.reducers),
             entry_point: self.entry_point.expect("Entry point should be validated"),
@@ -288,7 +295,7 @@ pub struct CompiledGraphImpl<S: GraphState> {
     /// Graph ID
     id: String,
     /// Node functions
-    nodes: Arc<HashMap<NodeId, Box<dyn NodeFunc<S>>>>,
+    nodes: Arc<HashMap<NodeId, Arc<dyn NodeFunc<S>>>>,
     /// Edges
     edges: Arc<HashMap<NodeId, EdgeTarget>>,
     /// Reducers
@@ -300,6 +307,61 @@ pub struct CompiledGraphImpl<S: GraphState> {
 }
 
 impl<S: GraphState> CompiledGraphImpl<S> {
+    fn build_node_context(base: &RuntimeContext, node_id: &str) -> RuntimeContext {
+        RuntimeContext {
+            execution_id: base.execution_id.clone(),
+            graph_id: base.graph_id.clone(),
+            current_node: Arc::new(RwLock::new(node_id.to_string())),
+            remaining_steps: base.remaining_steps.clone(),
+            config: base.config.clone(),
+            metadata: base.metadata.clone(),
+            parent_execution_id: base.parent_execution_id.clone(),
+            tags: base.tags.clone(),
+        }
+    }
+
+    async fn execute_parallel_nodes(
+        nodes: &HashMap<NodeId, Arc<dyn NodeFunc<S>>>,
+        node_ids: &[String],
+        base_state: &S,
+        base_ctx: &RuntimeContext,
+    ) -> AgentResult<Vec<(String, Command)>> {
+        let mut join_set = JoinSet::new();
+
+        for (index, node_id) in node_ids.iter().enumerate() {
+            let node = nodes
+                .get(node_id)
+                .ok_or_else(|| AgentError::NotFound(format!("Node '{}'", node_id)))?
+                .clone();
+            let mut node_state = base_state.clone();
+            let node_ctx = Self::build_node_context(base_ctx, node_id);
+            let node_id = node_id.clone();
+
+            join_set.spawn(async move {
+                let command = node.call(&mut node_state, &node_ctx).await?;
+                Ok::<(usize, String, Command), AgentError>((index, node_id, command))
+            });
+        }
+
+        let mut ordered_results: Vec<Option<(String, Command)>> = vec![None; node_ids.len()];
+        while let Some(joined) = join_set.join_next().await {
+            let (index, node_id, command) = joined
+                .map_err(|e| AgentError::Internal(format!("Parallel node task failed: {}", e)))??;
+            ordered_results[index] = Some((node_id, command));
+        }
+
+        ordered_results
+            .into_iter()
+            .map(|entry| {
+                entry.ok_or_else(|| {
+                    AgentError::Internal(
+                        "Parallel node execution returned incomplete results".to_string(),
+                    )
+                })
+            })
+            .collect()
+    }
+
     /// Get the next node(s) based on the current node and command
     fn get_next_nodes(&self, current_node: &str, command: &Command) -> Vec<String> {
         match &command.control {
@@ -410,19 +472,18 @@ impl<S: GraphState + 'static> CompiledGraph<S> for CompiledGraphImpl<S> {
                 // Parallel execution
                 let mut next_nodes = Vec::new();
                 let nodes_to_execute = std::mem::take(&mut current_nodes);
+                let parallel_results = Self::execute_parallel_nodes(
+                    self.nodes.as_ref(),
+                    &nodes_to_execute,
+                    &state,
+                    &ctx,
+                )
+                .await?;
 
-                for node_id in nodes_to_execute {
-                    let node = self
-                        .nodes
-                        .get(&node_id)
-                        .ok_or_else(|| AgentError::NotFound(format!("Node '{}'", node_id)))?;
-
-                    ctx.set_current_node(&node_id).await;
+                for (node_id, command) in parallel_results {
                     debug!("Executing node '{}' (parallel)", node_id);
 
-                    let command = node.call(&mut state, &ctx).await?;
-
-                    // Apply updates
+                    // Apply updates only after all parallel nodes have completed.
                     self.apply_updates(&mut state, &command.updates).await?;
 
                     // Collect next nodes
@@ -522,8 +583,10 @@ impl<S: GraphState + 'static> CompiledGraph<S> for CompiledGraphImpl<S> {
                 ctx.remaining_steps.decrement().await;
 
                 let nodes_to_execute = std::mem::take(&mut current_nodes);
+                let mut next_nodes = Vec::new();
 
-                for node_id in nodes_to_execute {
+                if nodes_to_execute.len() == 1 {
+                    let node_id = nodes_to_execute[0].clone();
                     let node = match nodes.get(&node_id) {
                         Some(n) => n,
                         None => {
@@ -558,7 +621,6 @@ impl<S: GraphState + 'static> CompiledGraph<S> for CompiledGraphImpl<S> {
                         }
                     };
 
-                    // Apply updates
                     for update in &command.updates {
                         let current = state.get_value(&update.key);
                         let new_value = if let Some(reducer) = reducers.get(&update.key) {
@@ -597,13 +659,81 @@ impl<S: GraphState + 'static> CompiledGraph<S> for CompiledGraphImpl<S> {
                         }))
                         .await;
 
-                    // Get next nodes and add to current_nodes for next iteration
-                    let next_nodes = get_next_nodes(&node_id, &command);
-                    current_nodes.extend(next_nodes);
+                    next_nodes.extend(get_next_nodes(&node_id, &command));
+                } else {
+                    for node_id in &nodes_to_execute {
+                        let _ = tx
+                            .send(Ok(StreamEvent::NodeStart {
+                                node_id: node_id.clone(),
+                                state: state.clone(),
+                            }))
+                            .await;
+                    }
+
+                    let commands = match Self::execute_parallel_nodes(
+                        nodes.as_ref(),
+                        &nodes_to_execute,
+                        &state,
+                        &ctx,
+                    )
+                    .await
+                    {
+                        Ok(results) => results,
+                        Err(e) => {
+                            let _ = tx
+                                .send(Ok(StreamEvent::Error {
+                                    node_id: None,
+                                    error: e.to_string(),
+                                }))
+                                .await;
+                            return;
+                        }
+                    };
+
+                    for (node_id, command) in commands {
+                        for update in &command.updates {
+                            let current = state.get_value(&update.key);
+                            let new_value = if let Some(reducer) = reducers.get(&update.key) {
+                                match reducer.reduce(current.as_ref(), &update.value).await {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        let _ = tx
+                                            .send(Ok(StreamEvent::Error {
+                                                node_id: Some(node_id.clone()),
+                                                error: e.to_string(),
+                                            }))
+                                            .await;
+                                        return;
+                                    }
+                                }
+                            } else {
+                                update.value.clone()
+                            };
+                            if let Err(e) = state.apply_update(&update.key, new_value).await {
+                                let _ = tx
+                                    .send(Ok(StreamEvent::Error {
+                                        node_id: Some(node_id.clone()),
+                                        error: e.to_string(),
+                                    }))
+                                    .await;
+                                return;
+                            }
+                        }
+
+                        let _ = tx
+                            .send(Ok(StreamEvent::NodeEnd {
+                                node_id: node_id.clone(),
+                                state: state.clone(),
+                                command: command.clone(),
+                            }))
+                            .await;
+
+                        next_nodes.extend(get_next_nodes(&node_id, &command));
+                    }
                 }
 
                 // Deduplicate current_nodes for parallel execution
-                let node_set: HashSet<String> = current_nodes.drain(..).collect();
+                let node_set: HashSet<String> = next_nodes.into_iter().collect();
                 current_nodes = node_set.into_iter().collect();
             }
 
@@ -670,8 +800,11 @@ impl<S: GraphState + 'static> CompiledGraph<S> for CompiledGraphImpl<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
     use mofa_kernel::workflow::{JsonState, StateGraph};
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{Duration, sleep};
 
     // Simple test node
     struct TestNode {
@@ -695,6 +828,51 @@ mod tests {
 
         fn name(&self) -> &str {
             &self.name
+        }
+    }
+
+    struct ConcurrencyProbeNode {
+        name: String,
+        active: Arc<AtomicUsize>,
+        max_active: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl NodeFunc<JsonState> for ConcurrencyProbeNode {
+        async fn call(
+            &self,
+            _state: &mut JsonState,
+            _ctx: &RuntimeContext,
+        ) -> AgentResult<Command> {
+            let concurrent = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(concurrent, Ordering::SeqCst);
+            sleep(Duration::from_millis(100)).await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+
+            Ok(Command::new().continue_())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    struct FlagReaderNode;
+
+    #[async_trait]
+    impl NodeFunc<JsonState> for FlagReaderNode {
+        async fn call(&self, state: &mut JsonState, _ctx: &RuntimeContext) -> AgentResult<Command> {
+            let saw_flag = state
+                .get_value("flag")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            Ok(Command::new()
+                .update("reader_saw_flag", json!(saw_flag))
+                .continue_())
+        }
+
+        fn name(&self) -> &str {
+            "flag_reader"
         }
     }
 
@@ -768,5 +946,108 @@ mod tests {
         let final_state = result.unwrap();
         assert_eq!(final_state.get_value("processed"), Some(json!(true)));
         assert_eq!(final_state.get_value("count"), Some(json!(1)));
+    }
+
+    #[tokio::test]
+    async fn test_parallel_nodes_execute_concurrently_in_invoke() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let mut graph = StateGraphImpl::<JsonState>::new("parallel_concurrency");
+
+        graph
+            .add_node(
+                "fan_out",
+                Box::new(TestNode {
+                    name: "fan_out".to_string(),
+                    updates: vec![],
+                }),
+            )
+            .add_node(
+                "node_a",
+                Box::new(ConcurrencyProbeNode {
+                    name: "node_a".to_string(),
+                    active: active.clone(),
+                    max_active: max_active.clone(),
+                }),
+            )
+            .add_node(
+                "node_b",
+                Box::new(ConcurrencyProbeNode {
+                    name: "node_b".to_string(),
+                    active: active.clone(),
+                    max_active: max_active.clone(),
+                }),
+            )
+            .add_node(
+                "node_c",
+                Box::new(ConcurrencyProbeNode {
+                    name: "node_c".to_string(),
+                    active,
+                    max_active: max_active.clone(),
+                }),
+            )
+            .add_edge(START, "fan_out")
+            .add_parallel_edges(
+                "fan_out",
+                vec![
+                    "node_a".to_string(),
+                    "node_b".to_string(),
+                    "node_c".to_string(),
+                ],
+            );
+
+        let compiled = graph.compile().unwrap();
+        compiled.invoke(JsonState::new(), None).await.unwrap();
+
+        assert!(
+            max_active.load(Ordering::SeqCst) > 1,
+            "parallel nodes should overlap in execution"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parallel_nodes_use_state_snapshot_in_invoke_and_stream() {
+        let mut graph = StateGraphImpl::<JsonState>::new("parallel_state_snapshot");
+
+        graph
+            .add_node(
+                "fan_out",
+                Box::new(TestNode {
+                    name: "fan_out".to_string(),
+                    updates: vec![],
+                }),
+            )
+            .add_node(
+                "writer",
+                Box::new(TestNode {
+                    name: "writer".to_string(),
+                    updates: vec![StateUpdate::new("flag", json!(true))],
+                }),
+            )
+            .add_node("reader", Box::new(FlagReaderNode))
+            .add_edge(START, "fan_out")
+            .add_parallel_edges("fan_out", vec!["writer".to_string(), "reader".to_string()]);
+
+        let compiled = graph.compile().unwrap();
+
+        let final_state = compiled.invoke(JsonState::new(), None).await.unwrap();
+        assert_eq!(final_state.get_value("flag"), Some(json!(true)));
+        assert_eq!(final_state.get_value("reader_saw_flag"), Some(json!(false)));
+
+        let mut stream = compiled.stream(JsonState::new(), None).await.unwrap();
+        let mut stream_final_state = None;
+        while let Some(event) = stream.next().await {
+            if let StreamEvent::End { final_state } = event.unwrap() {
+                stream_final_state = Some(final_state);
+            }
+        }
+
+        let stream_final_state =
+            stream_final_state.expect("stream should emit a final end event with state");
+        assert_eq!(stream_final_state.get_value("flag"), Some(json!(true)));
+        assert_eq!(
+            stream_final_state.get_value("reader_saw_flag"),
+            Some(json!(false))
+        );
     }
 }


### PR DESCRIPTION
StateGraph Parallel Execution Update
====================================

Problem
-------
Previously, StateGraph parallel branches were executed sequentially in both
`invoke()` and `stream()` while sharing a single mutable state reference.

This caused two major issues:

1. Parallel branches were not truly parallel.
   - Latency increased linearly with the number of branches.

2. Shared mutable state caused interference.
   - Sibling nodes could observe each other's updates within the same step.


Solution
--------
Implemented true parallel execution with isolated state snapshots and
deterministic post-execution merging.


Core Changes
------------

1. Node Storage

Converted compiled node storage to:

    Arc<dyn NodeFunc<S>>

This allows node handlers to be safely spawned across threads.


2. Parallel Execution Engine

Added:

    execute_parallel_nodes()

Implementation details:

    - Uses `tokio::task::JoinSet`
    - Clones base state per node
    - Executes sibling nodes concurrently
    - Collects results in deterministic input order


3. Node Context Isolation

Added:

    build_node_context()

Each spawned node receives:

    - Its own `current_node` context
    - Shared execution metadata
    - Shared configuration

This prevents context contamination across sibling nodes.


4. invoke() Behavior

Updated parallel batch execution:

    Before:
        Nodes executed sequentially with shared mutable state

    Now:
        - Nodes execute concurrently
        - Each node uses a state snapshot
        - Updates applied only after all nodes finish
        - Next-node routing derived after merge

Execution Flow:

    Base State
        ↓
    Snapshot per Node
        ↓
    Concurrent Execution
        ↓
    Collect Results
        ↓
    Merge Updates
        ↓
    Route Next Nodes


5. stream() Behavior

Updated multi-node semantics:

Single-node path:
    - Unchanged

Multi-node path:

    - Emit NodeStart for all siblings
    - Execute nodes concurrently
    - Apply merged updates
    - Emit NodeEnd events

Error Handling:

    - Node failures propagate
    - Reducer failures propagate
    - Update failures propagate


Tests Added
-----------

<img width="729" height="424" alt="image" src="https://github.com/user-attachments/assets/cf60a642-2703-4064-9eb8-27c2e6c9f396" />
<img width="730" height="93" alt="image" src="https://github.com/user-attachments/assets/a8a75f55-ee01-4e85-aa08-4d40c374b55f" />
<img width="721" height="85" alt="image" src="https://github.com/user-attachments/assets/d19486cd-5f08-42f2-836b-6c1e8c925371" />


1. test_parallel_nodes_execute_concurrently_in_invoke

Purpose:

    Validate true concurrency.

Method:

    - Uses atomic active/max-active counters
    - Confirms overlapping execution


2. test_parallel_nodes_use_state_snapshot_in_invoke_and_stream

Purpose:

    Validate sibling state isolation.

Method:

    - Writer branch modifies state
    - Reader branch checks state
    - Reader must NOT see writer update

Validated For:

    - invoke()
    - stream()


Result
------

✔ Parallel branches execute concurrently

✔ Latency no longer scales linearly with branch count

✔ Sibling state contamination prevented

✔ Deterministic merge preserved

✔ Reducer behavior unchanged


Summary
-------

Before:

    Sequential Execution
    Shared Mutable State
    Side-Effect Leakage

After:

    True Parallel Execution
    State Snapshots per Node
    Deterministic Merge