### PR TITLE
refactor(kernel): centralize timestamp logic and fix lossy u128 cast

### DIFF
--- a/crates/mofa-kernel/src/agent/components/coordinator.rs
+++ b/crates/mofa-kernel/src/agent/components/coordinator.rs
@@ -159,10 +159,7 @@ impl Task {
     /// 创建新任务
     /// Create a new task
     pub fn new(id: impl Into<String>, content: impl Into<String>) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             id: id.into(),

--- a/crates/mofa-kernel/src/agent/components/memory.rs
+++ b/crates/mofa-kernel/src/agent/components/memory.rs
@@ -217,10 +217,7 @@ impl MemoryItem {
     /// 创建新的记忆项
     /// Create a new memory item
     pub fn new(key: impl Into<String>, value: MemoryValue) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             key: key.into(),
@@ -269,10 +266,7 @@ impl Message {
     /// 创建新消息
     /// Create new message
     pub fn new(role: MessageRole, content: impl Into<String>) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             role,

--- a/crates/mofa-kernel/src/agent/components/reasoner.rs
+++ b/crates/mofa-kernel/src/agent/components/reasoner.rs
@@ -158,10 +158,7 @@ impl ThoughtStep {
     /// 创建新的思考步骤
     /// Create a new thought step
     pub fn new(step_type: ThoughtStepType, content: impl Into<String>, step_number: usize) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             step_type,

--- a/crates/mofa-kernel/src/agent/context.rs
+++ b/crates/mofa-kernel/src/agent/context.rs
@@ -323,10 +323,7 @@ impl AgentEvent {
     /// 创建新事件
     /// Create a new event
     pub fn new(event_type: impl Into<String>, data: serde_json::Value) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             event_type: event_type.into(),

--- a/crates/mofa-kernel/src/agent/core.rs
+++ b/crates/mofa-kernel/src/agent/core.rs
@@ -549,10 +549,7 @@ impl AgentMessage {
     /// 创建新消息
     /// Create new message
     pub fn new(msg_type: impl Into<String>) -> Self {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
+        let timestamp = crate::utils::now_ms() as i64;
 
         Self {
             msg_type: msg_type.into(),

--- a/crates/mofa-kernel/src/agent/types.rs
+++ b/crates/mofa-kernel/src/agent/types.rs
@@ -559,10 +559,7 @@ impl ReasoningStep {
         content: impl Into<String>,
         step_number: usize,
     ) -> Self {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = crate::utils::now_ms();
 
         Self {
             step_type,

--- a/crates/mofa-kernel/src/agent/types/event.rs
+++ b/crates/mofa-kernel/src/agent/types/event.rs
@@ -81,10 +81,7 @@ impl GlobalEvent {
     /// 创建新事件
     /// Create a new event
     pub fn new(event_type: impl Into<String>, source: impl Into<String>) -> Self {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        let timestamp = crate::utils::now_ms();
 
         Self {
             event_id: uuid::Uuid::new_v4().to_string(),

--- a/crates/mofa-kernel/src/agent/types/global.rs
+++ b/crates/mofa-kernel/src/agent/types/global.rs
@@ -364,10 +364,7 @@ impl Default for MessageMetadata {
     fn default() -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64,
+            timestamp: crate::utils::now_ms(),
             properties: HashMap::new(),
         }
     }

--- a/crates/mofa-kernel/src/lib.rs
+++ b/crates/mofa-kernel/src/lib.rs
@@ -9,6 +9,9 @@ pub use plugin::*;
 pub mod bus;
 pub use bus::*;
 
+// utils module
+pub mod utils;
+
 // logging module
 pub mod logging;
 

--- a/crates/mofa-kernel/src/utils.rs
+++ b/crates/mofa-kernel/src/utils.rs
@@ -1,0 +1,12 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Get the current timestamp in milliseconds since the UNIX epoch safely.
+/// This prevents silent truncation that could happen with `as u64`
+/// by using `try_from` and defaulting on overflow.
+pub fn now_ms() -> u64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    u64::try_from(millis).unwrap_or(0)
+}

--- a/crates/mofa-kernel/src/workflow/telemetry.rs
+++ b/crates/mofa-kernel/src/workflow/telemetry.rs
@@ -153,10 +153,7 @@ impl DebugEvent {
 
     /// Get the current timestamp in milliseconds since epoch
     pub fn now_ms() -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64
+        crate::utils::now_ms()
     }
 
     /// Returns a human-readable event type name


### PR DESCRIPTION
### Description
This PR addresses the duplicated and potentially unsafe timestamp generation across `mofa-kernel`. 

Closes #394 

Previously, the pattern `std::time::SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64` was copy-pasted across 10 different struct constructors. Furthermore, the `as u64` cast was silently truncating the `u128` returned by `as_millis()`.

**Changes proposed:**
- Introduced a centralized `crate::utils::now_ms()` utility function in mofa-kernel/src/utils.rs.
- Replaced the lossy `as u64` casting with a safe `u64::try_from(millis).unwrap_or(0)` to explicitly handle potential overflows without silent truncation or panics.
- Refactored all 10 inline timestamp generations across the crate (telemetry.rs, context.rs, coordinator.rs, memory.rs, reasoner.rs, event.rs, types.rs, global.rs, core.rs) to utilize the new centralized utility.

### Type of change
- [x] Refactoring (non-breaking change which improves code quality/structure)
- [x] Bug fix (non-breaking change which fixes an issue)
