### PR TITLE
FIX : **EventHandlingEngine::start** lacks lifecycle guard, allowing multiple concurrent event loops

### DIFF
--- a/crates/mofa-foundation/src/secretary/monitoring/engine.rs
+++ b/crates/mofa-foundation/src/secretary/monitoring/engine.rs
@@ -8,6 +8,7 @@ use super::plugin::EventResponsePlugin;
 use super::rule_manager::{RuleAdjustmentStrategy, RuleManager};
 use mofa_kernel::plugin::{AgentPlugin, PluginContext, PluginResult};
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
 
@@ -174,6 +175,59 @@ impl EventHandlingEngine {
     }
 }
 
+/// Lifecycle-aware runner for `EventHandlingEngine`.
+///
+/// This wrapper ensures that at most one main event-processing loop is running
+/// for a given engine instance. Calling `spawn()` multiple times on the same
+/// runner is idempotent: only the first call will actually start the loop.
+pub struct EventEngineRunner {
+    engine: Arc<EventHandlingEngine>,
+    running: Arc<AtomicBool>,
+}
+
+impl EventEngineRunner {
+    /// Create a new runner for the given engine instance.
+    pub fn new(engine: Arc<EventHandlingEngine>) -> Self {
+        Self {
+            engine,
+            running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Return a reference to the wrapped engine.
+    pub fn engine(&self) -> &Arc<EventHandlingEngine> {
+        &self.engine
+    }
+
+    /// Start the event-handling loop if it is not already running.
+    ///
+    /// Multiple calls to `spawn()` on the same runner (or its clones) will
+    /// result in at most one background task that invokes `engine.start()`.
+    /// If the loop is already running, this method spawns a no-op task so
+    /// callers can always `await` the returned handle without special-casing.
+    pub fn spawn(&self) -> tokio::task::JoinHandle<()> {
+        // Try to transition running: false -> true. If this fails, another
+        // task has already started the loop for this runner.
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            // Already running: spawn a no-op task so the caller still
+            // receives a handle it can `.await` or `.abort()` safely.
+            return tokio::spawn(async {});
+        }
+
+        let engine = Arc::clone(&self.engine);
+        let running_flag = Arc::clone(&self.running);
+
+        tokio::spawn(async move {
+            let _ = engine.start().await;
+            running_flag.store(false, Ordering::SeqCst);
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,5 +285,47 @@ mod tests {
         if let Ok(Some(event)) = result {
             assert!(matches!(event.status, EventStatus::Resolved));
         }
+    }
+
+    /// Demonstrates that calling `start()` twice on the same `EventHandlingEngine`
+    /// instance creates two independent event loops, both logging their startup.
+    #[tokio::test]
+    async fn demo_engine_double_start_logs_twice() {
+        use std::sync::Arc;
+
+        let engine = Arc::new(EventHandlingEngine::new());
+
+        // (Optionally register plugins and submit events here)
+
+        let e1 = engine.clone();
+        let e2 = engine.clone();
+
+        let h1 = tokio::spawn(async move {
+            let _ = e1.start().await;
+        });
+        let h2 = tokio::spawn(async move {
+            let _ = e2.start().await;
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        h1.abort();
+        h2.abort();
+    }
+
+    /// Verifies that `EventEngineRunner::spawn` is idempotent: calling it multiple
+    /// times results in at most one real `start()` invocation for the wrapped engine.
+    #[tokio::test]
+    async fn event_engine_runner_spawn_is_idempotent() {
+        use std::sync::Arc;
+
+        let engine = Arc::new(EventHandlingEngine::new());
+        let runner = EventEngineRunner::new(engine);
+
+        let h1 = runner.spawn();
+        let h2 = runner.spawn();
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        h1.abort();
+        h2.abort();
     }
 }


### PR DESCRIPTION
## 📋 Summary

Add a lifecycle-aware `EventEngineRunner` wrapper around `EventHandlingEngine` to prevent multiple concurrent `start()` loops per engine instance, and add tests that demonstrate both the original double-start behaviour and the new idempotent runner semantics.

## 🔗 Related Issues

Closes #422

Related to: `crates/mofa-foundation/src/secretary/monitoring/engine.rs`

---

## 🧠 Context

`EventHandlingEngine::start(&self)` can be called multiple times on the same `Arc<EventHandlingEngine>`, and each call launches its own infinite event loop sharing the same `event_queue`. This is safe from a data-race perspective but violates the intuitive “one engine = one loop” invariant and can lead to surprising behaviour under rapid or overlapping `start()` calls.  
This PR introduces a small runner type responsible for lifecycle so that higher-level code has an explicit, idempotent way to start the engine without accidentally spawning multiple loops.

---

## 🛠️ Changes

- Add `EventEngineRunner` in `secretary/monitoring/engine.rs` that wraps an `Arc<EventHandlingEngine>` and guards `start()` with an `AtomicBool`-based `spawn()` method.
- Keep `EventHandlingEngine::start` unchanged as the low-level primitive, but document and test its behaviour when called twice on the same instance.
- Extend the test module to:
  - keep `demo_engine_double_start_logs_twice` as a focused repro of the underlying behaviour, and
  - add `event_engine_runner_spawn_is_idempotent` to verify the runner only starts one loop even when `spawn()` is called multiple times.

---

## 🧪 How you Tested

1. **Foundation tests**
   - `cargo test -p mofa-foundation --lib`
   - Confirms all existing secretary, monitoring, workflow, and foundation tests still pass with the new runner.
 
2. **Behavioural tests for this change**
   - Repro of underlying behaviour:
     - `cargo test -p mofa-foundation secretary::monitoring::engine::tests::demo_engine_double_start_logs_twice -- --nocapture`
     - Expected logs include **two** lines:
       - `Starting event handling engine with 10 concurrent handlers...`
       - `Starting event handling engine with 10 concurrent handlers...`
   - Runner idempotency:
     - `cargo test -p mofa-foundation secretary::monitoring::engine::tests::event_engine_runner_spawn_is_idempotent -- --nocapture`
     - Expected logs include **one**:
       - `Starting event handling engine with 10 concurrent handlers...`

3. **Optional runtime sanity (manual)**
   - Verify CLI and examples still behave:
     - `cargo run -p mofa-cli -- --help`
     - `cargo run -p mofa-cli -- new test_agent` (optional)
     - `cd examples/secretary_agent && cargo run`
     - `cd ../workflow_orchestration && cargo run`

(All these tests passed with few unrelated warnings but absolutely NO Errors)

---

## 📸 Screenshots / Logs 

- Screenshot / log for **double-start repro**:
  - Command:
    - `cargo test -p mofa-foundation secretary::monitoring::engine::tests::demo_engine_double_start_logs_twice -- --nocapture`
<img width="699" height="108" alt="before" src="https://github.com/user-attachments/assets/2549d975-4543-4ccb-826e-1afed2a7162e" />


- Screenshot / log for **runner idempotency**:
  - Command:
    - `cargo test -p mofa-foundation secretary::monitoring::engine::tests::event_engine_runner_spawn_is_idempotent -- --nocapture`

<img width="698" height="113" alt="After" src="https://github.com/user-attachments/assets/79682a71-86db-4801-9edf-1a2fc2e0b305" />


- Screenshots/logs from:
  - `cargo test -p mofa-foundation --lib`

<img width="724" height="456" alt="mofa-foundation-lib" src="https://github.com/user-attachments/assets/f7cdd3e9-c466-4eab-95b8-43636392053d" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

> N/A – this is an additive, opt-in runner type; existing call sites remain unchanged.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings <!-- run before merge -->

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error (at least `-p mofa-foundation`)

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes 

- No migrations or configuration changes required.
- This change is internal to `mofa-foundation` and does not alter public CLI or SDK behaviour.

---

## 🧩 Additional Notes for Reviewers

- The `demo_engine_double_start_logs_twice` test is intentionally left as a repro of the underlying behaviour when `start()` is misused directly; the recommended path for new code is to use `EventEngineRunner::spawn`.
- If we later wire `EventHandlingEngine` into a long-running service, we should do so via `EventEngineRunner` to ensure lifecycle is always coordinated in one place.

