### PR TITLE
fix(kernel): replace deprecated error-stack attach_printable usage

### DIFF
--- a/crates/mofa-kernel/src/error.rs
+++ b/crates/mofa-kernel/src/error.rs
@@ -12,11 +12,11 @@
 //!
 //! fn load_agent() -> KernelResult<()> {
 //!     // Errors from sub-modules convert automatically via From impls.
-//!     // Attach extra context with .change_context() / .attach_printable().
+//!     // Attach extra context with .change_context() / .attach().
 //!     let config = std::fs::read_to_string("agent.toml")
 //!         .map_err(KernelError::from)
 //!         .map_err(error_stack::Report::new)
-//!         .attach_printable("loading agent.toml")?;
+//!         .attach("loading agent.toml")?;
 //!     Ok(())
 //! }
 //! ```

--- a/crates/mofa-kernel/src/error.rs
+++ b/crates/mofa-kernel/src/error.rs
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn report_carries_context() {
         let result: KernelResult<()> = Err(Report::new(KernelError::Internal("root cause".into())))
-            .attach_printable("while loading agent config");
+            .attach("while loading agent config");
 
         let report = result.unwrap_err();
         let display = format!("{report:?}");


### PR DESCRIPTION
## Summary
Fixes a `mofa-kernel` clippy failure under `-D warnings` by replacing deprecated `error-stack` API usage in test code.

## Change
- In `crates/mofa-kernel/src/error.rs`, replaced:
  - `.attach_printable("while loading agent config")`
  - with `.attach("while loading agent config")`

## Why
`attach_printable` is deprecated in `error-stack 0.6`, and `cargo clippy -p mofa-kernel --all-targets -- -D warnings` fails because deprecations are treated as errors.

## Validation
```bash
cargo clippy -p mofa-kernel --all-targets -- -D warnings
cargo test -p mofa-kernel report_carries_context
```
