### PR TITLE
fix: replace deterministic jitter with random jitter in ExponentialBackoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "mofa-kernel",
  "mofa-monitoring",
  "mofa-plugins",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",

--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -25,6 +25,7 @@ flume.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
 eyre.workspace = true
+rand.workspace = true
 
 # Local dependencies
 mofa-kernel = { path = "../mofa-kernel", version = "0.1", features = ["config"] }

--- a/crates/mofa-runtime/src/retry.rs
+++ b/crates/mofa-runtime/src/retry.rs
@@ -3,6 +3,8 @@
 use std::future::Future;
 use std::time::Duration;
 
+use rand::Rng;
+
 use crate::agent::error::{AgentError, AgentResult};
 
 /// Delay strategy between retry attempts.
@@ -31,12 +33,9 @@ impl RetryPolicy {
                 let capped = exp.min(*max_ms);
                 if *jitter {
                     let eighth = capped / 8;
-                    if attempt.is_multiple_of(2) {
-                        capped.saturating_add(eighth)
-                    } else {
-                        capped.saturating_sub(eighth)
-                    }
-                    .min(*max_ms)
+                    let jitter_range = eighth.max(1);
+                    let jitter_val = rand::thread_rng().gen_range(0..=jitter_range * 2);
+                    capped.saturating_sub(jitter_range).saturating_add(jitter_val).min(*max_ms)
                 } else {
                     capped
                 }


### PR DESCRIPTION
## Summary

Replace deterministic jitter in `RetryPolicy::ExponentialBackoff` with actual random jitter using `rand::thread_rng().gen_range()`.

## Problem

The existing jitter implementation alternates between +12.5% and -12.5% based on attempt parity (`attempt % 2`). This means all agents using the same retry config produce identical delay sequences, causing correlated retry storms — the exact problem jitter is supposed to prevent.

## Fix

Replace the deterministic alternating pattern with uniform random jitter in the range `[-12.5%, +12.5%]` of the capped delay. The `rand` crate is already a workspace dependency (used in the foundation crate's `BackoffStrategy::ExponentialWithJitter`).

### Changes
- `crates/mofa-runtime/Cargo.toml`: add `rand.workspace = true`
- `crates/mofa-runtime/src/retry.rs`: use `rand::thread_rng().gen_range()` for jitter

Fixes #667