### PR TITLE
ci: add cargo-audit and cargo-deny for security and license compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,31 @@ jobs:
 
       - name: Check docs intra-doc links
         run: cargo doc --workspace --no-deps --all-features --document-private-items
+
+  # Security audit - check for CVEs and license compliance
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-security-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo audit (CVE check)
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run cargo deny (license + advisory check)
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,35 @@
+# cargo-deny configuration for MoFA
+# https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Check for known security vulnerabilities
+yanked = "warn"
+ignore = []
+
+[licenses]
+# Allow permissive licenses compatible with Apache-2.0
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OFL-1.1",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Disallow multiple versions of the same crate
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+# Only allow crates from crates.io by default
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## Summary

Adds automated security scanning to CI pipeline:
- **cargo-audit**: Checks for known CVEs in dependencies via rustsec/audit-check
- **cargo-deny**: Enforces license compliance and checks for duplicate dependencies

Closes #610

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- Added new `security` job that runs in parallel with lint/test/docs
- Uses official GitHub Actions for both tools

### deny.toml
- Created configuration allowing permissive licenses compatible with Apache-2.0
- MIT, Apache-2.0, BSD variants, ISC, Zlib, MPL-2.0, etc.
- Warns on duplicate crate versions
- Denies crates from unknown sources

## Testing

Both actions will run automatically on this PR and future pushes.

## Checklist
- [x] No code changes (CI only)
- [x] Configuration follows best practices from both tools
- [x] Licenses allowlist is permissive but reasonable for an Apache-2.0 project