### PR TITLE
fix: replace unsafe as u64 casts with u64::try_from in timestamp conversions

### DIFF
--- a/crates/mofa-kernel/src/gateway/envelope.rs
+++ b/crates/mofa-kernel/src/gateway/envelope.rs
@@ -71,11 +71,7 @@ impl RequestEnvelope {
     ///
     /// `route_id` is typically empty at construction time and filled in by
     /// the routing middleware once a matching route has been found.
-    pub fn new(
-        route_id: impl Into<String>,
-        payload: serde_json::Value,
-        origin_ip: IpAddr,
-    ) -> Self {
+    pub fn new(route_id: impl Into<String>, payload: serde_json::Value, origin_ip: IpAddr) -> Self {
         Self {
             correlation_id: Uuid::new_v4().to_string(),
             route_id: route_id.into(),
@@ -101,9 +97,7 @@ impl RequestEnvelope {
 
     /// Returns `true` if a deadline is set and has already passed.
     pub fn is_expired(&self) -> bool {
-        self.deadline
-            .map(|d| Instant::now() > d)
-            .unwrap_or(false)
+        self.deadline.map(|d| Instant::now() > d).unwrap_or(false)
     }
 
     /// Return the deadline as milliseconds since UNIX epoch, suitable for
@@ -111,7 +105,8 @@ impl RequestEnvelope {
     pub fn deadline_unix_ms(&self) -> Option<u64> {
         self.deadline.map(|d| {
             let remaining = d.saturating_duration_since(Instant::now());
-            now_ms().saturating_add(remaining.as_millis() as u64)
+            let remaining_ms = u64::try_from(remaining.as_millis()).unwrap_or(u64::MAX);
+            now_ms().saturating_add(remaining_ms)
         })
     }
 }
@@ -182,10 +177,13 @@ impl AgentResponse {
 
 /// Current wall-clock time as milliseconds since UNIX epoch.
 fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
+    u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+    )
+    .unwrap_or(u64::MAX)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -230,10 +228,7 @@ mod tests {
             env.headers.get("content-type"),
             Some(&"application/json".to_string())
         );
-        assert_eq!(
-            env.headers.get("x-api-key"),
-            Some(&"secret".to_string())
-        );
+        assert_eq!(env.headers.get("x-api-key"), Some(&"secret".to_string()));
     }
 
     #[test]
@@ -324,5 +319,16 @@ mod tests {
         assert!(json.contains("latency_ms"));
         assert!(json.contains("agent_id"));
         assert!(json.contains("correlation_id"));
+    }
+
+    #[test]
+    fn now_ms_uses_safe_conversion() {
+        // Verify the module-local now_ms() returns a sane value (i.e. the
+        // u128→u64 try_from path works in practice).
+        let ms = super::now_ms();
+        assert!(
+            ms > 1_577_836_800_000,
+            "now_ms() = {ms}, expected > 2020-01-01 epoch millis"
+        );
     }
 }

--- a/crates/mofa-kernel/src/utils.rs
+++ b/crates/mofa-kernel/src/utils.rs
@@ -10,3 +10,26 @@ pub fn now_ms() -> u64 {
         .as_millis();
     u64::try_from(millis).unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_ms_returns_reasonable_epoch_millis() {
+        let ms = now_ms();
+        // Must be after 2020-01-01 (~1_577_836_800_000 ms) and before some far
+        // future date.  This validates the safe u128→u64 conversion path.
+        assert!(
+            ms > 1_577_836_800_000,
+            "now_ms() returned {ms}, expected > 2020-01-01 epoch millis"
+        );
+    }
+
+    #[test]
+    fn now_ms_is_monotonically_non_decreasing() {
+        let a = now_ms();
+        let b = now_ms();
+        assert!(b >= a);
+    }
+}

--- a/crates/mofa-runtime/src/agent/execution.rs
+++ b/crates/mofa-runtime/src/agent/execution.rs
@@ -370,7 +370,7 @@ impl ExecutionEngine {
             .execute_with_options(&agent, processed_input.clone(), &ctx, &options, &retry_cfg)
             .await;
 
-        let duration_ms = start_time.elapsed().as_millis() as u64;
+        let duration_ms = u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         // 构建结果
         // Build result
@@ -579,10 +579,7 @@ impl ExecutionEngine {
 
             let span = tracing::info_span!("agent.parallel", agent_id = %agent_id);
             let handle = tokio::spawn(
-                async move {
-                    engine.execute(&agent_id, input, opts).await
-                }
-                .instrument(span),
+                async move { engine.execute(&agent_id, input, opts).await }.instrument(span),
             );
 
             handles.push(handle);

--- a/crates/mofa-runtime/src/agent/registry.rs
+++ b/crates/mofa-runtime/src/agent/registry.rs
@@ -201,10 +201,7 @@ impl AgentRegistry {
         let state = agent_guard.state();
         drop(agent_guard);
 
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+        let now = mofa_kernel::utils::now_ms();
 
         let metadata = AgentMetadata {
             id: id.clone(),

--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -408,7 +408,7 @@ impl<T: MoFAAgent> AgentRunner<T> {
         // Execute Agent
         let result = self.agent.execute(input, &self.context).await;
 
-        let duration = start.elapsed().as_millis() as u64;
+        let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
         // 更新统计信息
         // Update statistics
@@ -774,8 +774,8 @@ pub async fn run_agents<T: MoFAAgent>(
 // GlobalResult-based APIs (Phase 4 unified error handling)
 // ============================================================================
 
-use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 use mofa_foundation::recovery::RetryPolicy;
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
 
 impl<T: MoFAAgent> AgentRunner<T> {
     /// Execute a task returning `GlobalResult` (unified error type).
@@ -844,9 +844,7 @@ pub async fn run_agents_global<T: MoFAAgent>(
     agent: T,
     inputs: Vec<AgentInput>,
 ) -> GlobalResult<Vec<AgentOutput>> {
-    let mut runner = AgentRunner::new(agent)
-        .await
-        .map_err(GlobalError::from)?;
+    let mut runner = AgentRunner::new(agent).await.map_err(GlobalError::from)?;
 
     let mut outputs = Vec::with_capacity(inputs.len());
     for input in inputs {
@@ -1388,8 +1386,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resume_failure_preserves_paused_state() {
-        let agent = LifecycleTestAgent::new("lc-002", "Failing Resume Agent")
-            .with_failing_resume();
+        let agent = LifecycleTestAgent::new("lc-002", "Failing Resume Agent").with_failing_resume();
         let mut runner = AgentRunner::new(agent).await.unwrap();
 
         // Move into Running, then pause.
@@ -1409,8 +1406,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pause_failure_preserves_running_state() {
-        let agent = LifecycleTestAgent::new("lc-003", "Failing Pause Agent")
-            .with_failing_pause();
+        let agent = LifecycleTestAgent::new("lc-003", "Failing Pause Agent").with_failing_pause();
         let mut runner = AgentRunner::new(agent).await.unwrap();
 
         // Move into Running.


### PR DESCRIPTION
### Problem #1172

`Duration::as_millis()` returns `u128`. Multiple call sites across `mofa-kernel` and `mofa-runtime` cast this directly with `as u64`, which silently truncates on overflow. While current wall-clock values fit in `u64`, the project's coding standard (Section VII.2) requires that "numeric type conversions MUST explicitly handle potential overflow."

Affected files:
- `mofa-kernel/src/gateway/envelope.rs` — local `now_ms()` helper + `deadline_unix_ms()`
- `mofa-runtime/src/agent/registry.rs` — inline timestamp for agent registration
- `mofa-runtime/src/agent/execution.rs` — execution duration measurement
- `mofa-runtime/src/runner.rs` — runner execution duration measurement

### Fix

- **envelope.rs**: Replace `as_millis() as u64` with `u64::try_from(...).unwrap_or(u64::MAX)` in both `now_ms()` and `deadline_unix_ms()`
- **registry.rs**: Replace inline `SystemTime::now()...as_millis() as u64` with the safe `mofa_kernel::utils::now_ms()` utility (which already uses `try_from`)
- **execution.rs** and **runner.rs**: Replace `as_millis() as u64` with `u64::try_from(...).unwrap_or(u64::MAX)`

### Tests added

| Test | Location | Validates |
|------|----------|-----------|
| `now_ms_returns_reasonable_epoch_millis` | `mofa-kernel/src/utils.rs` | Safe u128→u64 conversion returns sane epoch value |
| `now_ms_is_monotonically_non_decreasing` | `mofa-kernel/src/utils.rs` | Successive calls don't regress |
| `now_ms_uses_safe_conversion` | `mofa-kernel/src/gateway/envelope.rs` | Module-local `now_ms()` uses safe path |

All 86 runtime tests + 15 envelope tests + 2 utils tests pass. No clippy warnings introduced.
