### PR TITLE
feat(testing): add TestStatus predicates and serde support for report types

### DIFF
--- a/tests/src/report/types.rs
+++ b/tests/src/report/types.rs
@@ -1,14 +1,29 @@
 //! Core data types for test reports.
 
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// Outcome of a single test case.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum TestStatus {
     Passed,
     Failed,
     Skipped,
+}
+
+impl TestStatus {
+    pub fn is_passed(&self) -> bool {
+        matches!(self, Self::Passed)
+    }
+
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed)
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self, Self::Skipped)
+    }
 }
 
 impl std::fmt::Display for TestStatus {
@@ -22,22 +37,44 @@ impl std::fmt::Display for TestStatus {
 }
 
 /// Result of a single test case execution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestCaseResult {
     pub name: String,
     pub status: TestStatus,
+    #[serde(with = "duration_millis")]
     pub duration: Duration,
     pub error: Option<String>,
     pub metadata: Vec<(String, String)>,
 }
 
 /// Aggregated report for a test suite.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestReport {
     pub suite_name: String,
     pub results: Vec<TestCaseResult>,
+    #[serde(with = "duration_millis")]
     pub total_duration: Duration,
     pub timestamp: u64,
+}
+
+mod duration_millis {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S>(d: &Duration, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_u64(d.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let ms = u64::deserialize(d)?;
+        Ok(Duration::from_millis(ms))
+    }
 }
 
 impl TestReport {

--- a/tests/tests/serde_predicate_tests.rs
+++ b/tests/tests/serde_predicate_tests.rs
@@ -1,0 +1,127 @@
+//! Tests for TestStatus predicates and Serde support on report types.
+
+use mofa_testing::report::{TestCaseResult, TestReport, TestStatus};
+use std::time::Duration;
+
+#[test]
+fn is_passed_returns_true_for_passed() {
+    assert!(TestStatus::Passed.is_passed());
+    assert!(!TestStatus::Failed.is_passed());
+    assert!(!TestStatus::Skipped.is_passed());
+}
+
+#[test]
+fn is_failed_returns_true_for_failed() {
+    assert!(TestStatus::Failed.is_failed());
+    assert!(!TestStatus::Passed.is_failed());
+    assert!(!TestStatus::Skipped.is_failed());
+}
+
+#[test]
+fn is_skipped_returns_true_for_skipped() {
+    assert!(TestStatus::Skipped.is_skipped());
+    assert!(!TestStatus::Passed.is_skipped());
+    assert!(!TestStatus::Failed.is_skipped());
+}
+
+#[test]
+fn test_status_serde_roundtrip() {
+    for status in [TestStatus::Passed, TestStatus::Failed, TestStatus::Skipped] {
+        let json = serde_json::to_string(&status).unwrap();
+        let back: TestStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, status);
+    }
+}
+
+#[test]
+fn test_case_result_serde_roundtrip() {
+    let result = TestCaseResult {
+        name: "my_test".into(),
+        status: TestStatus::Failed,
+        duration: Duration::from_millis(42),
+        error: Some("assertion failed".into()),
+        metadata: vec![("key".into(), "value".into())],
+    };
+
+    let json = serde_json::to_string(&result).unwrap();
+    let back: TestCaseResult = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back.name, "my_test");
+    assert_eq!(back.status, TestStatus::Failed);
+    assert_eq!(back.duration, Duration::from_millis(42));
+    assert_eq!(back.error.as_deref(), Some("assertion failed"));
+    assert_eq!(back.metadata, vec![("key".into(), "value".into())]);
+}
+
+#[test]
+fn test_report_serde_roundtrip_all_fields() {
+    let report = TestReport {
+        suite_name: "my-suite".into(),
+        results: vec![
+            TestCaseResult {
+                name: "test_a".into(),
+                status: TestStatus::Passed,
+                duration: Duration::from_millis(10),
+                error: None,
+                metadata: Vec::new(),
+            },
+            TestCaseResult {
+                name: "test_b".into(),
+                status: TestStatus::Failed,
+                duration: Duration::from_millis(25),
+                error: Some("boom".into()),
+                metadata: vec![("env".into(), "ci".into())],
+            },
+            TestCaseResult {
+                name: "test_c".into(),
+                status: TestStatus::Skipped,
+                duration: Duration::from_millis(0),
+                error: None,
+                metadata: Vec::new(),
+            },
+        ],
+        total_duration: Duration::from_millis(100),
+        timestamp: 1_234_567_890,
+    };
+
+    let json = serde_json::to_string_pretty(&report).unwrap();
+    let back: TestReport = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back.suite_name, "my-suite");
+    assert_eq!(back.total(), 3);
+    assert_eq!(back.passed(), 1);
+    assert_eq!(back.failed(), 1);
+    assert_eq!(back.skipped(), 1);
+    assert_eq!(back.total_duration, Duration::from_millis(100));
+    assert_eq!(back.timestamp, 1_234_567_890);
+}
+
+#[test]
+fn deserialized_report_has_correct_pass_rate() {
+    let report = TestReport {
+        suite_name: "rate-test".into(),
+        results: vec![
+            TestCaseResult {
+                name: "t1".into(),
+                status: TestStatus::Passed,
+                duration: Duration::from_millis(10),
+                error: None,
+                metadata: Vec::new(),
+            },
+            TestCaseResult {
+                name: "t2".into(),
+                status: TestStatus::Failed,
+                duration: Duration::from_millis(10),
+                error: Some("fail".into()),
+                metadata: Vec::new(),
+            },
+        ],
+        total_duration: Duration::from_millis(20),
+        timestamp: 0,
+    };
+
+    let json = serde_json::to_string(&report).unwrap();
+    let back: TestReport = serde_json::from_str(&json).unwrap();
+
+    assert!((back.pass_rate() - 0.5).abs() < f64::EPSILON);
+}


### PR DESCRIPTION

<img width="3518" height="1835" alt="pr1185" src="https://github.com/user-attachments/assets/b31036d1-4524-4e01-be10-88ecb2ab8f87" />



## Summary

Add `TestStatus` predicate helpers and native serde support for `TestStatus`, `TestCaseResult`, and `TestReport` so test reports can be serialized and deserialized without going through a formatter.

## Related Issues

Closes #1183 

---

## Changes

- `tests/src/report/types.rs` - Added `is_passed()`, `is_failed()`, and `is_skipped()` on `TestStatus`
- `tests/src/report/types.rs` - Added `Serialize` / `Deserialize` derives for report types and millis-based serde for `Duration` fields
- `tests/tests/serde_predicate_tests.rs` - Added 7 tests covering predicates plus serde round-trips for status, case results, and reports

---

## Testing

1. `cargo test -p mofa-testing --test serde_predicate_tests` - 7 tests pass
2. `cargo test -p mofa-testing` - full `mofa-testing` suite passes locally
3. `cargo clippy -p mofa-testing --all-targets -- -D warnings` currently stops on unrelated pre-existing warnings in `crates/mofa-kernel/src/workflow/telemetry.rs`


## Checklist

- [x] Code follows Rust idioms and project conventions
- [x] Tests added/updated
- [x] `cargo test -p mofa-testing` passes locally

