### PR TITLE
fix(extra): cap exponential backoff delay to prevent overflow

### DIFF
--- a/crates/mofa-extra/src/rhai/workflow.rs
+++ b/crates/mofa-extra/src/rhai/workflow.rs
@@ -272,9 +272,11 @@ impl ScriptWorkflowNode {
             }
 
             if retry_count < self.config.max_retries {
-                // 指数退避重试
-                // Exponential backoff retry
-                let delay = std::time::Duration::from_millis(100 * 2u64.pow(retry_count));
+                // Exponential backoff retry, capped to avoid overflow.
+                // 2u64.pow(n) overflows for n >= 64, and 100 * 2^57 exceeds u64.
+                let exp = 2u64.saturating_pow(retry_count.min(63));
+                let delay_ms = 100u64.saturating_mul(exp).min(30_000);
+                let delay = std::time::Duration::from_millis(delay_ms);
                 tokio::time::sleep(delay).await;
             }
             retry_count += 1;


### PR DESCRIPTION
Closes https://github.com/moxin-org/mofa/issues/1188

## Problem

`2u64.pow(retry_count)` overflows for `retry_count >= 64` (panics in debug, wraps in release). Even at retry 57, `100 * 2^57` exceeds `u64::MAX`. `max_retries` is a `u32` with no upper bound, so any config with a large retry count hits this.

## Fix

- Use `saturating_pow` with the exponent clamped to 63
- Use `saturating_mul` for the `100 *` multiplier
- Cap the final delay at 30 seconds to keep retries practical