### PR TITLE
fix(plugins): use checked u32 conversion in WASM alloc_bytes

### DIFF
--- a/crates/mofa-plugins/src/wasm_runtime/memory.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/memory.rs
@@ -304,9 +304,12 @@ impl WasmMemory {
 
     /// Allocate and write data
     pub fn alloc_bytes(&mut self, data: &[u8]) -> WasmResult<GuestSlice> {
-        let ptr = self.alloc(data.len() as u32)?;
+        let size = u32::try_from(data.len()).map_err(|_| WasmError::AllocationFailed {
+            size: u32::MAX,
+        })?;
+        let ptr = self.alloc(size)?;
         self.write(ptr, data)?;
-        Ok(GuestSlice::new(ptr, data.len() as u32))
+        Ok(GuestSlice::new(ptr, size))
     }
 
     /// Allocate and write string


### PR DESCRIPTION
Closes https://github.com/moxin-org/mofa/issues/1196

## Problem

`alloc_bytes()` casts `data.len()` to `u32` with `as`, which silently truncates on 64-bit systems. A 5 GB buffer would be allocated as ~1 GB and the subsequent write would go out of bounds.

## Fix

Use `u32::try_from(data.len())` and return an `AllocationFailed` error when the length exceeds the WASM 32-bit address space.