### PR TITLE
fix: replace blocking std::fs calls with tokio::fs in async context

### DIFF
--- a/crates/mofa-foundation/src/llm/agent_loop.rs
+++ b/crates/mofa-foundation/src/llm/agent_loop.rs
@@ -127,7 +127,7 @@ impl AgentLoop {
         // Build user message with optional media
         let user_msg = if let Some(media_paths) = media {
             if !media_paths.is_empty() {
-                Self::build_vision_message(content, &media_paths)?
+                Self::build_vision_message(content, &media_paths).await?
             } else {
                 ChatMessage::user(content)
             }
@@ -193,7 +193,7 @@ impl AgentLoop {
             let mut messages = history;
             let user_msg = if let Some(media_paths) = media.clone() {
                 if !media_paths.is_empty() {
-                    Self::build_vision_message(content, &media_paths)?
+                    Self::build_vision_message(content, &media_paths).await?
                 } else {
                     ChatMessage::user(content)
                 }
@@ -214,7 +214,7 @@ impl AgentLoop {
 
         let user_msg = if let Some(media_paths) = media {
             if !media_paths.is_empty() {
-                Self::build_vision_message(content, &media_paths)?
+                Self::build_vision_message(content, &media_paths).await?
             } else {
                 ChatMessage::user(content)
             }
@@ -320,13 +320,13 @@ impl AgentLoop {
     }
 
     /// Build a vision message with images
-    fn build_vision_message(text: &str, image_paths: &[String]) -> GlobalResult<ChatMessage> {
+    async fn build_vision_message(text: &str, image_paths: &[String]) -> GlobalResult<ChatMessage> {
         let mut parts = vec![ContentPart::Text {
             text: text.to_string(),
         }];
 
         for path in image_paths {
-            let image_url = Self::encode_image_data_url(Path::new(path))?;
+            let image_url = Self::encode_image_data_url(Path::new(path)).await?;
             parts.push(ContentPart::Image { image_url });
         }
 
@@ -340,12 +340,11 @@ impl AgentLoop {
     }
 
     /// Encode an image file as a data URL
-    fn encode_image_data_url(path: &Path) -> GlobalResult<ImageUrl> {
+    async fn encode_image_data_url(path: &Path) -> GlobalResult<ImageUrl> {
         use base64::Engine;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
-        use std::fs;
 
-        let bytes = fs::read(path)?;
+        let bytes = tokio::fs::read(path).await?;
         let mime_type = infer::get_from_path(path)?
             .ok_or_else(|| GlobalError::Other(format!("Unknown MIME type for: {:?}", path)))?
             .mime_type()

--- a/crates/mofa-foundation/src/llm/context.rs
+++ b/crates/mofa-foundation/src/llm/context.rs
@@ -160,7 +160,7 @@ impl AgentContextBuilder {
         // Load bootstrap files
         for filename in &self.bootstrap_files {
             let path = self.workspace.join(filename);
-            if let Ok(content) = Self::load_file(&path) {
+            if let Ok(content) = Self::load_file(&path).await {
                 parts.push(format!("## {}\n{}", filename, content));
             }
         }
@@ -340,8 +340,9 @@ The following skills extend your capabilities. To use a skill, read its document
     }
 
     /// Load a file's content
-    fn load_file(path: &Path) -> GlobalResult<String> {
-        std::fs::read_to_string(path)
+    async fn load_file(path: &Path) -> GlobalResult<String> {
+        tokio::fs::read_to_string(path)
+            .await
             .map_err(|e| GlobalError::Other(format!("Failed to read {:?}: {}", path, e)))
     }
 


### PR DESCRIPTION
# fix: replace blocking std::fs calls with tokio::fs in async context

## Summary

`encode_image_data_url()` and `load_file()` use synchronous `std::fs::read` / `std::fs::read_to_string` but are called from async functions. This blocks the tokio worker thread for the duration of the disk I/O, degrading latency for **all** concurrent tasks sharing that thread.

## Problem

### `encode_image_data_url` in `agent_loop.rs:343`

```rust
fn encode_image_data_url(path: &Path) -> GlobalResult<ImageUrl> {
    use std::fs;
    let bytes = fs::read(path)?; // blocks the tokio thread
    // ...
}
```

Called from `build_vision_message()`, which is called from 3 async paths:
- `process_with_options()` (line 130)
- `process_with_session()` (lines 196, 217)

### `load_file` in `context.rs:343`

```rust
fn load_file(path: &Path) -> GlobalResult<String> {
    std::fs::read_to_string(path) // blocks the tokio thread
        .map_err(|e| GlobalError::Other(...))
}
```

Called from `build_system_prompt()` (async, line 163).

## Impact

Reading a 5MB image file blocks the tokio worker thread for 10-50ms. On a server handling concurrent requests, one slow disk read cascades into p99 latency spikes for unrelated tasks. With multiple images per request, the problem compounds.

## Fix

- Converted `encode_image_data_url` and `build_vision_message` to `async fn`
- Replaced `std::fs::read` with `tokio::fs::read`
- Replaced `std::fs::read_to_string` with `tokio::fs::read_to_string`
- Updated all 3 call sites of `build_vision_message` and the `load_file` call site to `.await`

## Files Changed

| File | Change |
|------|--------|
| `crates/mofa-foundation/src/llm/agent_loop.rs` | `build_vision_message` + `encode_image_data_url` -> async, use `tokio::fs::read` |
| `crates/mofa-foundation/src/llm/context.rs` | `load_file` -> async, use `tokio::fs::read_to_string` |

## Test plan

- [x] `cargo check` — clean compilation
- [x] `cargo test -p mofa-foundation` — all tests pass
- [x] No new clippy warnings
