### PR TITLE
fix: clean up empty index entries on agent unregister

### DIFF
--- a/crates/mofa-runtime/src/agent/registry.rs
+++ b/crates/mofa-runtime/src/agent/registry.rs
@@ -89,12 +89,14 @@ impl CapabilityIndex {
     /// 移除索引
     /// Remove Index
     fn unindex(&mut self, agent_id: &str) {
-        for ids in self.by_tag.values_mut() {
+        self.by_tag.retain(|_, ids| {
             ids.retain(|id| id != agent_id);
-        }
-        for ids in self.by_strategy.values_mut() {
+            !ids.is_empty()
+        });
+        self.by_strategy.retain(|_, ids| {
             ids.retain(|id| id != agent_id);
-        }
+            !ids.is_empty()
+        });
     }
 
     /// 按标签查找


### PR DESCRIPTION
# fix: clean up empty index entries on agent unregister

## Summary

`CapabilityIndex::unindex()` removes agent IDs from the `by_tag` and `by_strategy` index maps but never removes entries whose `Vec` becomes empty. In long-running systems with frequent register/unregister cycles, this causes unbounded growth of empty `Vec` allocations.

## Problem

```rust
fn unindex(&mut self, agent_id: &str) {
    for ids in self.by_tag.values_mut() {
        ids.retain(|id| id != agent_id);
        // empty Vecs are left in the HashMap forever
    }
    for ids in self.by_strategy.values_mut() {
        ids.retain(|id| id != agent_id);
        // same problem
    }
}
```

Each empty `Vec<String>` holds 24 bytes (pointer + length + capacity). A supervisor agent that registers/unregisters sub-agents with unique tags 100 times/day accumulates 36,500 dead entries per year — wasting memory and slowing iteration over the index maps.

## Fix

Use `HashMap::retain()` to atomically remove the agent ID and drop entries that become empty, all in a single pass:

```rust
fn unindex(&mut self, agent_id: &str) {
    self.by_tag.retain(|_, ids| {
        ids.retain(|id| id != agent_id);
        !ids.is_empty()
    });
    self.by_strategy.retain(|_, ids| {
        ids.retain(|id| id != agent_id);
        !ids.is_empty()
    });
}
```

## Files Changed

| File | Change |
|------|--------|
| `crates/mofa-runtime/src/agent/registry.rs` | `unindex()` now removes empty entries |

## Test plan

- [x] `cargo check -p mofa-runtime` — clean compilation
- [x] `cargo test -p mofa-runtime -- registry` — all 5 registry tests pass
- [x] No new clippy warnings
