### PR TITLE
fix(react): release tools RwLock before async tool execution

### DIFF
--- a/crates/mofa-foundation/src/react/core.rs
+++ b/crates/mofa-foundation/src/react/core.rs
@@ -689,25 +689,32 @@ Rules:
         let span = tracing::info_span!("react.tool_call", tool = %tool_name);
         let timeout_dur = self.config.tool_timeout;
 
-        async {
+        // Clone the Arc while holding the read lock, then release the lock
+        // before the potentially long-running tool.execute() call. Holding
+        // a tokio RwLock read guard across an .await blocks all concurrent
+        // write operations (e.g. register_tool) for the full tool duration.
+        let maybe_tool: Option<Arc<dyn ReActTool>> = {
             let tools = self.tools.read().await;
+            tools.get(tool_name).cloned()
+        }; // read guard dropped here, before any .await
 
-            match tools.get(tool_name) {
+        async {
+            match maybe_tool {
                 Some(tool) => {
                     match tokio::time::timeout(timeout_dur, tool.execute(input)).await {
                         Ok(Ok(result)) => result,
                         Ok(Err(e)) => format!("Tool error: {}", e),
-                        Err(_) => format!(
-                            "Tool '{}' timed out after {:?}",
-                            tool_name, timeout_dur
-                        ),
+                        Err(_) => format!("Tool '{}' timed out after {:?}", tool_name, timeout_dur),
                     }
                 }
-                None => format!(
-                    "Tool '{}' not found. Available tools: {:?}",
-                    tool_name,
-                    tools.keys().collect::<Vec<_>>()
-                ),
+                None => {
+                    let tools = self.tools.read().await;
+                    format!(
+                        "Tool '{}' not found. Available tools: {:?}",
+                        tool_name,
+                        tools.keys().collect::<Vec<_>>()
+                    )
+                }
             }
         }
         .instrument(span)


### PR DESCRIPTION
# Summary

This PR fixes a locking issue in **`ReActAgent::execute_tool`** inside:

```
crates/mofa-foundation/src/react/core.rs
```

Previously, the code held a **`tokio::RwLock` read guard** while awaiting the async call `tool.execute(input).await`.

Because tool execution can take several seconds (up to the configured timeout), the read lock could stay active for a long time. This prevents any writer (such as `register_tool`) from acquiring the lock.

As a result, tool registration and other operations that need the write lock could be delayed significantly under load.

---

# Fix

The fix is simple:

Clone the `Arc` of the tool while holding the read lock, then drop the lock **before awaiting the tool execution**.

This reduces the lock scope to only the lookup operation.

Example:

```rust
let maybe_tool = {
    let tools = self.tools.read().await;
    tools.get(tool_name).cloned()
}; // read lock released here
```

The async execution then runs **without holding the lock**.

---

## VERIFICATION

1. Run the agent with tools executing concurrently.
2. Try registering a new tool while another tool is still running.
**Before the fix**
* `register_tool` waits until the running tool finishes.
**After the fix**
* `register_tool` returns immediately even while tools are executing.


