### PR TITLE
ci: disable scheduled issue triage on forks

### DIFF
--- a/.github/workflows/scheduled-issue-triage.yml
+++ b/.github/workflows/scheduled-issue-triage.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   triage:
+    if: github.repository == 'mofa-org/mofa'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
The MoFA Scheduled Issue Triage workflow (`.github/workflows/scheduled-issue-triage.yml`) fails on forks because GitHub disables Issues on forks by default, causing the `gh issue list` command in the "Find issues needing triage" step to fail and notify the fork's owner.

This PR adds a condition to the `triage` job so that it only runs on the upstream `mofa-org/mofa` repository.

## Changes
- Added `if: github.repository == 'mofa-org/mofa'` to the `triage` job.

## Motivation
Prevents unnecessary workflow failures and notification spam for users who fork the project.