### PR TITLE
feat(runtime): add panic containment at workflow node execution boundary

### DIFF
--- a/crates/mofa-foundation/src/llm/agent_workflow.rs
+++ b/crates/mofa-foundation/src/llm/agent_workflow.rs
@@ -43,6 +43,7 @@ use super::agent::LLMAgent;
 use super::types::{LLMError, LLMResult};
 use std::collections::HashMap;
 use std::future::Future;
+use std::panic;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -662,7 +663,26 @@ impl AgentWorkflow {
                     .router
                     .as_ref()
                     .ok_or_else(|| LLMError::Other("Router function not set".to_string()))?;
-                let route = router(input.clone()).await;
+                
+                // Panic containment for user-provided router closure
+                let route = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    router(input.clone())
+                }))
+                .map_err(|payload| {
+                    let panic_msg = extract_panic_message(payload);
+                    tracing::error!(
+                        workflow_id = %self.id,
+                        node_id = %node.id,
+                        error = %panic_msg,
+                        "Panic caught in router function"
+                    );
+                    LLMError::Other(format!(
+                        "Router node '{}' panicked: {}",
+                        node.id, panic_msg
+                    ))
+                })?
+                .await;
+                
                 ctx.set_router_decision(&node.id, &route).await;
                 // 路由节点返回原输入，路由决策在 get_next_node 中使用
                 // Router returns original input; decision is used in get_next_node
@@ -681,7 +701,25 @@ impl AgentWorkflow {
                 let outputs = ctx.get_outputs(&node.wait_for).await;
 
                 if let Some(ref join_fn) = node.join_fn {
-                    Ok(join_fn(outputs).await)
+                    // Panic containment for user-provided join closure
+                    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        join_fn(outputs)
+                    }))
+                    .map_err(|payload| {
+                        let panic_msg = extract_panic_message(payload);
+                        tracing::error!(
+                            workflow_id = %self.id,
+                            node_id = %node.id,
+                            error = %panic_msg,
+                            "Panic caught in join function"
+                        );
+                        LLMError::Other(format!(
+                            "Join node '{}' panicked: {}",
+                            node.id, panic_msg
+                        ))
+                    })?
+                    .await;
+                    Ok(result)
                 } else {
                     // 默认聚合：合并所有文本输出
                     // Default aggregation: merge all text outputs
@@ -695,7 +733,27 @@ impl AgentWorkflow {
                     .transform
                     .as_ref()
                     .ok_or_else(|| LLMError::Other("Transform function not set".to_string()))?;
-                Ok(transform(input).await)
+                
+                // Panic containment for user-provided transform closure
+                let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    transform(input)
+                }))
+                .map_err(|payload| {
+                    let panic_msg = extract_panic_message(payload);
+                    tracing::error!(
+                        workflow_id = %self.id,
+                        node_id = %node.id,
+                        error = %panic_msg,
+                        "Panic caught in transform function"
+                    );
+                    LLMError::Other(format!(
+                        "Transform node '{}' panicked: {}",
+                        node.id, panic_msg
+                    ))
+                })?
+                .await;
+                
+                Ok(result)
             }
         }
     }
@@ -725,7 +783,27 @@ impl AgentWorkflow {
                 Some(route) => route,
                 None => {
                     let router = node.router.as_ref()?;
-                    router(output.clone()).await
+                    
+                    // Panic containment for router in get_next_node
+                    // If panic occurs, log error and end workflow gracefully
+                    let router_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        router(output.clone())
+                    }));
+                    
+                    match router_result {
+                        Ok(router_future) => router_future.await,
+                        Err(payload) => {
+                            let panic_msg = extract_panic_message(payload);
+                            tracing::error!(
+                                workflow_id = %self.id,
+                                node_id = %current_id,
+                                error = %panic_msg,
+                                "Panic caught in router function during node selection"
+                            );
+                            // Return None to end workflow gracefully
+                            return None;
+                        }
+                    }
                 }
             };
 
@@ -1038,6 +1116,22 @@ impl AgentWorkflowBuilder {
 }
 
 // ============================================================================
+// Panic Containment Helper Functions
+// ============================================================================
+
+/// Extract panic message from payload
+/// Handles cases: &str, String, and unknown panic payload
+fn extract_panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic payload".to_string()
+    }
+}
+
+// ============================================================================
 // 便捷函数
 // Helper functions
 // ============================================================================
@@ -1245,5 +1339,27 @@ mod tests {
         assert!(workflow.get_node("step1").is_some());
         assert!(workflow.get_node("step2").is_some());
         assert!(workflow.get_node("step3").is_some());
+    }
+
+    // ============================================================================
+    // Panic Containment Tests
+    // ============================================================================
+
+    #[test]
+    fn test_extract_panic_message() {
+        // Test &str panic payload
+        let payload: Box<dyn std::any::Any + Send> = Box::new("test panic message");
+        let msg = extract_panic_message(payload);
+        assert_eq!(msg, "test panic message");
+
+        // Test String panic payload
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("string panic"));
+        let msg = extract_panic_message(payload);
+        assert_eq!(msg, "string panic");
+
+        // Test unknown panic payload
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let msg = extract_panic_message(payload);
+        assert_eq!(msg, "Unknown panic payload");
     }
 }


### PR DESCRIPTION
## 📋 Summary

This PR adds panic containment at the workflow node execution boundary in AgentWorkflow.
User-defined closures (RouterFn, TransformFn, JoinFn) are now executed inside a panic boundary using std::panic::catch_unwind. If a panic occurs inside user logic, it is captured and converted into a structured LLMError instead of crashing the workflow runtime.

This improves the robustness of the workflow engine when executing user-supplied logic or integrations that may panic. The change introduces a minimal containment boundary without modifying the public API or affecting normal execution behavior.

---

## 🔗 Related Issues

Closes #549

Related to AgentWorkflow runtime safety improvements.

---

## 🧠 Context

AgentWorkflow allows users to define custom closures for routing, transformation, and join operations during workflow execution.

Previously, if a user-provided closure panicked, the panic would propagate through the runtime and terminate the entire workflow execution engine. This could lead to loss of execution state, broken telemetry traces, and difficult debugging in production environments.

To improve runtime safety, this change introduces panic containment at the node execution boundary. Panics from user logic are captured using std::panic::catch_unwind and converted into structured errors. This ensures the workflow runtime remains stable even when user-defined logic fails unexpectedly.

The containment is implemented only around the synchronous closure invocation boundary and does not alter async scheduling or runtime behavior.

---

## 🛠️ Changes

Added panic containment around user-provided closures in AgentWorkflow node execution.

Introduced extract_panic_message helper function to safely extract panic payload messages from &str, String, and unknown panic payloads.

Wrapped RouterFn, TransformFn, and JoinFn execution inside std::panic::catch_unwind to prevent runtime crashes.

Added structured error conversion using LLMError::Other with panic message and node identifier.

Added tracing::error logging when a panic is captured for better observability.

Added a unit test validating panic payload extraction logic.

The change is limited to the workflow runtime implementation and does not modify public APIs.

---

## 🧪 How ITested

1. Verified compilation of the crate

cargo check -p mofa-foundation

2. Ran all workflow tests

cargo test -p mofa-foundation -- llm::agent_workflow

3. Ran specific panic helper test

cargo test -p mofa-foundation -- test_extract_panic_message

4. Verified the entire workspace compiles

cargo check --workspace

5. Ran clippy to ensure no new warnings were introduced

cargo clippy -p mofa-foundation

All tests passed successfully and no new warnings were introduced by this change.

---


## Logs 

Example output showing the panic helper test passing:

running 1 test
test llm::agent_workflow::tests::test_extract_panic_message ... ok

test result: ok. 1 passed; 0 failed

---

## ⚠️ Breaking Changes

No breaking changes.

This change introduces a safety boundary but does not modify public APIs or existing execution semantics.

---

## 🧹 Checklist

### Code Quality

Code follows Rust idioms and project conventions
cargo fmt run
cargo clippy passes without new warnings

### Testing

Unit tests added
cargo test passes locally

### Documentation

Code contains inline comments describing the panic containment boundary

### PR Hygiene

PR is focused on a single feature (panic containment)
Branch is rebased on latest main
No unrelated commits
Commit message explains the motivation and purpose of the change

---

🚀 Deployment Notes

No deployment changes required.
This is a runtime safety improvement within the library implementation.

---

## 🧩 Additional Notes for Reviewers

The panic containment boundary is intentionally implemented only around the synchronous closure invocation. Panics occurring during async await execution cannot be captured by catch_unwind at this boundary and are outside the scope of this change.

The implementation ensures that panics from user-provided RouterFn, TransformFn, and JoinFn closures do not terminate the workflow runtime. Instead, they are converted into structured errors and logged via tracing for observability.

The non-panic execution path has negligible overhead because catch_unwind introduces minimal cost when no panic occurs.