### PR TITLE
fix: fixed hot-reload error propagation and added reload manager regression tests

### DIFF
--- a/crates/mofa-plugins/src/hot_reload/manager.rs
+++ b/crates/mofa-plugins/src/hot_reload/manager.rs
@@ -395,7 +395,7 @@ impl HotReloadManager {
                                 // Queue reload based on strategy
                                 match config.base.strategy {
                                     ReloadStrategy::Immediate => {
-                                        Self::handle_reload(
+                                        if let Err(e) = Self::handle_reload(
                                             &watch_event.path,
                                             &loader,
                                             &registry,
@@ -404,7 +404,9 @@ impl HotReloadManager {
                                             &event_tx,
                                             &config,
                                             plugin_context.as_ref(),
-                                        ).await;
+                                        ).await {
+                                            warn!("Failed to reload plugin {:?}: {}", watch_event.path, e);
+                                        }
                                     }
                                     ReloadStrategy::Debounced(duration) => {
                                         pending_reloads.insert(
@@ -479,7 +481,7 @@ impl HotReloadManager {
 
                         for path in ready {
                             pending_reloads.remove(&path);
-                            Self::handle_reload(
+                            if let Err(e) = Self::handle_reload(
                                 &path,
                                 &loader,
                                 &registry,
@@ -488,7 +490,9 @@ impl HotReloadManager {
                                 &event_tx,
                                 &config,
                                 plugin_context.as_ref(),
-                            ).await;
+                            ).await {
+                                warn!("Failed to reload plugin {:?}: {}", path, e);
+                            }
                         }
                     }
 
@@ -601,7 +605,7 @@ impl HotReloadManager {
         event_tx: &broadcast::Sender<ReloadEvent>,
         config: &HotReloadConfig,
         context: Option<&PluginContext>,
-    ) {
+    ) -> Result<(), ReloadError> {
         let start = std::time::Instant::now();
 
         // Find the plugin
@@ -614,8 +618,9 @@ impl HotReloadManager {
                         .await
                 {
                     warn!("Failed to load plugin: {}", e);
+                    return Err(e);
                 }
-                return;
+                return Ok(());
             }
         };
 
@@ -687,7 +692,7 @@ impl HotReloadManager {
                     });
                 }
 
-                return;
+                return Err(ReloadError::LoadError(e));
             }
         };
 
@@ -704,7 +709,7 @@ impl HotReloadManager {
                     attempt: 1,
                 });
 
-                return;
+                return Err(ReloadError::LoadError(e));
             }
         };
 
@@ -712,15 +717,15 @@ impl HotReloadManager {
         if let Some(ctx) = context {
             if let Err(e) = dynamic_plugin.plugin_mut().load(ctx).await {
                 error!("Failed to load plugin: {}", e);
-                return;
+                return Err(ReloadError::InitError(e.to_string()));
             }
             if let Err(e) = dynamic_plugin.plugin_mut().init_plugin().await {
                 error!("Failed to initialize plugin: {}", e);
-                return;
+                return Err(ReloadError::InitError(e.to_string()));
             }
             if let Err(e) = dynamic_plugin.plugin_mut().start().await {
                 error!("Failed to start plugin: {}", e);
-                return;
+                return Err(ReloadError::InitError(e.to_string()));
             }
         }
 
@@ -764,6 +769,8 @@ impl HotReloadManager {
             success: true,
             duration,
         });
+
+        Ok(())
     }
 
     /// Load a plugin from path
@@ -859,7 +866,7 @@ impl HotReloadManager {
             &self.config,
             self.plugin_context.as_ref(),
         )
-        .await;
+        .await?;
 
         Ok(ReloadResult {
             plugin_id: plugin_id.to_string(),

--- a/crates/mofa-plugins/tests/hot_reload_manager_tests.rs
+++ b/crates/mofa-plugins/tests/hot_reload_manager_tests.rs
@@ -1,0 +1,123 @@
+//! Integration tests for hot-reload manager.
+//!
+//! Focused on deterministic API-level behavior and fault paths.
+
+use std::time::Duration;
+
+use mofa_plugins::hot_reload::{
+    HotReloadConfig, HotReloadManager, PluginInfo, PluginVersion, ReloadError, ReloadEvent,
+    ReloadStrategy,
+};
+use tempfile::tempdir;
+use tokio::time::timeout;
+
+#[test]
+fn hot_reload_config_builder_applies_fields() {
+    let cfg = HotReloadConfig::new()
+        .with_strategy(ReloadStrategy::Manual)
+        .with_preserve_state(true)
+        .with_auto_rollback(true)
+        .with_max_attempts(7)
+        .with_reload_cooldown(Duration::from_secs(3))
+        .with_shutdown_timeout(Duration::from_secs(9))
+        .with_parallel_reload(true);
+
+    assert!(matches!(cfg.base.strategy, ReloadStrategy::Manual));
+    assert!(cfg.base.preserve_state);
+    assert!(cfg.base.auto_rollback);
+    assert_eq!(cfg.base.max_reload_attempts, 7);
+    assert_eq!(cfg.base.reload_cooldown, Duration::from_secs(3));
+    assert_eq!(cfg.shutdown_timeout, Duration::from_secs(9));
+    assert!(cfg.parallel_reload);
+}
+
+#[tokio::test]
+async fn manager_defaults_to_not_running_and_no_plugins() {
+    let manager = HotReloadManager::default();
+
+    assert!(!manager.is_running().await);
+    assert!(manager.list_plugins().await.is_empty());
+}
+
+#[tokio::test]
+async fn unload_missing_plugin_returns_not_found() {
+    let manager = HotReloadManager::default();
+
+    let err = manager
+        .unload_plugin("missing-plugin")
+        .await
+        .expect_err("missing plugin should fail unload");
+
+    assert!(matches!(err, ReloadError::PluginNotFound(id) if id == "missing-plugin"));
+}
+
+#[tokio::test]
+async fn reload_missing_plugin_returns_not_found() {
+    let manager = HotReloadManager::default();
+
+    let err = manager
+        .reload_plugin("missing-plugin")
+        .await
+        .expect_err("missing plugin should fail reload");
+
+    assert!(matches!(err, ReloadError::PluginNotFound(id) if id == "missing-plugin"));
+}
+
+#[tokio::test]
+async fn reload_registered_missing_library_propagates_load_error_and_emits_event() {
+    let manager = HotReloadManager::default();
+    let mut event_rx = manager.subscribe();
+
+    let tmp = tempdir().expect("create tempdir");
+    let missing_lib = tmp.path().join("missing_test_plugin.dll");
+
+    let info = PluginInfo::new(
+        "missing-lib",
+        "Missing Library Plugin",
+        PluginVersion::new(1, 0, 0),
+    )
+    .with_library_path(&missing_lib);
+    manager
+        .registry()
+        .register(info)
+        .await
+        .expect("register plugin info");
+
+    let err = manager
+        .reload_plugin("missing-lib")
+        .await
+        .expect_err("reload should fail when library file does not exist");
+
+    assert!(matches!(err, ReloadError::LoadError(_)));
+
+    let mut saw_failed = false;
+    for _ in 0..6 {
+        let recv = timeout(Duration::from_millis(300), event_rx.recv()).await;
+        if let Ok(Ok(ReloadEvent::ReloadFailed {
+            plugin_id, path, ..
+        })) = recv
+            && plugin_id == "missing-lib"
+            && path == missing_lib
+        {
+            saw_failed = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_failed,
+        "expected ReloadFailed event for missing registered library"
+    );
+}
+
+#[tokio::test]
+async fn add_watch_path_nonexistent_is_ok() {
+    let manager = HotReloadManager::default();
+    let tmp = tempdir().expect("create tempdir");
+    let nonexistent = tmp.path().join("does_not_exist");
+
+    manager
+        .add_watch_path(&nonexistent)
+        .await
+        .expect("nonexistent watch path should be accepted");
+}


### PR DESCRIPTION
## 📋 Summary

This PR improves error handling in the plugin hot-reload path and adds regression tests for the reload manager.

Previously, reload operations could appear successful even if an internal step failed. This change ensures reload failures are properly returned to the caller and covered by tests.

## 🔗 Related Issues

Closes #1236 

---

## 🧠 Context

The plugin hot-reload manager previously did not propagate errors from internal reload steps. If plugin loading, initialization, or startup failed, the reload path could still return a successful result to the caller.

This made reload failures difficult to detect and left important failure paths untested.

---

## 🛠️ Changes

Updated the reload flow in `manager.rs` so errors from load/init/start steps are returned instead of being silently ignored.

Ensured manual reload calls propagate failures back to the API caller.

Added explicit logging for reload failures triggered by the event loop.

Added regression tests in `hot_reload_manager_tests.rs` covering:

- unloading a missing plugin (`PluginNotFound`)
- reloading a missing plugin (`PluginNotFound`)
- reload attempts with a missing plugin library (`LoadError` and `ReloadFailed event`)
- baseline manager configuration and initialization behavior.

---

## 🧪 How you Tested

```
cargo test -p mofa-plugins --test hot_reload_manager_tests
```
```
cargo test -p mofa-plugins --tests
```

---

## 📸 Screenshots / Logs (if applicable)

<img width="1156" height="336" alt="image" src="https://github.com/user-attachments/assets/3e6c1094-eab1-4895-860b-01440271450a" />

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---
