### PR TITLE
# feat(rag): add BM25 sparse retrieval module

### DIFF
--- a/crates/mofa-foundation/src/rag/mod.rs
+++ b/crates/mofa-foundation/src/rag/mod.rs
@@ -13,6 +13,7 @@ pub mod recursive_chunker;
 pub mod default_reranker;
 pub mod score_reranker;
 pub mod similarity;
+pub mod sparse;
 pub mod streaming_generator;
 pub mod vector_store;
 
@@ -35,6 +36,7 @@ pub use pipeline_adapters::{InMemoryRetriever, SimpleGenerator};
 pub use recursive_chunker::{RecursiveChunker, RecursiveChunkConfig};
 pub use default_reranker::IdentityReranker;
 pub use score_reranker::ScoreReranker;
+pub use sparse::bm25::Bm25Retriever;
 pub use similarity::compute_similarity;
 pub use streaming_generator::PassthroughStreamingGenerator;
 pub use vector_store::InMemoryVectorStore;

--- a/crates/mofa-foundation/src/rag/sparse/bm25.rs
+++ b/crates/mofa-foundation/src/rag/sparse/bm25.rs
@@ -1,0 +1,188 @@
+//! BM25 Retriever implementation
+//!
+//! Provides a Retriever implementation using BM25 sparse retrieval.
+
+use async_trait::async_trait;
+use mofa_kernel::agent::error::AgentResult;
+use mofa_kernel::rag::{Retriever, ScoredDocument};
+
+use super::index::Bm25Index;
+
+/// BM25 Retriever for sparse document retrieval.
+///
+/// This retriever uses the BM25 ranking algorithm to find relevant documents
+/// based on keyword matching.
+#[derive(Clone)]
+pub struct Bm25Retriever {
+    /// The underlying BM25 index
+    index: Bm25Index,
+}
+
+impl Bm25Retriever {
+    /// Create a new BM25 retriever with default parameters.
+    pub fn new() -> Self {
+        Self {
+            index: Bm25Index::new(),
+        }
+    }
+
+    /// Create a new BM25 retriever with custom BM25 parameters.
+    pub fn with_params(k1: f64, b: f64) -> Self {
+        Self {
+            index: Bm25Index::with_params(k1, b),
+        }
+    }
+
+    /// Index documents for retrieval.
+    pub fn index_documents(
+        &mut self,
+        documents: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) {
+        self.index.index_documents(documents);
+    }
+
+    /// Index a single document.
+    pub fn index_document(&mut self, id: impl Into<String>, text: impl Into<String>) {
+        self.index.index_document(id, text);
+    }
+
+    /// Get the number of indexed documents.
+    pub fn num_docs(&self) -> usize {
+        self.index.num_docs()
+    }
+
+    /// Clear all indexed documents.
+    pub fn clear(&mut self) {
+        self.index.clear();
+    }
+
+    /// Retrieve documents matching the query using BM25 scoring.
+    fn retrieve_sync(&self, query: &str, top_k: usize) -> Vec<ScoredDocument> {
+        if self.index.num_docs() == 0 || query.trim().is_empty() {
+            return Vec::new();
+        }
+
+        // Score all documents against the query
+        let mut scored_docs: Vec<ScoredDocument> = self
+            .index
+            .document_ids()
+            .iter()
+            .filter_map(|id| {
+                let score = self.index.score(id, query);
+                let text = self.index.get_document(id)?.clone();
+                Some(ScoredDocument::new(
+                    mofa_kernel::rag::Document::new((*id).clone(), text),
+                    score as f32,
+                    Some("bm25".to_string()),
+                ))
+            })
+            .collect();
+
+        // Sort by score in descending order
+        scored_docs.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Return top_k results
+        scored_docs.truncate(top_k);
+        scored_docs
+    }
+}
+
+impl Default for Bm25Retriever {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Retriever for Bm25Retriever {
+    /// Retrieve the top-k most relevant documents for the given query.
+    async fn retrieve(&self, query: &str, top_k: usize) -> AgentResult<Vec<ScoredDocument>> {
+        // Use the synchronous version directly
+        Ok(self.retrieve_sync(query, top_k))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_retrieve_empty_index() {
+        let retriever = Bm25Retriever::new();
+        let results = retriever.retrieve("query", 5).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_with_documents() {
+        let mut retriever = Bm25Retriever::new();
+        retriever.index_documents(vec![
+            ("doc1", "Rust is a systems programming language"),
+            ("doc2", "Python is great for machine learning"),
+        ]);
+
+        let results = retriever.retrieve("systems programming", 2).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        // doc1 should rank higher for "systems programming"
+        assert_eq!(results[0].document.id, "doc1");
+    }
+
+    #[tokio::test]
+    async fn test_top_k_filtering() {
+        let mut retriever = Bm25Retriever::new();
+        retriever.index_documents(vec![
+            ("doc1", "Rust programming"),
+            ("doc2", "Python programming"),
+            ("doc3", "JavaScript programming"),
+            ("doc4", "Go programming"),
+        ]);
+
+        let results = retriever.retrieve("programming", 2).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_empty_query() {
+        let mut retriever = Bm25Retriever::new();
+        retriever.index_document("doc1", "Some text");
+
+        let results = retriever.retrieve("", 5).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_no_matching_documents() {
+        let mut retriever = Bm25Retriever::new();
+        retriever.index_document("doc1", "Rust programming language");
+
+        let results = retriever
+            .retrieve("python machine learning", 5)
+            .await
+            .unwrap();
+        // Documents are returned with score 0 when no match
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].score, 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_ranking_correctness() {
+        let mut retriever = Bm25Retriever::new();
+        retriever.index_documents(vec![
+            ("doc1", "Rust is a systems programming language"),
+            ("doc2", "Python is great for machine learning"),
+        ]);
+
+        let results = retriever.retrieve("systems programming", 2).await.unwrap();
+
+        // Verify that doc1 ranks higher for this query
+        assert_eq!(results.len(), 2);
+        assert!(results[0].score >= results[1].score);
+        assert_eq!(results[0].document.id, "doc1");
+    }
+}

--- a/crates/mofa-foundation/src/rag/sparse/index.rs
+++ b/crates/mofa-foundation/src/rag/sparse/index.rs
@@ -1,0 +1,301 @@
+//! BM25 Index implementation
+//!
+//! Provides an in-memory BM25 index for sparse document retrieval.
+
+use std::collections::{HashMap, HashSet};
+
+/// BM25 index for sparse retrieval.
+///
+/// Uses the BM25 ranking function to score documents against queries.
+///
+/// BM25 formula:
+/// score = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl)))
+///
+/// Parameters:
+/// - k1: term frequency saturation parameter (default: 1.5)
+/// - b: document length normalization parameter (default: 0.75)
+#[derive(Debug, Clone)]
+pub struct Bm25Index {
+    /// Document storage: id -> text
+    documents: HashMap<String, String>,
+    /// Term frequency per document: doc_id -> {term -> frequency}
+    term_freqs: HashMap<String, HashMap<String, usize>>,
+    /// Document lengths
+    doc_lengths: HashMap<String, usize>,
+    /// Average document length
+    avg_doc_length: f64,
+    /// Number of documents
+    num_docs: usize,
+    /// IDF scores: term -> idf
+    idf: HashMap<String, f64>,
+    /// BM25 parameter k1
+    k1: f64,
+    /// BM25 parameter b
+    b: f64,
+    /// Stop words to ignore
+    stop_words: HashSet<String>,
+}
+
+impl Bm25Index {
+    /// Create a new BM25 index with default parameters.
+    pub fn new() -> Self {
+        Self {
+            documents: HashMap::new(),
+            term_freqs: HashMap::new(),
+            doc_lengths: HashMap::new(),
+            avg_doc_length: 0.0,
+            num_docs: 0,
+            idf: HashMap::new(),
+            k1: 1.5,
+            b: 0.75,
+            stop_words: default_stop_words(),
+        }
+    }
+
+    /// Create a new BM25 index with custom parameters.
+    pub fn with_params(k1: f64, b: f64) -> Self {
+        Self {
+            documents: HashMap::new(),
+            term_freqs: HashMap::new(),
+            doc_lengths: HashMap::new(),
+            avg_doc_length: 0.0,
+            num_docs: 0,
+            idf: HashMap::new(),
+            k1,
+            b,
+            stop_words: default_stop_words(),
+        }
+    }
+
+    /// Index a single document.
+    pub fn index_document(&mut self, id: impl Into<String>, text: impl Into<String>) {
+        let id = id.into();
+        let text = text.into();
+
+        // Tokenize the document
+        let tokens = self.tokenize(&text);
+        let doc_length = tokens.len();
+
+        // Calculate term frequencies
+        let mut term_freq: HashMap<String, usize> = HashMap::new();
+        for token in &tokens {
+            *term_freq.entry(token.clone()).or_insert(0) += 1;
+        }
+
+        // Store document and term frequencies
+        self.documents.insert(id.clone(), text);
+        self.term_freqs.insert(id.clone(), term_freq);
+        self.doc_lengths.insert(id.clone(), doc_length);
+
+        // Update document count and average length
+        self.num_docs += 1;
+        let total_length: usize = self.doc_lengths.values().sum();
+        self.avg_doc_length = total_length as f64 / self.num_docs as f64;
+
+        // Recalculate IDF for all terms
+        self.recalculate_idf();
+    }
+
+    /// Index multiple documents at once.
+    pub fn index_documents(
+        &mut self,
+        documents: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) {
+        for (id, text) in documents {
+            let id = id.into();
+            let text = text.into();
+
+            let tokens = self.tokenize(&text);
+            let doc_length = tokens.len();
+
+            let mut term_freq: HashMap<String, usize> = HashMap::new();
+            for token in &tokens {
+                *term_freq.entry(token.clone()).or_insert(0) += 1;
+            }
+
+            self.documents.insert(id.clone(), text);
+            self.term_freqs.insert(id.clone(), term_freq);
+            self.doc_lengths.insert(id.clone(), doc_length);
+        }
+
+        // Update statistics
+        self.num_docs = self.documents.len();
+        let total_length: usize = self.doc_lengths.values().sum();
+        self.avg_doc_length = if self.num_docs > 0 {
+            total_length as f64 / self.num_docs as f64
+        } else {
+            0.0
+        };
+
+        self.recalculate_idf();
+    }
+
+    /// Tokenize text into terms.
+    fn tokenize(&self, text: &str) -> Vec<String> {
+        text.to_lowercase()
+            .split(|c: char| !c.is_alphanumeric() && c != '\'')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .filter(|s| !self.stop_words.contains(s))
+            .collect()
+    }
+
+    /// Recalculate IDF scores for all terms in the index.
+    fn recalculate_idf(&mut self) {
+        // Collect all unique terms
+        let mut all_terms: HashSet<String> = HashSet::new();
+        for term_freqs in self.term_freqs.values() {
+            for term in term_freqs.keys() {
+                all_terms.insert(term.clone());
+            }
+        }
+
+        // Calculate IDF for each term
+        for term in all_terms {
+            let doc_count = self
+                .term_freqs
+                .values()
+                .filter(|tf| tf.contains_key(&term))
+                .count();
+
+            // IDF formula: log((N - n + 0.5) / (n + 0.5) + 1)
+            // Using a smoothed version to avoid division by zero
+            let idf = if self.num_docs > doc_count {
+                let n = doc_count as f64;
+                let n_docs = self.num_docs as f64;
+                ((n_docs - n + 0.5) / (n + 0.5) + 1.0).ln()
+            } else {
+                0.0
+            };
+
+            self.idf.insert(term, idf);
+        }
+    }
+
+    /// Get the BM25 score for a document against a query.
+    pub fn score(&self, doc_id: &str, query: &str) -> f64 {
+        let query_terms = self.tokenize(query);
+        let term_freqs = match self.term_freqs.get(doc_id) {
+            Some(tf) => tf,
+            None => return 0.0,
+        };
+
+        let doc_length = *self.doc_lengths.get(doc_id).unwrap_or(&1);
+
+        let mut score = 0.0;
+        for term in query_terms {
+            let tf = *term_freqs.get(&term).unwrap_or(&0);
+            let idf = *self.idf.get(&term).unwrap_or(&0.0);
+
+            if tf > 0 {
+                // BM25 scoring formula
+                let numerator = tf as f64 * (self.k1 + 1.0);
+                let denominator = tf as f64
+                    + self.k1
+                        * (1.0 - self.b
+                            + self.b * doc_length as f64 / self.avg_doc_length.max(1.0));
+                score += idf * (numerator / denominator);
+            }
+        }
+
+        score
+    }
+
+    /// Get the number of indexed documents.
+    pub fn num_docs(&self) -> usize {
+        self.num_docs
+    }
+
+    /// Get a document by ID.
+    pub fn get_document(&self, id: &str) -> Option<&String> {
+        self.documents.get(id)
+    }
+
+    /// Get all document IDs.
+    pub fn document_ids(&self) -> Vec<&String> {
+        self.documents.keys().collect()
+    }
+
+    /// Clear all indexed documents.
+    pub fn clear(&mut self) {
+        self.documents.clear();
+        self.term_freqs.clear();
+        self.doc_lengths.clear();
+        self.idf.clear();
+        self.num_docs = 0;
+        self.avg_doc_length = 0.0;
+    }
+}
+
+impl Default for Bm25Index {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Get default English stop words.
+fn default_stop_words() -> HashSet<String> {
+    vec![
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has", "he", "in", "is",
+        "it", "its", "of", "on", "that", "the", "to", "was", "were", "will", "with", "the", "this",
+        "but", "they", "have", "had", "what", "when", "where", "who", "which", "why", "how",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_documents() {
+        let mut index = Bm25Index::new();
+        index.index_documents(vec![
+            ("doc1", "Rust is a systems programming language"),
+            ("doc2", "Python is great for machine learning"),
+        ]);
+
+        assert_eq!(index.num_docs(), 2);
+        assert!(index.get_document("doc1").is_some());
+        assert!(index.get_document("doc2").is_some());
+    }
+
+    #[test]
+    fn test_tokenize() {
+        let index = Bm25Index::new();
+        let tokens = index.tokenize("Hello, World! This is a TEST.");
+
+        assert!(tokens.contains(&"hello".to_string()));
+        assert!(tokens.contains(&"world".to_string()));
+        assert!(tokens.contains(&"test".to_string()));
+        // Stop words should be removed
+        assert!(!tokens.contains(&"is".to_string()));
+    }
+
+    #[test]
+    fn test_bm25_scoring() {
+        let mut index = Bm25Index::new();
+        index.index_documents(vec![
+            ("doc1", "Rust is a systems programming language"),
+            ("doc2", "Python is great for machine learning"),
+        ]);
+
+        // Query for "systems programming" - should match doc1 better
+        let score1 = index.score("doc1", "systems programming");
+        let score2 = index.score("doc2", "systems programming");
+
+        assert!(
+            score1 > score2,
+            "doc1 should score higher for systems programming query"
+        );
+    }
+
+    #[test]
+    fn test_empty_index() {
+        let index = Bm25Index::new();
+        assert_eq!(index.num_docs(), 0);
+        assert!(index.document_ids().is_empty());
+    }
+}

--- a/crates/mofa-foundation/src/rag/sparse/mod.rs
+++ b/crates/mofa-foundation/src/rag/sparse/mod.rs
@@ -1,0 +1,9 @@
+//! Sparse retrieval module
+//!
+//! Provides BM25-based sparse retrieval implementations.
+
+pub mod bm25;
+pub mod index;
+
+pub use bm25::Bm25Retriever;
+pub use index::Bm25Index;

--- a/crates/mofa-foundation/tests/bm25_retrieval.rs
+++ b/crates/mofa-foundation/tests/bm25_retrieval.rs
@@ -1,0 +1,75 @@
+//! BM25 Retrieval Integration Tests
+
+use mofa_foundation::rag::{Bm25Retriever, Retriever};
+
+/// Test indexing documents.
+#[tokio::test]
+async fn test_indexing_documents() {
+    let mut retriever = Bm25Retriever::new();
+
+    retriever.index_documents(vec![
+        ("doc1", "Rust is a systems programming language"),
+        ("doc2", "Python is great for machine learning"),
+    ]);
+
+    assert_eq!(retriever.num_docs(), 2);
+}
+
+/// Test query retrieval.
+#[tokio::test]
+async fn test_query_retrieval() {
+    let mut retriever = Bm25Retriever::new();
+
+    retriever.index_documents(vec![
+        ("doc1", "Rust is a systems programming language"),
+        ("doc2", "Python is great for machine learning"),
+    ]);
+
+    let results = retriever.retrieve("systems programming", 2).await.unwrap();
+
+    assert!(!results.is_empty());
+    assert_eq!(results[0].document.id, "doc1");
+}
+
+/// Test ranking correctness.
+#[tokio::test]
+async fn test_ranking_correctness() {
+    let mut retriever = Bm25Retriever::new();
+
+    retriever.index_documents(vec![
+        (
+            "rust_doc",
+            "Rust is a systems programming language that focuses on performance",
+        ),
+        (
+            "python_doc",
+            "Python is great for machine learning and data science",
+        ),
+        ("web_doc", "JavaScript is a web programming language"),
+    ]);
+
+    // Query for "systems programming" - should rank rust_doc highest
+    let results = retriever.retrieve("systems programming", 3).await.unwrap();
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].document.id, "rust_doc");
+    assert!(results[0].score >= results[1].score);
+}
+
+/// Test top_k filtering.
+#[tokio::test]
+async fn test_top_k_filtering() {
+    let mut retriever = Bm25Retriever::new();
+
+    retriever.index_documents(vec![
+        ("doc1", "Rust programming language"),
+        ("doc2", "Python programming language"),
+        ("doc3", "JavaScript programming language"),
+        ("doc4", "Go programming language"),
+        ("doc5", "Java programming language"),
+    ]);
+
+    let results = retriever.retrieve("programming language", 2).await.unwrap();
+
+    assert_eq!(results.len(), 2);
+}


### PR DESCRIPTION
This PR introduces a **BM25-based sparse retrieval module** for the MoFA RAG pipeline.

It adds **deterministic keyword-based document retrieval**, complementing the existing **dense embedding-based retrieval** used in MoFA and enabling future **hybrid retrieval (dense + sparse)**.

Relates to #305

---

# Summary

This PR introduces a **BM25 sparse retrieval implementation** for MoFA that:

* enables **exact keyword search**
* complements existing **dense vector retrieval**
* lays the groundwork for **hybrid RAG retrieval**

The implementation is lightweight, modular, and fully compatible with the existing **MoFA retriever interface**.

---

# Overview

BM25 (Best Matching 25) is a widely used probabilistic ranking algorithm in information retrieval systems. It ranks documents using:

* **Term Frequency (TF)** — how often a term appears in a document
* **Inverse Document Frequency (IDF)** — how rare the term is across the corpus
* **Document Length Normalization**

Integrating BM25 allows MoFA's RAG pipeline to support **exact keyword matching** alongside semantic vector search.

---

# Motivation

The current MoFA RAG implementation focuses primarily on **dense vector retrieval** via embeddings.

While powerful for semantic similarity, dense retrieval can miss:

* exact keyword matches
* rare domain-specific terminology
* identifiers, code symbols, or uncommon tokens

Sparse retrieval methods like BM25 provide complementary strengths:

* ✅ **No embedding generation required**
* ✅ **Deterministic keyword matching**
* ✅ **Interpretable scoring based on term statistics**
* ✅ **Lower computational overhead for large corpora**
* ✅ **Strong foundation for hybrid dense + sparse retrieval**

---

# Architecture

This implementation follows the **MoFA microkernel architecture**:

```
┌───────────────────────────────────────────┐
│              mofa-kernel                  │
│  - Retriever trait (already exists)       │
└───────────────────────────────────────────┘
                    ↓
┌───────────────────────────────────────────┐
│            mofa-foundation                │
│  - Bm25Index                              │
│  - Bm25Retriever                          │
└───────────────────────────────────────────┘
```

## Core Components

### `Bm25Index`

Responsible for:

* document indexing
* tokenization
* term frequency tracking
* document length statistics
* IDF computation
* BM25 score calculation

The index is currently **in-memory**.

---

### `Bm25Retriever`

Implements the existing `Retriever` trait:

```rust
async fn retrieve(
    &self,
    query: &str,
    top_k: usize
) -> AgentResult<Vec<ScoredDocument>>
```

This allows BM25 retrieval to **plug directly into the existing MoFA RAG pipeline**.

---

# BM25 Scoring Formula

The implementation uses the standard BM25 ranking function:

```
score = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl)))
```

Where:

| Parameter | Description                    |
| --------- | ------------------------------ |
| tf        | term frequency in the document |
| dl        | document length                |
| avgdl     | average document length        |
| idf       | inverse document frequency     |

Default parameters:

```
k1 = 1.5
b  = 0.75
```

---

# Module Structure

```
crates/mofa-foundation/src/rag/sparse/
├── mod.rs
├── index.rs
└── bm25.rs
```

### Responsibilities

**index.rs**

* BM25 indexing
* IDF computation
* scoring logic

**bm25.rs**

* `Bm25Retriever`
* `Retriever` trait implementation
* async retrieval API

---

# Tokenization

Current implementation uses **simple normalization**:

* whitespace splitting
* lowercase normalization
* empty token filtering

This keeps the initial implementation lightweight while leaving room for future improvements.

---

# Features

* In-memory BM25 index
* Configurable BM25 parameters
* Async retrieval via `Retriever` trait
* Top-k filtering
* Deterministic keyword matching
* Compatible with existing RAG pipeline

---

# Tests

Unit tests cover:

* document indexing
* tokenization behavior
* BM25 scoring correctness
* retrieval ranking
* top-k filtering
* empty query handling
* empty index handling
* no matching documents

Example output:

```
running 10 tests
10 passed; 0 failed
```

All workspace tests pass:

```
cargo test --workspace
```

---

# Example Usage

```rust
use mofa_foundation::rag::{Bm25Retriever, Retriever};

let mut retriever = Bm25Retriever::new();

retriever.index_documents(vec![
    ("doc1", "Rust is a systems programming language"),
    ("doc2", "Python is great for machine learning"),
    ("doc3", "JavaScript is used for web development"),
]);

let results = retriever
    .retrieve("systems programming", 2)
    .await?;

for doc in results {
    println!("{} {:.3}", doc.document.id, doc.score);
}
```

Results are **sorted by BM25 score (descending)**.

---

# API Additions

New public types:

```
mofa_foundation::rag::Bm25Retriever
mofa_foundation::rag::sparse::Bm25Index
```

Exports added in:

```
mofa_foundation::rag
```

No breaking changes were introduced.

---

# Future Work

This module unlocks several future improvements.

## Hybrid Retrieval

Combine **dense embeddings + BM25** using:

* Reciprocal Rank Fusion (RRF)
* score weighting

## Improved Tokenization

* stemming
* lemmatization
* stop-word removal
* language-aware tokenizers

## Persistent Index

* disk-backed storage
* fast reloads
* incremental updates

## Multi-field Search

Support structured documents (BM25F):

```
title
body
tags
metadata
```

## Query Expansion

* synonym expansion
* pseudo relevance feedback
