### PR TITLE
fix(mofa-foundation): replace 3.14 with 1.5 in WorkflowValue float test

### DIFF
--- a/crates/mofa-foundation/src/workflow/state.rs
+++ b/crates/mofa-foundation/src/workflow/state.rs
@@ -672,7 +672,7 @@ mod tests {
         let v: WorkflowValue = true.into();
         assert_eq!(v.as_bool(), Some(true));
 
-        let v: WorkflowValue = 3.14f64.into();
-        assert_eq!(v.as_f64(), Some(3.14));
+        let v: WorkflowValue = 1.5f64.into();
+        assert_eq!(v.as_f64(), Some(1.5));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1268

The literal `3.14f64` in `test_workflow_value_conversions` approximates π and triggers the deny-level `clippy::approx_constant` lint, causing both `cargo test -p mofa-foundation` and `cargo clippy --all-targets` to fail with a hard compiler error.

## Changes

Replace `3.14f64` / `3.14` with `1.5f64` / `1.5` — a clean, non-special float that exercises the same `WorkflowValue::Float` round-trip behaviour without triggering the lint.

```diff
- let v: WorkflowValue = 3.14f64.into();
- assert_eq!(v.as_f64(), Some(3.14));
+ let v: WorkflowValue = 1.5f64.into();
+ assert_eq!(v.as_f64(), Some(1.5));
```

## Verification

```bash
cargo clippy -p mofa-foundation --tests   # exit 0, no approx_constant errors
cargo test -p mofa-foundation             # all tests pass
```