### PR TITLE
feat(testing): add declarative scenario runner for agent evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6156,6 +6156,7 @@ dependencies = [
  "mofa-kernel",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,4 +14,5 @@ async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod report;
+pub mod scenario;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
@@ -18,4 +19,5 @@ pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
 };
+pub use scenario::{ScenarioContext, ScenarioExpectations, ScenarioRunner, ScenarioSpec};
 pub use tools::MockTool;

--- a/tests/src/scenario/mod.rs
+++ b/tests/src/scenario/mod.rs
@@ -1,0 +1,12 @@
+//! Declarative scenario runner for end-to-end mock-based agent evaluation.
+
+mod runner;
+mod spec;
+
+pub use runner::{ScenarioContext, ScenarioRunner};
+pub use spec::{
+    BusExpectation, BusScenarioSpec, ClockScenarioSpec, LlmFailureSpec, LlmResponseRule,
+    LlmResponseSequence, LlmScenarioSpec, PromptCountExpectation, ScenarioExpectations,
+    ScenarioSpec, ToolCallExpectation, ToolFailureSpec, ToolInputFailureSpec, ToolResultSpec,
+    ToolScenarioSpec,
+};

--- a/tests/src/scenario/runner.rs
+++ b/tests/src/scenario/runner.rs
@@ -1,0 +1,291 @@
+use crate::backend::MockLLMBackend;
+use crate::bus::MockAgentBus;
+use crate::clock::MockClock;
+use crate::report::{TestCaseResult, TestReport, TestReportBuilder, TestStatus};
+use crate::scenario::spec::{ScenarioSpec, ToolResultSpec};
+use crate::tools::MockTool;
+use mofa_foundation::orchestrator::{
+    ModelOrchestrator, ModelProviderConfig, ModelType, OrchestratorError,
+};
+use mofa_kernel::agent::components::tool::ToolResult;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct ScenarioContext {
+    pub backend: Arc<MockLLMBackend>,
+    pub bus: Arc<MockAgentBus>,
+    pub clock: Arc<MockClock>,
+    pub model_name: String,
+    tools: HashMap<String, MockTool>,
+    tracked_prompts: Arc<RwLock<Vec<String>>>,
+}
+
+impl ScenarioContext {
+    pub async fn infer(&self, prompt: &str) -> Result<String, OrchestratorError> {
+        self.tracked_prompts.write().await.push(prompt.to_string());
+        self.backend.infer(&self.model_name, prompt).await
+    }
+
+    pub fn tool(&self, name: &str) -> Option<MockTool> {
+        self.tools.get(name).cloned()
+    }
+
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+}
+
+pub struct ScenarioRunner {
+    spec: ScenarioSpec,
+}
+
+impl ScenarioRunner {
+    pub fn new(spec: ScenarioSpec) -> Self {
+        Self { spec }
+    }
+
+    pub async fn run<F, Fut>(&self, scenario: F) -> anyhow::Result<TestReport>
+    where
+        F: FnOnce(ScenarioContext) -> Fut,
+        Fut: Future<Output = Result<(), String>>,
+    {
+        let context = self.build_context().await?;
+
+        let mut builder = TestReportBuilder::new(self.spec.suite_name.clone())
+            .with_clock(context.clock.clone())
+            .record("scenario_execution", || async {
+                scenario(context.clone()).await
+            })
+            .await;
+
+        for result in self.evaluate_expectations(&context).await {
+            builder = builder.add_result(result);
+        }
+
+        Ok(builder.build())
+    }
+
+    async fn build_context(&self) -> anyhow::Result<ScenarioContext> {
+        let mut backend = MockLLMBackend::new();
+        let llm_spec = &self.spec.llm;
+        let model_name = llm_spec
+            .model_name
+            .clone()
+            .unwrap_or_else(|| "scenario-model".to_string());
+
+        if let Some(fallback) = &llm_spec.fallback {
+            backend.set_fallback(fallback);
+        }
+
+        for rule in &llm_spec.responses {
+            backend.add_response(&rule.prompt_substring, &rule.response);
+        }
+
+        for sequence in &llm_spec.response_sequences {
+            let responses = sequence.responses.iter().map(String::as_str).collect();
+            backend.add_response_sequence(&sequence.prompt_substring, responses);
+        }
+
+        for failure in &llm_spec.fail_next {
+            backend.fail_next(
+                failure.count,
+                OrchestratorError::InferenceFailed(failure.error.clone()),
+            );
+        }
+
+        for failure in &llm_spec.fail_on {
+            backend.fail_on(
+                &failure.prompt_substring,
+                OrchestratorError::Other(failure.error.clone()),
+            );
+        }
+
+        backend
+            .register_model(make_model_config(&model_name))
+            .await
+            .map_err(anyhow::Error::from)?;
+        backend
+            .load_model(&model_name)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        let clock = Arc::new(match self.spec.clock.start_ms {
+            Some(ms) => MockClock::starting_at(Duration::from_millis(ms)),
+            None => MockClock::new(),
+        });
+        if let Some(step) = self.spec.clock.auto_advance_ms {
+            clock.set_auto_advance(Duration::from_millis(step));
+        }
+
+        let bus = Arc::new(MockAgentBus::new());
+        for failure in &self.spec.bus.fail_next_send {
+            bus.fail_next_send(failure.count, &failure.error).await;
+        }
+
+        let mut tools = HashMap::new();
+        for tool_spec in &self.spec.tools {
+            let tool = MockTool::new(
+                &tool_spec.name,
+                &tool_spec.description,
+                tool_spec.schema.clone(),
+            );
+
+            if let Some(result) = &tool_spec.stubbed_result {
+                tool.set_result(to_tool_result(result)).await;
+            }
+
+            for failure in &tool_spec.fail_next {
+                tool.fail_next(failure.count, &failure.error).await;
+            }
+
+            for failure in &tool_spec.fail_on_input {
+                tool.fail_on_input(failure.input.clone(), &failure.error)
+                    .await;
+            }
+
+            if !tool_spec.result_sequence.is_empty() {
+                let sequence = tool_spec
+                    .result_sequence
+                    .iter()
+                    .map(to_tool_result)
+                    .collect();
+                tool.add_result_sequence(sequence).await;
+            }
+
+            tools.insert(tool_spec.name.clone(), tool);
+        }
+
+        Ok(ScenarioContext {
+            backend: Arc::new(backend),
+            bus,
+            clock,
+            model_name,
+            tools,
+            tracked_prompts: Arc::new(RwLock::new(Vec::new())),
+        })
+    }
+
+    async fn evaluate_expectations(&self, context: &ScenarioContext) -> Vec<TestCaseResult> {
+        let mut results = Vec::new();
+
+        if let Some(expected) = self.spec.expectations.infer_total {
+            let actual = context.backend.call_count();
+            results.push(expectation_result(
+                "expect_infer_total",
+                actual == expected,
+                format!("expected infer_total={expected}, got {actual}"),
+            ));
+        }
+
+        for expectation in &self.spec.expectations.prompt_counts {
+            let actual = {
+                let prompts = context.tracked_prompts.read().await;
+                prompts
+                    .iter()
+                    .filter(|prompt| prompt.contains(&expectation.substring))
+                    .count()
+            };
+            results.push(expectation_result(
+                &format!("expect_prompt_count::{}", expectation.substring),
+                actual == expectation.expected,
+                format!(
+                    "expected prompt substring '{}' count={}, got {}",
+                    expectation.substring, expectation.expected, actual
+                ),
+            ));
+        }
+
+        for expectation in &self.spec.expectations.tool_calls {
+            let result = match context.tool(&expectation.tool_name) {
+                Some(tool) => {
+                    let actual = tool.call_count().await;
+                    expectation_result(
+                        &format!("expect_tool_calls::{}", expectation.tool_name),
+                        actual == expectation.expected,
+                        format!(
+                            "expected tool '{}' calls={}, got {}",
+                            expectation.tool_name, expectation.expected, actual
+                        ),
+                    )
+                }
+                None => expectation_result(
+                    &format!("expect_tool_calls::{}", expectation.tool_name),
+                    false,
+                    format!(
+                        "tool '{}' not found in scenario context",
+                        expectation.tool_name
+                    ),
+                ),
+            };
+            results.push(result);
+        }
+
+        for expectation in &self.spec.expectations.bus_messages_from {
+            let actual = {
+                let messages = context.bus.captured_messages.read().await;
+                messages
+                    .iter()
+                    .filter(|(sender, _, _)| sender == &expectation.sender_id)
+                    .count()
+            };
+            results.push(expectation_result(
+                &format!("expect_bus_messages_from::{}", expectation.sender_id),
+                actual == expectation.expected,
+                format!(
+                    "expected sender '{}' messages={}, got {}",
+                    expectation.sender_id, expectation.expected, actual
+                ),
+            ));
+        }
+
+        results
+    }
+}
+
+fn make_model_config(name: &str) -> ModelProviderConfig {
+    ModelProviderConfig {
+        model_name: name.into(),
+        model_path: "/mock".into(),
+        device: "cpu".into(),
+        model_type: ModelType::Llm,
+        max_context_length: None,
+        quantization: None,
+        extra_config: HashMap::new(),
+    }
+}
+
+fn to_tool_result(spec: &ToolResultSpec) -> ToolResult {
+    let mut result = if let Some(error) = &spec.error {
+        ToolResult::failure(error)
+    } else if let Some(json) = &spec.json {
+        ToolResult::success(json.clone())
+    } else if let Some(text) = &spec.text {
+        ToolResult::success_text(text)
+    } else {
+        ToolResult::success_text("Mock execution default")
+    };
+
+    for (key, value) in &spec.metadata {
+        result.metadata.insert(key.clone(), value.clone());
+    }
+
+    result
+}
+
+fn expectation_result(name: &str, passed: bool, failure_message: String) -> TestCaseResult {
+    TestCaseResult {
+        name: name.to_string(),
+        status: if passed {
+            TestStatus::Passed
+        } else {
+            TestStatus::Failed
+        },
+        duration: Duration::ZERO,
+        error: if passed { None } else { Some(failure_message) },
+        metadata: Vec::new(),
+    }
+}

--- a/tests/src/scenario/spec.rs
+++ b/tests/src/scenario/spec.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScenarioSpec {
+    pub suite_name: String,
+    #[serde(default)]
+    pub clock: ClockScenarioSpec,
+    #[serde(default)]
+    pub llm: LlmScenarioSpec,
+    #[serde(default)]
+    pub bus: BusScenarioSpec,
+    #[serde(default)]
+    pub tools: Vec<ToolScenarioSpec>,
+    #[serde(default)]
+    pub expectations: ScenarioExpectations,
+}
+
+impl ScenarioSpec {
+    pub fn from_yaml_str(input: &str) -> anyhow::Result<Self> {
+        Ok(serde_yaml::from_str(input)?)
+    }
+
+    pub fn from_json_str(input: &str) -> anyhow::Result<Self> {
+        Ok(serde_json::from_str(input)?)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClockScenarioSpec {
+    pub start_ms: Option<u64>,
+    pub auto_advance_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponseRule {
+    pub prompt_substring: String,
+    pub response: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponseSequence {
+    pub prompt_substring: String,
+    pub responses: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmFailureSpec {
+    pub prompt_substring: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LlmScenarioSpec {
+    pub model_name: Option<String>,
+    pub fallback: Option<String>,
+    #[serde(default)]
+    pub responses: Vec<LlmResponseRule>,
+    #[serde(default)]
+    pub response_sequences: Vec<LlmResponseSequence>,
+    #[serde(default)]
+    pub fail_next: Vec<ToolFailureSpec>,
+    #[serde(default)]
+    pub fail_on: Vec<LlmFailureSpec>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BusScenarioSpec {
+    #[serde(default)]
+    pub fail_next_send: Vec<ToolFailureSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultSpec {
+    pub text: Option<String>,
+    pub json: Option<Value>,
+    pub error: Option<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFailureSpec {
+    pub count: usize,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallExpectation {
+    pub tool_name: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptCountExpectation {
+    pub substring: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BusExpectation {
+    pub sender_id: String,
+    pub expected: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolScenarioSpec {
+    pub name: String,
+    pub description: String,
+    pub schema: Value,
+    pub stubbed_result: Option<ToolResultSpec>,
+    #[serde(default)]
+    pub fail_next: Vec<ToolFailureSpec>,
+    #[serde(default)]
+    pub fail_on_input: Vec<ToolInputFailureSpec>,
+    #[serde(default)]
+    pub result_sequence: Vec<ToolResultSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInputFailureSpec {
+    pub input: Value,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScenarioExpectations {
+    pub infer_total: Option<usize>,
+    #[serde(default)]
+    pub prompt_counts: Vec<PromptCountExpectation>,
+    #[serde(default)]
+    pub tool_calls: Vec<ToolCallExpectation>,
+    #[serde(default)]
+    pub bus_messages_from: Vec<BusExpectation>,
+}

--- a/tests/tests/scenario_runner_tests.rs
+++ b/tests/tests/scenario_runner_tests.rs
@@ -1,0 +1,185 @@
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_kernel::agent::components::tool::ToolInput;
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::{ScenarioRunner, ScenarioSpec, TestStatus};
+use serde_json::json;
+
+#[test]
+fn scenario_spec_parses_from_yaml() {
+    let input = r#"
+suite_name: yaml-scenario
+clock:
+  start_ms: 42000
+llm:
+  model_name: test-model
+  responses:
+    - prompt_substring: summarize
+      response: compact summary
+tools:
+  - name: search
+    description: Search docs
+    schema:
+      type: object
+    stubbed_result:
+      text: Found it
+expectations:
+  infer_total: 1
+"#;
+
+    let spec = ScenarioSpec::from_yaml_str(input).unwrap();
+    assert_eq!(spec.suite_name, "yaml-scenario");
+    assert_eq!(spec.clock.start_ms, Some(42_000));
+    assert_eq!(spec.llm.model_name.as_deref(), Some("test-model"));
+    assert_eq!(spec.tools.len(), 1);
+    assert_eq!(spec.expectations.infer_total, Some(1));
+}
+
+#[test]
+fn scenario_spec_parses_from_json() {
+    let input = r#"
+{
+  "suite_name": "json-scenario",
+  "llm": {
+    "responses": [
+      { "prompt_substring": "translate", "response": "bonjour" }
+    ]
+  }
+}
+"#;
+
+    let spec = ScenarioSpec::from_json_str(input).unwrap();
+    assert_eq!(spec.suite_name, "json-scenario");
+    assert_eq!(spec.llm.responses.len(), 1);
+    assert_eq!(spec.llm.responses[0].response, "bonjour");
+}
+
+#[tokio::test]
+async fn scenario_runner_configures_fixtures_and_expectations() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: end-to-end-scenario
+clock:
+  start_ms: 2500
+llm:
+  model_name: scenario-model
+  responses:
+    - prompt_substring: summarize
+      response: "Short summary"
+tools:
+  - name: search
+    description: Search docs
+    schema:
+      type: object
+    stubbed_result:
+      text: "Found result"
+expectations:
+  infer_total: 1
+  prompt_counts:
+    - substring: summarize
+      expected: 1
+  tool_calls:
+    - tool_name: search
+      expected: 1
+  bus_messages_from:
+    - sender_id: evaluator
+      expected: 1
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            let response = ctx.infer("summarize this").await.unwrap();
+            assert_eq!(response, "Short summary");
+
+            let tool = ctx.tool("search").unwrap();
+            let result = tool
+                .execute(ToolInput::from_json(json!({"query": "rust"})))
+                .await;
+            assert!(result.success);
+
+            let message = AgentMessage::TaskRequest {
+                task_id: "t1".into(),
+                content: "done".into(),
+            };
+            let _ = ctx
+                .bus
+                .send_and_capture("evaluator", CommunicationMode::Broadcast, message)
+                .await;
+
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.timestamp, 2500);
+    assert_eq!(report.total(), 5);
+    assert_eq!(report.failed(), 0);
+    assert_eq!(report.passed(), 5);
+}
+
+#[tokio::test]
+async fn scenario_runner_records_failed_expectations() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: failing-expectation-scenario
+llm:
+  responses:
+    - prompt_substring: summarize
+      response: "Short summary"
+expectations:
+  infer_total: 2
+  prompt_counts:
+    - substring: summarize
+      expected: 2
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            let _ = ctx.infer("summarize this").await.unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.total(), 3);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 2);
+    assert_eq!(report.results[1].status, TestStatus::Failed);
+    assert_eq!(report.results[2].status, TestStatus::Failed);
+}
+
+#[tokio::test]
+async fn scenario_runner_applies_fail_next_and_reports_execution_failure() {
+    let spec = ScenarioSpec::from_yaml_str(
+        r#"
+suite_name: fail-next-scenario
+llm:
+  fail_next:
+    - count: 1
+      error: "boom"
+expectations:
+  infer_total: 1
+"#,
+    )
+    .unwrap();
+
+    let report = ScenarioRunner::new(spec)
+        .run(|ctx| async move {
+            ctx.infer("anything")
+                .await
+                .map(|_| ())
+                .map_err(|err| err.to_string())
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(report.total(), 2);
+    assert_eq!(report.failed(), 1);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.results[0].status, TestStatus::Failed);
+    assert_eq!(report.results[1].status, TestStatus::Passed);
+}


### PR DESCRIPTION
## Summary
closes #1279 

Add a declarative `ScenarioRunner` to `mofa-testing` that loads YAML/JSON scenario specs, configures the existing mocks automatically, runs an async scenario body, and validates structured expectations into a `TestReport`.

## Builds On  my previous prs

- #486 - core `mofa-testing` mocks and framework
- #888 - failure injection, response sequencing, and `MockClock`
- #895 - test report generation and formatting

## What This Adds

- `ScenarioSpec::from_yaml_str` and `ScenarioSpec::from_json_str`
- a new `scenario` module in `mofa-testing`
- `ScenarioContext` for configured mock backend, bus, clock, and tool access
- expectation evaluation for:
  - total infer calls
  - prompt substring counts
  - tool call counts
  - bus messages by sender
- end-to-end tests for parsing, successful execution, expectation failures, and injected execution failures

## Why This Matters

`mofa-testing` already provides strong low-level primitives. This PR adds a higher-level declarative layer that makes end-to-end agent evaluation reproducible and easier to adopt across contributors. It is a direct step toward a real testing and evaluation platform for MoFA agents.

## How I Tested

- `cargo test -p mofa-testing --test scenario_runner_tests`
- `cargo test -p mofa-testing --test integration`
