### PR TITLE
feat(foundation): add MCP HTTP transport support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-eventsource",
  "secrecy 0.10.3",
  "serde",
@@ -3056,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5aafcc0b21e8747d73b8b60e9cda202c7072eadc0a16f38fe9f45cc115b7ec"
 dependencies = [
  "eyre",
- "reqwest",
+ "reqwest 0.12.28",
  "tokio",
  "tracing",
 ]
@@ -4363,7 +4363,7 @@ dependencies = [
  "native-tls",
  "num_cpus",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5809,7 +5809,7 @@ dependencies = [
  "nix 0.29.0",
  "predicates",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5877,6 +5877,7 @@ dependencies = [
  "config",
  "criterion",
  "cron",
+ "dashmap 5.5.3",
  "error-stack",
  "futures",
  "hex",
@@ -5896,7 +5897,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rhai",
  "rmcp",
  "serde",
@@ -5972,7 +5973,7 @@ dependencies = [
  "futures",
  "hex",
  "mofa-kernel",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "socketioxide",
@@ -6044,7 +6045,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "rust-embed",
  "serde",
  "serde_json",
@@ -6080,7 +6081,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rhai",
  "rodio",
  "serde",
@@ -6763,7 +6764,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -6780,7 +6781,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -7668,7 +7669,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "prost-types",
- "reqwest",
+ "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
@@ -8184,9 +8185,43 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -8201,7 +8236,7 @@ dependencies = [
  "mime",
  "nom 7.1.3",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
 ]
 
@@ -8286,13 +8321,16 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
+ "http 1.4.0",
  "pastey",
  "pin-project-lite",
  "process-wrap 9.0.3",
+ "reqwest 0.13.2",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -9536,6 +9574,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -11347,6 +11398,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -96,6 +96,7 @@ rmcp = { version = "0.16", features = [
     "client",
     "transport-child-process",
     "transport-io",
+    "transport-streamable-http-client-reqwest",
 ], optional = true }
 
 # Datetime support for persistence

--- a/crates/mofa-foundation/src/agent/tools/mcp/client.rs
+++ b/crates/mofa-foundation/src/agent/tools/mcp/client.rs
@@ -12,7 +12,7 @@ use mofa_kernel::agent::error::{AgentError, AgentResult};
 use rmcp::ServiceExt;
 use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
 use rmcp::service::{RoleClient, RunningService};
-use rmcp::transport::TokioChildProcess;
+use rmcp::transport::{StreamableHttpClientTransport, TokioChildProcess};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::process::Command;
@@ -154,13 +154,29 @@ impl McpClient for McpClientManager {
                     ))
                 })?
             }
-            McpTransportConfig::Http { url: _ } => {
-                // HTTP/SSE transport requires the `transport-streamable-http-client-reqwest` feature
-                // which is not included by default. For now, return an error.
-                // HTTP/SSE 传输需要 `transport-streamable-http-client-reqwest` 特性，目前尚未默认包含。
-                return Err(AgentError::ConfigError(
-                    "HTTP transport is not yet supported. Use Stdio transport instead.".to_string(),
-                ));
+            McpTransportConfig::Http { url } => {
+                let transport = StreamableHttpClientTransport::from_uri(url.clone());
+
+                let client_info = ClientInfo {
+                    meta: None,
+                    protocol_version: Default::default(),
+                    capabilities: ClientCapabilities::default(),
+                    client_info: Implementation {
+                        name: "mofa-agent".to_string(),
+                        version: "0.1.0".to_string(),
+                        title: None,
+                        description: None,
+                        icons: None,
+                        website_url: None,
+                    },
+                };
+
+                client_info.serve(transport).await.map_err(|e| {
+                    AgentError::InitializationFailed(format!(
+                        "Failed to initialize MCP session with '{}': {}",
+                        server_name, e
+                    ))
+                })?
             }
             _ => {
                 return Err(AgentError::ConfigError(format!(
@@ -236,11 +252,7 @@ impl McpClient for McpClientManager {
 
         let params = CallToolRequestParams {
             name: tool_name.to_string().into(),
-            arguments: Some(
-                arguments
-                    .as_object().cloned()
-                    .unwrap_or_default(),
-            ),
+            arguments: Some(arguments.as_object().cloned().unwrap_or_default()),
             meta: None,
             task: None,
         };
@@ -359,10 +371,15 @@ mod tests {
         let config = McpServerConfig::stdio("test", "nonexistent-command-xyz", vec![]);
         let _ = manager.connect(config).await; // This will fail - that's okay
 
-        // Test HTTP transport error
-        // 测试 HTTP 传输错误
+        // Test HTTP transport path reaches connection initialization.
+        // We expect a connection failure here because no MCP server is running.
+        // 测试 HTTP 传输路径可达连接初始化（本地无 MCP 服务时应连接失败）
         let http_config = McpServerConfig::http("http-test", "http://localhost:9999");
         let result = manager.connect(http_config).await;
-        assert!(result.is_err()); // HTTP not yet supported
+        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(AgentError::InitializationFailed(_))),
+            "expected initialization failure for unreachable HTTP endpoint"
+        );
     }
 }


### PR DESCRIPTION
## Summary
  Add HTTP/SSE MCP transport support to `McpClientManager` so `McpTransportConfig::Http` can be used for remote MCP servers.

  ## Motivation
  Kernel-level MCP transport config already exposes an HTTP variant, but foundation client logic rejected it at runtime. This blocks real remote MCP integration use cases.

  ## Changes
  - Enabled rmcp feature `transport-streamable-http-client-reqwest` in `mofa-foundation`.
  - Implemented `McpTransportConfig::Http` connect path using `StreamableHttpClientTransport::from_uri(...)`.
  - Reused existing `ClientInfo` + `serve(...)` flow for HTTP session initialization.
  - Updated MCP unit test to validate HTTP path behavior (expects initialization failure for unreachable endpoint, instead of “unsupported transport”).

  ## Related Issues
  Resolves #1304 

  ## Testing
  - `cargo test -p mofa-foundation --features mcp agent::tools::mcp::client::tests::test_connect_duplicate -- --nocapture`
  - `cargo build -p mofa-foundation --features mcp`

  ## Checklist
  - [x] `cargo fmt --check` passes
  - [x] `cargo clippy --workspace --all-features -- -D errors` passes
  - [x] `cargo test --workspace --all-features` passes
  - [x] `cargo build --examples` succeeds
  - [x] `cargo doc --workspace --no-deps --all-features` succeeds
  - [x] Architecture layer rules respected (see CONTRIBUTING.md)
  - [x] Relevant documentation updated