### PR TITLE
fix(cli): prevent tar path traversal in plugin install

### DIFF
--- a/crates/mofa-cli/src/commands/plugin/install.rs
+++ b/crates/mofa-cli/src/commands/plugin/install.rs
@@ -427,9 +427,34 @@ fn extract_tar_gz(bytes: &[u8], dest_dir: &Path) -> Result<(), CliError> {
     let gz = GzDecoder::new(bytes);
     let mut archive = Archive::new(gz);
 
-    archive
-        .unpack(dest_dir)
-        .map_err(|e| CliError::PluginError(format!("Failed to extract tar.gz archive: {}", e)))?;
+    let entries = archive
+        .entries()
+        .map_err(|e| CliError::PluginError(format!("Failed to read tar.gz entries: {}", e)))?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|e| {
+            CliError::PluginError(format!("Failed to read tar.gz entry metadata: {}", e))
+        })?;
+        let entry_path = entry
+            .path()
+            .ok()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        let unpacked = entry.unpack_in(dest_dir).map_err(|e| {
+            CliError::PluginError(format!(
+                "Failed to extract tar.gz entry '{}': {}",
+                entry_path, e
+            ))
+        })?;
+
+        if !unpacked {
+            return Err(CliError::PluginError(format!(
+                "Unsafe archive entry escapes destination: {}",
+                entry_path
+            )));
+        }
+    }
 
     Ok(())
 }
@@ -705,5 +730,43 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("empty") || err_msg.contains("Plugin directory"));
+    }
+
+    #[test]
+    fn test_extract_tar_gz_rejects_path_traversal() {
+        use flate2::{Compression, write::GzEncoder};
+        use std::io::Write;
+        use tar::{Builder, Header};
+
+        let temp_dir = TempDir::new().unwrap();
+        let dest_dir = temp_dir.path().join("plugin");
+        std::fs::create_dir_all(&dest_dir).unwrap();
+
+        let mut tar_builder = Builder::new(Vec::new());
+        let payload = b"malicious";
+        let mut header = Header::new_gnu();
+        {
+            let old = header.as_old_mut();
+            old.name.fill(0);
+            let path = b"../escape.txt";
+            old.name[..path.len()].copy_from_slice(path);
+        }
+        header.set_size(payload.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar_builder.append(&header, &payload[..]).unwrap();
+        let tar_bytes = tar_builder.into_inner().unwrap();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_bytes).unwrap();
+        let tar_gz_bytes = encoder.finish().unwrap();
+
+        let err = extract_tar_gz(&tar_gz_bytes, &dest_dir).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("Unsafe archive entry escapes destination")
+                || message.contains("must not have `..`")
+        );
+        assert!(!temp_dir.path().join("escape.txt").exists());
     }
 }


### PR DESCRIPTION
## Summary
Harden mofa plugin install tar extraction to prevent archive path traversal attempts from writing outside the plugin destination directory.

## Related Issues
Closes #1323

Related to #461

---

## Context
install_from_url() accepts remote .tar.gz archives and previously extracted them via tar::Archive::unpack(dest_dir). That broad extraction path does not provide explicit per-entry confinement logic in the installer and is risky in a supply-chain-sensitive code path.

This change applies explicit entry-level extraction checks so malicious archive entries cannot escape the plugin directory.

---

## Changes
- Replaced bulk tar extraction in extract_tar_gz() with per-entry iteration.
- Switched to entry.unpack_in(dest_dir) for destination confinement.
- Return a dedicated plugin error when an entry escape attempt is detected.
- Added a regression test that builds a crafted traversal-style tar entry and verifies extraction is rejected.

---

## How you Tested
1. cargo fmt --package mofa-cli
2. cargo test -p mofa-cli test_extract_tar_gz_rejects_path_traversal -- --nocapture
3. cargo test -p mofa-cli test_install_invalid_plugin_structure

---

## Screenshots / Logs (if applicable)
Key results:
- test_extract_tar_gz_rejects_path_traversal ... ok
- test_install_invalid_plugin_structure ... ok

---

## Breaking Changes
- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] cargo fmt run
- [x] cargo clippy passes without warnings

### Testing
- [x] Tests added/updated
- [x] cargo test passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with main
- [x] No unrelated commits
- [x] Commit messages explain why, not only what

---

## Deployment Notes (if applicable)
No migration required.

---

## Additional Notes for Reviewers
This PR intentionally limits scope to .tar.gz extraction hardening in CLI plugin install. Zip extraction already uses enclosed-name handling and is unchanged.
