### PR TITLE
fix(foundation): prevent integer overflow in RetryPolicy::get_delay

### DIFF
--- a/crates/mofa-foundation/src/workflow/node.rs
+++ b/crates/mofa-foundation/src/workflow/node.rs
@@ -127,7 +127,15 @@ impl RetryPolicy {
     /// Calculate delay for nth retry
     pub fn get_delay(&self, retry_count: u32) -> u64 {
         if self.exponential_backoff {
-            let delay = self.retry_delay_ms * 2u64.pow(retry_count);
+            // Use checked arithmetic to prevent integer overflow when retry_count
+            // is large (e.g. ≥64): an unchecked `2u64.pow(retry_count)` wraps to 0
+            // in release builds (→ zero delay, retry storm) and panics in debug.
+            // If either operation overflows we are already beyond max_delay_ms, so
+            // saturate at that cap instead.
+            let delay = 2u64
+                .checked_pow(retry_count)
+                .and_then(|exp| self.retry_delay_ms.checked_mul(exp))
+                .unwrap_or(self.max_delay_ms);
             delay.min(self.max_delay_ms)
         } else {
             self.retry_delay_ms
@@ -953,5 +961,26 @@ mod tests {
         assert_eq!(policy.get_delay(2), 4000);
         assert_eq!(policy.get_delay(10), 30000); // capped at max
         // capped at max
+    }
+
+    /// Verify that get_delay never panics or returns 0 for large retry counts.
+    ///
+    /// Before the fix, `2u64.pow(retry_count)` would overflow at retry_count ≥ 64:
+    ///   - release builds: wraparound to 0 → delay becomes 0 → unthrottled retry storm
+    ///   - debug builds: arithmetic-overflow panic → process crash
+    #[test]
+    fn test_retry_policy_large_count_does_not_overflow() {
+        let policy = RetryPolicy::default(); // retry_delay_ms: 1000, max_delay_ms: 30000
+
+        // These counts all overflow the raw 2u64.pow() calculation; the fixed
+        // implementation must clamp at max_delay_ms rather than return 0 or panic.
+        for &count in &[55u32, 63, 64, 65, 100, 1000, u32::MAX] {
+            let delay = policy.get_delay(count);
+            assert_eq!(
+                delay,
+                30_000,
+                "get_delay({count}) returned {delay}, expected max_delay_ms 30000"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`RetryPolicy::get_delay` in `mofa-foundation` used bare `u64::pow()` and `*` for exponential backoff, causing integer overflow when `retry_count` is large.

- **Debug builds**: arithmetic-overflow panic -> process crash
- **Release builds**: silent wraparound -> delay collapses to 0 -> zero-delay retry loop -> unthrottled retry storm (self-DoS + downstream DoS)

Replace with `checked_pow` + `checked_mul`, saturating at `max_delay_ms` on overflow (which is the intentional cap anyway).

## Related Issues

Closes #1325

## Context

`retry_count` is a `u32` parameter and `max_retries` in `RetryPolicy` is also `u32`. Any workflow config with `max_retries >= 55` (combined with the default `retry_delay_ms = 1000`) will trigger the overflow in the exponential path. The existing unit test only exercised counts 0-10, leaving the overflow undetected.

## Changes

**`crates/mofa-foundation/src/workflow/node.rs`**

- `RetryPolicy::get_delay`: replace `self.retry_delay_ms * 2u64.pow(retry_count)` with `checked_pow + checked_mul`, unwrapping to `max_delay_ms` on overflow
- Add `test_retry_policy_large_count_does_not_overflow` regression test covering counts 55, 63, 64, 65, 100, 1000, and `u32::MAX`

## How you Tested

```bash
cargo test -p mofa-foundation test_retry_policy
```

Results:
- `test workflow::node::tests::test_retry_policy ... ok`
- `test workflow::node::tests::test_retry_policy_large_count_does_not_overflow ... ok`

## Screenshots / Logs

```
running 5 tests
test recovery::tests::test_retry_policy_no_retry ... ok
test recovery::tests::test_retry_policy_default ... ok
test recovery::tests::test_retry_policy_builder ... ok
test workflow::node::tests::test_retry_policy ... ok
test workflow::node::tests::test_retry_policy_large_count_does_not_overflow ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
```

## Breaking Changes

- [x] No breaking changes

The fix changes only the internal arithmetic. The public API, default values, and observable behaviour for normal retry counts (0-53 with default delay) are identical.

## Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

## Deployment Notes

No migration required. Single crate, single function, no API change.

## Additional Notes for Reviewers

The `unwrap_or(self.max_delay_ms)` default is intentional: if the arithmetic would overflow, the delay is already beyond the configured maximum, so returning `max_delay_ms` is both mathematically correct and safe. The subsequent `.min(self.max_delay_ms)` is kept as a belt-and-suspenders guard for the normal (non-overflow) path.
