### PR TITLE
fix(rhai-workflow): prevent overflow-driven retry storm in scripted nodes

### DIFF
--- a/crates/mofa-extra/src/rhai/workflow.rs
+++ b/crates/mofa-extra/src/rhai/workflow.rs
@@ -19,6 +19,21 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// Global safety cap for scripted-node retry backoff.
+const MAX_SCRIPT_NODE_BACKOFF_MS: u64 = 60_000;
+
+/// Compute exponential retry delay for scripted workflow nodes.
+///
+/// Uses checked arithmetic to prevent overflow when `retry_count` is large.
+/// On overflow, clamps to `MAX_SCRIPT_NODE_BACKOFF_MS` instead of wrapping
+/// to zero and creating a retry storm.
+fn script_node_retry_delay_ms(retry_count: u32) -> u64 {
+    let delay = 100u64
+        .checked_mul(2u64.checked_pow(retry_count).unwrap_or(u64::MAX))
+        .unwrap_or(MAX_SCRIPT_NODE_BACKOFF_MS);
+    delay.min(MAX_SCRIPT_NODE_BACKOFF_MS)
+}
+
 // ============================================================================
 // 脚本节点定义
 // Script node definition
@@ -274,7 +289,7 @@ impl ScriptWorkflowNode {
             if retry_count < self.config.max_retries {
                 // 指数退避重试
                 // Exponential backoff retry
-                let delay = std::time::Duration::from_millis(100 * 2u64.pow(retry_count));
+                let delay = std::time::Duration::from_millis(script_node_retry_delay_ms(retry_count));
                 tokio::time::sleep(delay).await;
             }
             retry_count += 1;
@@ -900,6 +915,20 @@ mod tests {
         let result = executor.execute(serde_json::json!(5)).await.unwrap();
         // 5 * 2 = 10, 10 + 10 = 20
         assert_eq!(result, serde_json::json!(20));
+    }
+
+    #[test]
+    fn test_script_node_retry_delay_large_count_is_capped() {
+        assert_eq!(script_node_retry_delay_ms(0), 100);
+        assert_eq!(script_node_retry_delay_ms(1), 200);
+        // 100 * 2^10 = 102400, capped at 60_000
+        assert_eq!(script_node_retry_delay_ms(10), 60_000);
+
+        // Previously these overflowed and wrapped to 0 in release builds,
+        // causing unthrottled retry storms.
+        for &count in &[55u32, 63, 64, 65, 1000, u32::MAX] {
+            assert_eq!(script_node_retry_delay_ms(count), 60_000);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
﻿## Summary

Fix a critical overflow in Rhai scripted workflow retry backoff used by agentic pipeline nodes.

ScriptWorkflowNode::execute previously used unchecked arithmetic:

- 100 * 2u64.pow(retry_count)

For large retry counts, this overflows:
- Debug builds: panic/crash
- Release builds: wraparound, often to �ms delay


## Related Issues

Closes #1329

## Context

This directly impacts reliability of scripted agentic design patterns (conditional branches, transform chains, validation loops) built on ScriptWorkflowNode. Robust backoff behavior is foundational for iterative framework work under the GSoC “classic agentic design patterns” scope.

## Changes

- Add MAX_SCRIPT_NODE_BACKOFF_MS safety cap (60_000ms)
- Add helper script_node_retry_delay_ms(retry_count) with checked arithmetic
- Replace unsafe retry delay computation in ScriptWorkflowNode::execute
- Add regression test: 	est_script_node_retry_delay_large_count_is_capped

## How you Tested

`
cargo test -p mofa-extra script_node_retry_delay_large_count_is_capped -- --nocapture
cargo test -p mofa-extra test_simple_workflow_execution -- --nocapture
cargo test -p mofa-extra test_conditional_workflow -- --nocapture
`

All passed.

## Screenshots / Logs (if applicable)

Key output:
- 	est rhai::workflow::tests::test_script_node_retry_delay_large_count_is_capped ... ok
- 	est rhai::workflow::tests::test_simple_workflow_execution ... ok
- 	est rhai::workflow::tests::test_conditional_workflow ... ok

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] cargo fmt run
- [x] cargo clippy passes without warnings

### Testing
- [x] Tests added/updated
- [x] cargo test passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with main
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

## Deployment Notes (if applicable)

No migration required.
