### PR TITLE
fix(recovery): recover from poisoned mutex in CircuitBreaker

### DIFF
--- a/crates/mofa-foundation/src/recovery.rs
+++ b/crates/mofa-foundation/src/recovery.rs
@@ -378,7 +378,7 @@ impl CircuitBreaker {
 
     /// Get the current circuit state
     pub fn state(&self) -> CircuitState {
-        let guard = self.state.lock().unwrap();
+        let guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         guard.state
     }
 
@@ -390,7 +390,7 @@ impl CircuitBreaker {
     {
         // Check if we should allow the call
         {
-            let mut guard = self.state.lock().unwrap();
+            let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
             match guard.state {
                 CircuitState::Open => {
                     // Check if recovery timeout has elapsed
@@ -427,7 +427,7 @@ impl CircuitBreaker {
     }
 
     fn record_success(&self) {
-        let mut guard = self.state.lock().unwrap();
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         guard.consecutive_failures = 0;
         guard.consecutive_successes += 1;
 
@@ -440,7 +440,7 @@ impl CircuitBreaker {
     }
 
     fn record_failure(&self) {
-        let mut guard = self.state.lock().unwrap();
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         guard.consecutive_failures += 1;
         guard.consecutive_successes = 0;
         guard.last_failure_time = Some(std::time::Instant::now());
@@ -457,7 +457,7 @@ impl CircuitBreaker {
 
     /// Reset the circuit breaker to closed state
     pub fn reset(&self) {
-        let mut guard = self.state.lock().unwrap();
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         guard.state = CircuitState::Closed;
         guard.consecutive_failures = 0;
         guard.consecutive_successes = 0;


### PR DESCRIPTION
### SUMMARY

This PR prevents runtime panics in the `CircuitBreaker` by safely handling poisoned mutex locks instead of unwrapping them. It updates lock acquisition logic across `crates/mofa-foundation/src/recovery.rs`, ensuring the circuit breaker continues functioning even after a thread panic.

---

### FIX 

* **Root cause:**
  `std::sync::Mutex::lock().unwrap()` panics when the mutex is poisoned, causing cascading failures in all subsequent calls.

* **Technical approach:**
  Replace `.unwrap()` with `.unwrap_or_else(|e| e.into_inner())` to recover the guard from a poisoned mutex and continue execution safely.

**Before (problematic pattern):**

```rust
let mut guard = self.state.lock().unwrap();
```

**After (safe handling):**

```rust
let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
```

* Applied consistently across:

  * `state()`
  * `call()`
  * `record_success()`
  * `record_failure()`
  * `reset()`

---

### VERIFICATION

1. Create a `CircuitBreaker` instance.
2. Simulate a panic while holding the mutex (e.g., inject a panic inside a guarded section like `record_failure()`).
3. After the panic, invoke methods like `state()` or `call()`.


