### PR TITLE
fix(bench): fail fast on silent inference errors in throughput benchmark

### DIFF
--- a/crates/mofa-local-llm/benches/inference_throughput.rs
+++ b/crates/mofa-local-llm/benches/inference_throughput.rs
@@ -28,20 +28,43 @@ fn bench_backend(backend: ComputeBackend, model_path: &str, prompts: &[&str]) {
     }
 
     let mut total_tokens = 0usize;
+    let mut errors = 0usize;
     let start = Instant::now();
 
     for &prompt in prompts {
-        let out = rt.block_on(provider.infer(prompt));
-        if let Ok(response) = out {
-            total_tokens += response.split_whitespace().count();
+        match rt.block_on(provider.infer(prompt)) {
+            Ok(response) => {
+                total_tokens += response.split_whitespace().count();
+            }
+            Err(e) => {
+                eprintln!("  ERROR [{backend}] prompt={prompt:?}: {e}");
+                errors += 1;
+            }
         }
     }
 
     let elapsed = start.elapsed();
+
+    // Fail fast: if every inference call errored the benchmark results are
+    // meaningless.  Surface the failure loudly instead of printing zeros.
+    assert!(
+        errors < prompts.len(),
+        "{backend}: all {errors}/{} inference calls failed — benchmark results would be invalid",
+        prompts.len(),
+    );
+
+    if errors > 0 {
+        eprintln!(
+            "  WARN [{backend}]: {errors}/{} prompts failed; results may be skewed",
+            prompts.len(),
+        );
+    }
+
     println!(
-        "{backend} | prompts={} tokens={} elapsed={:.2}ms throughput={:.1} tok/s",
+        "{backend} | prompts={} tokens={} errors={} elapsed={:.2}ms throughput={:.1} tok/s",
         prompts.len(),
         total_tokens,
+        errors,
         elapsed.as_secs_f64() * 1000.0,
         total_tokens as f64 / elapsed.as_secs_f64().max(0.001),
     );


### PR DESCRIPTION
## Problem

The `inference_throughput` benchmark silently swallowed inference errors - if `infer()` returned `Err`, the result was simply skipped. This could produce misleadingly-good benchmark numbers (0 tokens / low elapsed time) from runs where inference was actually broken, masking real issues.

## Fix

- **Explicit error handling**: Each `infer()` call is now matched with `Ok`/`Err`, and errors are logged per-prompt with `eprintln!`
- - **Fail-fast assertion**: If **all** inference calls fail, the bench panics with a clear message instead of printing meaningless zero-token results
- - **Partial failure warning**: If some (but not all) prompts fail, a warning is printed to alert that results may be skewed
- - **Error count in output**: The summary line now includes an `errors=N` field for visibility
## Validation

- `cargo check -p mofa-local-llm --benches`
- - `cargo clippy -p mofa-local-llm --all-targets`