### PR TITLE
fix(gateway): align legacy OpenAI request behavior with openai-compat

### DIFF
--- a/crates/mofa-gateway/src/handlers/openai.rs
+++ b/crates/mofa-gateway/src/handlers/openai.rs
@@ -4,23 +4,19 @@
 //! that bridge to the InferenceOrchestrator.
 
 use axum::{
-    extract::State,
+    Extension, Json, Router,
     http::{HeaderMap, StatusCode},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::post,
-    Json, Router, Extension,
 };
+use serde::Serialize;
 use std::sync::Arc;
 
-use crate::error::GatewayError;
-use crate::inference_bridge::{
-    ChatCompletionRequest, ChatCompletionResponse, InferenceBridge,
-};
+use crate::inference_bridge::{ChatCompletionRequest, InferenceBridge};
 
 /// Create the OpenAI-compatible router
 pub fn openai_router() -> Router {
-    Router::new()
-        .route("/v1/chat/completions", post(chat_completions))
+    Router::new().route("/v1/chat/completions", post(chat_completions))
 }
 
 /// Extract client key from request headers for rate-limiting
@@ -32,6 +28,32 @@ fn client_key(headers: &HeaderMap) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
+#[derive(Debug, Serialize)]
+struct OpenAiErrorBody {
+    error: OpenAiErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiErrorDetail {
+    message: String,
+    #[serde(rename = "type")]
+    error_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<String>,
+}
+
+impl OpenAiErrorBody {
+    fn invalid_request(message: impl Into<String>) -> Self {
+        Self {
+            error: OpenAiErrorDetail {
+                message: message.into(),
+                error_type: "invalid_request_error".to_string(),
+                code: None,
+            },
+        }
+    }
+}
+
 /// POST /v1/chat/completions
 ///
 /// OpenAI-compatible chat completion endpoint.
@@ -40,18 +62,41 @@ pub async fn chat_completions(
     Extension(bridge): Extension<Arc<InferenceBridge>>,
     headers: HeaderMap,
     Json(req): Json<ChatCompletionRequest>,
-) -> Result<impl IntoResponse, GatewayError> {
+) -> Response {
     // Rate-limit check - simplified for now
     let client = client_key(&headers);
-    
+
+    if req.messages.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(OpenAiErrorBody::invalid_request(
+                "messages must not be empty",
+            )),
+        )
+            .into_response();
+    }
+
+    if req.stream.unwrap_or(false) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(OpenAiErrorBody::invalid_request(
+                "stream=true is not supported on legacy /v1/chat/completions; use openai-compat SSE endpoint",
+            )),
+        )
+            .into_response();
+    }
+
     // Demo logging
     println!("Routing request via InferenceOrchestrator");
     println!("  Model: {}", req.model);
 
     // Run chat completion via bridge
-    let response = bridge.run_chat_completion(req).await?;
+    let response = match bridge.run_chat_completion(req).await {
+        Ok(response) => response,
+        Err(error) => return error.into_response(),
+    };
 
-    Ok(Json(response))
+    Json(response).into_response()
 }
 
 #[cfg(test)]
@@ -84,5 +129,105 @@ mod tests {
         assert!(response.id.starts_with("chatcmpl-"));
         assert_eq!(response.object_type, "chat.completion");
         assert_eq!(response.choices.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_chat_completions_rejects_stream_true_with_structured_400() {
+        use axum::body::to_bytes;
+
+        let config = OrchestratorConfig::default();
+        let bridge = Arc::new(InferenceBridge::new(config));
+
+        let request = ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![crate::inference_bridge::Message {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            }],
+            max_tokens: None,
+            temperature: None,
+            stream: Some(true),
+        };
+
+        let response = chat_completions(Extension(bridge), HeaderMap::new(), Json(request)).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["error"]["type"], "invalid_request_error");
+    }
+
+    #[cfg(feature = "openai-compat")]
+    #[tokio::test]
+    async fn test_legacy_handler_prompt_matches_openai_compat_prompt_shape() {
+        let config = OrchestratorConfig::default();
+        let bridge = Arc::new(InferenceBridge::new(config));
+
+        let legacy_request = ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                crate::inference_bridge::Message {
+                    role: "system".to_string(),
+                    content: "You are concise.".to_string(),
+                },
+                crate::inference_bridge::Message {
+                    role: "user".to_string(),
+                    content: "first".to_string(),
+                },
+                crate::inference_bridge::Message {
+                    role: "assistant".to_string(),
+                    content: "ack".to_string(),
+                },
+                crate::inference_bridge::Message {
+                    role: "user".to_string(),
+                    content: "second".to_string(),
+                },
+            ],
+            max_tokens: None,
+            temperature: None,
+            stream: Some(false),
+        };
+
+        let compat_request = crate::openai_compat::types::ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![
+                crate::openai_compat::types::ChatMessage {
+                    role: "system".to_string(),
+                    content: "You are concise.".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "user".to_string(),
+                    content: "first".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "assistant".to_string(),
+                    content: "ack".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "user".to_string(),
+                    content: "second".to_string(),
+                },
+            ],
+            stream: false,
+            max_tokens: None,
+            temperature: None,
+            priority: crate::openai_compat::types::RequestPriorityParam::Normal,
+        };
+
+        let expected_prompt = compat_request.to_prompt();
+
+        let response =
+            chat_completions(Extension(bridge), HeaderMap::new(), Json(legacy_request)).await;
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            body["choices"][0]["message"]["content"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(&expected_prompt),
+            "legacy handler prompt should match openai_compat formatting"
+        );
     }
 }

--- a/crates/mofa-gateway/src/inference_bridge.rs
+++ b/crates/mofa-gateway/src/inference_bridge.rs
@@ -17,6 +17,7 @@
 //! ```
 
 use crate::error::GatewayError;
+use crate::prompt::build_chat_prompt;
 use mofa_foundation::inference::{
     InferenceOrchestrator, InferenceRequest, InferenceResult, OrchestratorConfig, Precision,
     RequestPriority,
@@ -112,7 +113,13 @@ impl InferenceBridge {
         &self,
         request: ChatCompletionRequest,
     ) -> Result<ChatCompletionResponse, GatewayError> {
-        // Extract prompt from messages (last user message)
+        if request.stream.unwrap_or(false) {
+            return Err(GatewayError::InvalidRequest(
+                "stream=true is not supported by legacy /v1/chat/completions; use openai-compat SSE endpoint".to_string(),
+            ));
+        }
+
+        // Extract prompt from messages (multi-turn context preserved)
         let prompt = extract_prompt_from_messages(&request.messages)?;
 
         // Demo logging for visualization
@@ -143,25 +150,17 @@ impl InferenceBridge {
 
 /// Extract prompt from OpenAI messages
 fn extract_prompt_from_messages(messages: &[Message]) -> Result<String, GatewayError> {
-    // Find the last user message
-    let mut prompt = String::new();
-
-    for msg in messages.iter().rev() {
-        if msg.role == "user" {
-            prompt = msg.content.clone();
-            break;
-        }
+    if messages.is_empty() {
+        return Err(GatewayError::InvalidRequest(
+            "messages must not be empty".to_string(),
+        ));
     }
 
-    if prompt.is_empty() {
-        // If no user message found, concatenate all messages
-        for msg in messages {
-            prompt.push_str(&msg.content);
-            prompt.push('\n');
-        }
-    }
-
-    Ok(prompt.trim().to_string())
+    Ok(build_chat_prompt(
+        messages
+            .iter()
+            .map(|msg| (msg.role.as_str(), msg.content.as_str())),
+    ))
 }
 
 /// Convert InferenceResult to OpenAI response format
@@ -213,7 +212,16 @@ mod tests {
         ];
 
         let prompt = extract_prompt_from_messages(&messages).unwrap();
-        assert_eq!(prompt, "Explain Rust ownership");
+        assert_eq!(
+            prompt,
+            "system: You are a helpful assistant.\nuser: Explain Rust ownership"
+        );
+    }
+
+    #[test]
+    fn test_extract_prompt_rejects_empty_messages() {
+        let err = extract_prompt_from_messages(&[]).unwrap_err();
+        assert!(matches!(err, GatewayError::InvalidRequest(_)));
     }
 
     #[test]
@@ -230,5 +238,89 @@ mod tests {
         assert_eq!(response.object_type, "chat.completion");
         assert_eq!(response.choices.len(), 1);
         assert_eq!(response.choices[0].message.content, "Test output");
+    }
+
+    #[tokio::test]
+    async fn test_run_chat_completion_rejects_stream_true_on_legacy_path() {
+        let bridge = InferenceBridge::new(OrchestratorConfig::default());
+        let request = ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            }],
+            max_tokens: None,
+            temperature: None,
+            stream: Some(true),
+        };
+
+        let err = bridge.run_chat_completion(request).await.unwrap_err();
+        assert!(matches!(err, GatewayError::InvalidRequest(_)));
+    }
+
+    #[cfg(feature = "openai-compat")]
+    #[tokio::test]
+    async fn test_legacy_prompt_matches_openai_compat_prompt_shape() {
+        let bridge = InferenceBridge::new(OrchestratorConfig::default());
+        let legacy_request = ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![
+                Message {
+                    role: "system".to_string(),
+                    content: "You are concise.".to_string(),
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: "Question 1".to_string(),
+                },
+                Message {
+                    role: "assistant".to_string(),
+                    content: "Answer 1".to_string(),
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: "Question 2".to_string(),
+                },
+            ],
+            max_tokens: Some(64),
+            temperature: Some(0.2),
+            stream: Some(false),
+        };
+
+        let compat_request = crate::openai_compat::types::ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![
+                crate::openai_compat::types::ChatMessage {
+                    role: "system".to_string(),
+                    content: "You are concise.".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "user".to_string(),
+                    content: "Question 1".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "assistant".to_string(),
+                    content: "Answer 1".to_string(),
+                },
+                crate::openai_compat::types::ChatMessage {
+                    role: "user".to_string(),
+                    content: "Question 2".to_string(),
+                },
+            ],
+            stream: false,
+            max_tokens: Some(64),
+            temperature: Some(0.2),
+            priority: crate::openai_compat::types::RequestPriorityParam::Normal,
+        };
+        let expected_prompt = compat_request.to_prompt();
+
+        let response = bridge.run_chat_completion(legacy_request).await.unwrap();
+        assert!(
+            response.choices[0]
+                .message
+                .content
+                .contains(&expected_prompt),
+            "legacy path prompt should match openai_compat formatting"
+        );
     }
 }

--- a/crates/mofa-gateway/src/lib.rs
+++ b/crates/mofa-gateway/src/lib.rs
@@ -80,6 +80,7 @@ pub mod handlers;
 pub mod inference_bridge;
 pub mod middleware;
 pub mod observability;
+pub mod prompt;
 pub mod server;
 pub mod state;
 pub mod state_machine;

--- a/crates/mofa-gateway/src/openai_compat/types.rs
+++ b/crates/mofa-gateway/src/openai_compat/types.rs
@@ -8,6 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::prompt::build_chat_prompt;
 use mofa_foundation::inference::types::RequestPriority;
 use mofa_foundation::inference::{OrchestratorConfig, RoutingPolicy};
 
@@ -62,11 +63,11 @@ pub struct ChatCompletionRequest {
 impl ChatCompletionRequest {
     /// Extract the prompt by concatenating all messages (user + system).
     pub fn to_prompt(&self) -> String {
-        self.messages
-            .iter()
-            .map(|m| format!("{}: {}", m.role, m.content))
-            .collect::<Vec<_>>()
-            .join("\n")
+        build_chat_prompt(
+            self.messages
+                .iter()
+                .map(|message| (message.role.as_str(), message.content.as_str())),
+        )
     }
 
     /// Convert the MoFA priority extension to an internal [`RequestPriority`].

--- a/crates/mofa-gateway/src/prompt.rs
+++ b/crates/mofa-gateway/src/prompt.rs
@@ -1,0 +1,34 @@
+//! Shared prompt-building helpers for OpenAI-compatible chat requests.
+
+/// Build a deterministic prompt string from role/content chat messages.
+///
+/// Format: one message per line as `"<role>: <content>"`.
+pub fn build_chat_prompt<'a, I>(messages: I) -> String
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    messages
+        .into_iter()
+        .map(|(role, content)| format!("{role}: {content}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_builder_preserves_role_and_order() {
+        let prompt = build_chat_prompt([
+            ("system", "You are helpful"),
+            ("user", "What is Rust?"),
+            ("assistant", "A language"),
+        ]);
+
+        assert_eq!(
+            prompt,
+            "system: You are helpful\nuser: What is Rust?\nassistant: A language"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Aligns request behavior between legacy and `openai-compat` chat completion paths in `mofa-gateway`.

This PR:
- Introduces a shared prompt builder for consistent multi-turn handling
- Makes legacy streaming behavior explicit (rejects unsupported `stream=true`)
- Adds compatibility tests to prevent future divergence

---

## Related Issues

Closes #1348

---

## Context

`mofa-gateway` currently exposes two OpenAI-like paths with inconsistent behavior:

- Legacy path had independent prompt shaping logic  
- `stream=true` was accepted but not actually supported  
- No guarantees existed to keep both paths behaviorally aligned  

This created ambiguity for clients and increased migration risk.

---

## What Changed

### Shared Prompt Construction

- Added a shared prompt utility:
  - `crates/mofa-gateway/src/prompt.rs`
- Integrated into:
  - `crates/mofa-gateway/src/inference_bridge.rs`
  - `crates/mofa-gateway/src/openai_compat/types.rs`

Ensures identical multi-turn prompt behavior across both paths.

---

### Explicit Legacy Streaming Behavior

- Updated:
  - `crates/mofa-gateway/src/handlers/openai.rs`

Legacy endpoint now:
- Rejects `stream=true`
- Returns structured OpenAI-style `invalid_request_error`
- Rejects empty messages with a proper 400 response

---

### Compatibility Tests

Added tests to enforce behavioral parity:

- Legacy prompt shape matches `openai-compat` prompt shape  
- Streaming rejection is explicit and structured  
- Empty message validation is consistent  

---

## Testing

Executed targeted tests:
- cargo test -p mofa-gateway handlers::openai -- --nocapture
- cargo test -p mofa-gateway inference_bridge -- --nocapture

All relevant tests for modified behavior pass locally.

---

## Impact

- Ensures consistent request semantics across endpoints  
- Reduces migration risk for clients  
- Prevents silent behavioral drift via tests  
- Makes protocol behavior explicit and predictable  

---

##  Checklist

### Code Quality

- [x] Code follows Rust idioms and project conventions  
- [x] Changes are minimal and scoped to this issue  
- [x] cargo fmt applied to modified files  
- [ ] cargo clippy --workspace --all-features -- -D warnings (blocked by unrelated existing lints)

### Testing

- [x] Tests added/updated for new behavior  
- [x] Relevant crate tests pass locally  

### Documentation

- [x] Behavior clarified via tests and structured error responses  
- [ ] README / docs update not required  

## Notes for Reviewers

- Legacy streaming is intentionally kept unsupported but explicit, rather than partially implemented  
- This lays groundwork for potential future deprecation of the legacy path in favor of `openai-compat`