### PR TITLE
fix(scheduler): prevent integer overflow bypass in MemoryScheduler evaluation

### DIFF
--- a/crates/mofa-foundation/src/scheduler/memory.rs
+++ b/crates/mofa-foundation/src/scheduler/memory.rs
@@ -164,7 +164,7 @@ impl MemoryScheduler {
     /// Call [`allocate`](Self::allocate) after an `Accept` decision to reserve memory.
     pub fn evaluate(&self, required_mb: u64) -> AdmissionDecision {
         let current = self.budget.used_mb();
-        let projected = current + required_mb;
+        let projected = current.saturating_add(required_mb);
         let available = self.budget.available_mb();
 
         if projected > self.policy.reject_threshold_mb() {
@@ -295,5 +295,31 @@ impl MemoryScheduler {
     /// Get the policy reference.
     pub fn policy(&self) -> &MemoryPolicy {
         &self.policy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_memory_scheduler_evaluate_overflow() {
+        // Set up a budget of 16GB
+        let mut scheduler = MemoryScheduler::with_capacity(16_384);
+        
+        // Use up 8GB
+        assert!(scheduler.allocate(8192));
+        assert_eq!(scheduler.used_mb(), 8192);
+
+        // Try to allocate an obscenely large amount that would overflow u64
+        // If the code uses `current + required_mb` (unchecked), `8192 + (u64::MAX - 100)`
+        // would overflow to 8091. This is less than the defer/reject thresholds, so it would
+        // incorrectly return `Accept` or `Defer`.
+        let attack_size = u64::MAX - 100;
+        
+        let decision = scheduler.evaluate(attack_size);
+        
+        // It should correctly saturate at u64::MAX and reject the massive request
+        assert_eq!(decision.outcome, AdmissionOutcome::Reject);
     }
 }


### PR DESCRIPTION
## 📋 Summary

This PR fixes a critical arithmetic integer overflow in `MemoryScheduler::evaluate()` that allowed unrealistically huge memory requests to bypass admission control thresholds silently. 

## 🔗 Related Issues

Closes #1358

---

## 🧠 Context

While chasing edge cases in how we admit inference executions, I noticed that we were calculating the `projected` memory usage using a standard, unchecked wrapper `current + required_mb`. 

If an agent or workflow misbehaves and requires an impossibly large block of memory (e.g. `u64::MAX - 100`), the `projected` addition overflows in release builds, dropping down to a very small number. Because this wrapped number falls cleanly underneath the [defer_threshold_mb](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-foundation/src/scheduler/memory.rs:108:4-111:5) and [reject_threshold_mb](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-foundation/src/scheduler/memory.rs:113:4-116:5), the [MemoryScheduler](cci:2://file:///c:/Users/aftab/mofa/crates/mofa-foundation/src/scheduler/memory.rs:128:0-134:1) would return `AdmissionOutcome::Accept` instead of forcefully rejecting the request, subsequently risking bringing down the host.

---

## 🛠️ Changes

- Swapped `current + required_mb` for `current.saturating_add(required_mb)` in [crates/mofa-foundation/src/scheduler/memory.rs](cci:7://file:///c:/Users/aftab/mofa/crates/mofa-foundation/src/scheduler/memory.rs:0:0-0:0)
- Added the [test_memory_scheduler_evaluate_overflow](cci:1://file:///c:/Users/aftab/mofa/crates/mofa-foundation/src/scheduler/memory.rs:304:4-323:5) unit test to verify that the math safely ceilings at `u64::MAX` instead of wrapping, resulting in a correct `AdmissionOutcome::Reject`.

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation`
2. Specifically validated the new test passing, confirming the saturating behavior. 
3. `cargo check` & `cargo clippy` run clean on the affected files.

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests cover the new behavior
- [x] Existing tests pass successfully
