### PR TITLE
fix: correctly handle whitespace in .env keys to avoid duplicates

### DIFF
--- a/mofa/commands/vibe.py
+++ b/mofa/commands/vibe.py
@@ -65,16 +65,21 @@ def _save_vibe_config(model=None, max_rounds=None, agents_output=None, flows_out
     # Update existing lines
     for i, line in enumerate(lines):
         stripped = line.strip()
-        if model and stripped.startswith("MOFA_VIBE_MODEL="):
+        if not stripped or stripped.startswith('#') or '=' not in stripped:
+            continue
+            
+        key = stripped.split('=', 1)[0].strip()
+        
+        if model and key == "MOFA_VIBE_MODEL":
             lines[i] = f"MOFA_VIBE_MODEL={model}\n"
             updated["MOFA_VIBE_MODEL"] = True
-        elif max_rounds is not None and stripped.startswith("MOFA_VIBE_MAX_ROUNDS="):
+        elif max_rounds is not None and key == "MOFA_VIBE_MAX_ROUNDS":
             lines[i] = f"MOFA_VIBE_MAX_ROUNDS={max_rounds}\n"
             updated["MOFA_VIBE_MAX_ROUNDS"] = True
-        elif agents_output and stripped.startswith("MOFA_VIBE_AGENTS_OUTPUT="):
+        elif agents_output and key == "MOFA_VIBE_AGENTS_OUTPUT":
             lines[i] = f"MOFA_VIBE_AGENTS_OUTPUT={agents_output}\n"
             updated["MOFA_VIBE_AGENTS_OUTPUT"] = True
-        elif flows_output and stripped.startswith("MOFA_VIBE_FLOWS_OUTPUT="):
+        elif flows_output and key == "MOFA_VIBE_FLOWS_OUTPUT":
             lines[i] = f"MOFA_VIBE_FLOWS_OUTPUT={flows_output}\n"
             updated["MOFA_VIBE_FLOWS_OUTPUT"] = True
 


### PR DESCRIPTION
Fixes #1369

Improved .env key matching in _save_vibe_config to ignore whitespace around the equals sign, preventing duplicate entries when updating configuration.