### PR TITLE
feat(observatory): implement CognitiveObservatory zero-config tracing subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6058,6 +6058,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/mofa-monitoring/Cargo.toml
+++ b/crates/mofa-monitoring/Cargo.toml
@@ -22,6 +22,7 @@ publish = true
 
 [features]
 default = []
+observatory = []
 otlp-metrics = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -35,6 +36,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 chrono.workspace = true
 thiserror.workspace = true

--- a/crates/mofa-monitoring/src/dashboard/prometheus.rs
+++ b/crates/mofa-monitoring/src/dashboard/prometheus.rs
@@ -451,7 +451,11 @@ impl PrometheusExporter {
         out
     }
 
-    async fn append_exporter_internal_metrics(&self, out: &mut String, last_refresh_unix_seconds: f64) {
+    async fn append_exporter_internal_metrics(
+        &self,
+        out: &mut String,
+        last_refresh_unix_seconds: f64,
+    ) {
         let render_hist = self.render_duration_histogram.read().await;
         write_metric_header(
             out,

--- a/crates/mofa-monitoring/src/lib.rs
+++ b/crates/mofa-monitoring/src/lib.rs
@@ -24,6 +24,7 @@
 //! ```
 
 mod dashboard;
+pub mod observatory;
 pub mod tracing;
 
 pub use dashboard::{
@@ -34,3 +35,4 @@ pub use dashboard::{
     PrometheusExporter, ServerState, SystemMetrics, SystemStatus, TokenAuthProvider,
     WebSocketClient, WebSocketHandler, WebSocketMessage, WorkflowMetrics,
 };
+pub use observatory::{CognitiveObservatory, ObservatoryConfig};

--- a/crates/mofa-monitoring/src/observatory/layer.rs
+++ b/crates/mofa-monitoring/src/observatory/layer.rs
@@ -1,0 +1,215 @@
+//! `tracing_subscriber::layer::Layer` implementation for Cognitive Observatory.
+
+use super::types::{SpanField, SpanRecord};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Internal per-span state stored in the tracing registry.
+struct SpanState {
+    span_id: String,
+    parent_span_id: Option<String>,
+    trace_id: String,
+    target: String,
+    name: String,
+    start_time_us: u64,
+    fields: Vec<SpanField>,
+}
+
+impl SpanState {
+    fn new(id: &Id, attrs: &Attributes<'_>, parent_id: Option<String>, trace_id: String) -> Self {
+        let start_time_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+
+        Self {
+            span_id: format!("{:016x}", id.into_u64()),
+            parent_span_id: parent_id,
+            trace_id,
+            target: attrs.metadata().target().to_string(),
+            name: attrs.metadata().name().to_string(),
+            start_time_us,
+            fields: visitor.fields,
+        }
+    }
+}
+
+/// The tracing Layer that captures spans and forwards them to Observatory.
+pub struct ObservatoryLayer {
+    tx: mpsc::Sender<SpanRecord>,
+}
+
+impl ObservatoryLayer {
+    pub fn new(tx: mpsc::Sender<SpanRecord>) -> Self {
+        Self { tx }
+    }
+}
+
+impl<S> Layer<S> for ObservatoryLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        // Determine parent span and trace ID
+        let (parent_span_id, trace_id) = ctx
+            .span(id)
+            .and_then(|span| span.parent())
+            .and_then(|parent| {
+                parent
+                    .extensions()
+                    .get::<SpanState>()
+                    .map(|s| (Some(s.span_id.clone()), s.trace_id.clone()))
+            })
+            .unwrap_or_else(|| {
+                // No parent → new trace; generate a trace ID from the span ID
+                let trace_id = format!("{:032x}", rand_trace_id(id));
+                (None, trace_id)
+            });
+
+        let state = SpanState::new(id, attrs, parent_span_id, trace_id);
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(state);
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(state) = extensions.get_mut::<SpanState>() {
+                let mut visitor = FieldVisitor::default();
+                values.record(&mut visitor);
+                state.fields.extend(visitor.fields);
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        // Attach event fields to the current span, if any
+        if let Some(span) = ctx.lookup_current() {
+            let mut extensions = span.extensions_mut();
+            if let Some(state) = extensions.get_mut::<SpanState>() {
+                let mut visitor = FieldVisitor::default();
+                event.record(&mut visitor);
+                // Prefix event fields with "event." to distinguish from span fields
+                for mut field in visitor.fields {
+                    field.key = format!("event.{}", field.key);
+                    state.fields.push(field);
+                }
+            }
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let end_time_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros() as u64;
+
+        let record = ctx.span(&id).and_then(|span| {
+            let extensions = span.extensions();
+            extensions.get::<SpanState>().map(|state| {
+                let latency_us = end_time_us.saturating_sub(state.start_time_us);
+
+                // Extract well-known fields
+                let tokens = state
+                    .fields
+                    .iter()
+                    .find(|f| f.key == "tokens" || f.key == "event.tokens")
+                    .and_then(|f| f.value.parse::<u64>().ok());
+                let model = state
+                    .fields
+                    .iter()
+                    .find(|f| f.key == "model" || f.key == "event.model")
+                    .map(|f| f.value.clone());
+
+                SpanRecord {
+                    span_id: state.span_id.clone(),
+                    parent_span_id: state.parent_span_id.clone(),
+                    trace_id: state.trace_id.clone(),
+                    target: state.target.clone(),
+                    name: state.name.clone(),
+                    start_time_us: state.start_time_us,
+                    end_time_us,
+                    latency_us,
+                    fields: state.fields.clone(),
+                    tokens,
+                    model,
+                }
+            })
+        });
+
+        if let Some(record) = record {
+            // Best-effort send — if buffer is full, drop the span rather than block
+            let _ = self.tx.try_send(record);
+        }
+    }
+}
+
+/// Generates a pseudo-random u128 trace ID seeded from the span ID.
+fn rand_trace_id(id: &Id) -> u128 {
+    let v = id.into_u64() as u128;
+    // Mix bits for better distribution
+    let v = v ^ (v << 64);
+    v.wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407)
+}
+
+/// Field visitor that collects all recorded fields into a Vec<SpanField>.
+#[derive(Default)]
+struct FieldVisitor {
+    fields: Vec<SpanField>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: format!("{:?}", value),
+        });
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.push(SpanField {
+            key: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+}

--- a/crates/mofa-monitoring/src/observatory/mod.rs
+++ b/crates/mofa-monitoring/src/observatory/mod.rs
@@ -1,0 +1,277 @@
+//! Cognitive Observatory — zero-config tracing subscriber for MoFA agents.
+//!
+//! Registers a global [`tracing_subscriber`] layer that forwards span events
+//! to the Cognitive Observatory ingestion endpoint via HTTP.
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use mofa_monitoring::observatory::CognitiveObservatory;
+//!
+//! CognitiveObservatory::init("http://localhost:7070").await?;
+//!
+//! // Existing tracing macros are now automatically captured:
+//! tracing::info!(tokens = 142, model = "gpt-4o", "LLM call completed");
+//! # Ok(())
+//! # }
+//! ```
+
+mod layer;
+mod transport;
+mod types;
+
+pub use layer::ObservatoryLayer;
+pub use transport::ObservatoryTransport;
+pub use types::{ObservatoryError, SpanField, SpanRecord};
+
+use tokio::sync::mpsc;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Cognitive Observatory client.
+///
+/// Call [`CognitiveObservatory::init`] once at application startup to register
+/// the global tracing subscriber layer.
+pub struct CognitiveObservatory;
+
+impl CognitiveObservatory {
+    /// Initialize the Cognitive Observatory subscriber with default settings.
+    ///
+    /// Registers a global `tracing` subscriber that batches spans and POSTs them
+    /// to `{endpoint}/v1/traces` every 100ms.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservatoryError`] if the subscriber has already been set or if
+    /// the transport cannot be started.
+    pub async fn init(endpoint: impl Into<String>) -> Result<(), ObservatoryError> {
+        Self::init_with_config(ObservatoryConfig::new(endpoint)).await
+    }
+
+    /// Initialize with custom configuration.
+    pub async fn init_with_config(config: ObservatoryConfig) -> Result<(), ObservatoryError> {
+        let (tx, rx) = mpsc::channel(config.buffer_size);
+        let transport = ObservatoryTransport::new(config.endpoint.clone(), rx);
+
+        // Start the background flush task
+        tokio::spawn(transport.run(config.flush_interval_ms));
+
+        let layer = ObservatoryLayer::new(tx);
+
+        tracing_subscriber::registry()
+            .with(layer)
+            .try_init()
+            .map_err(|e| ObservatoryError::SubscriberInit(e.to_string()))
+    }
+
+    /// Build a layer that can be composed with an existing subscriber via `.with()`.
+    ///
+    /// Use this when you already have a tracing subscriber and want to add
+    /// Observatory as an additional layer.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use mofa_monitoring::observatory::CognitiveObservatory;
+    /// use tracing_subscriber::layer::SubscriberExt;
+    /// use tracing_subscriber::util::SubscriberInitExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let (layer, transport) = CognitiveObservatory::layer("http://localhost:7070").await;
+    /// tokio::spawn(transport.run(100));
+    ///
+    /// tracing_subscriber::registry()
+    ///     .with(layer)
+    ///     .with(tracing_subscriber::fmt::layer())
+    ///     .init();
+    /// # }
+    /// ```
+    pub async fn layer(endpoint: impl Into<String>) -> (ObservatoryLayer, ObservatoryTransport) {
+        let config = ObservatoryConfig::new(endpoint);
+        let (tx, rx) = mpsc::channel(config.buffer_size);
+        let transport = ObservatoryTransport::new(config.endpoint, rx);
+        let layer = ObservatoryLayer::new(tx);
+        (layer, transport)
+    }
+}
+
+/// Configuration for the Cognitive Observatory subscriber.
+#[derive(Debug, Clone)]
+pub struct ObservatoryConfig {
+    /// Base URL of the Cognitive Observatory server, e.g. `"http://localhost:7070"`.
+    pub endpoint: String,
+    /// How often to flush buffered spans to the server (milliseconds). Default: 100.
+    pub flush_interval_ms: u64,
+    /// Maximum number of spans to buffer before back-pressure. Default: 1024.
+    pub buffer_size: usize,
+}
+
+impl ObservatoryConfig {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into().trim_end_matches('/').to_string(),
+            flush_interval_ms: 100,
+            buffer_size: 1024,
+        }
+    }
+
+    pub fn with_flush_interval(mut self, ms: u64) -> Self {
+        self.flush_interval_ms = ms;
+        self
+    }
+
+    pub fn with_buffer_size(mut self, size: usize) -> Self {
+        self.buffer_size = size;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observatory::layer::ObservatoryLayer;
+    use crate::observatory::types::SpanRecord;
+    use tokio::sync::mpsc;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    #[test]
+    fn test_observatory_config_defaults() {
+        let config = ObservatoryConfig::new("http://localhost:7070");
+        assert_eq!(config.endpoint, "http://localhost:7070");
+        assert_eq!(config.flush_interval_ms, 100);
+        assert_eq!(config.buffer_size, 1024);
+    }
+
+    #[test]
+    fn test_observatory_config_trailing_slash_stripped() {
+        let config = ObservatoryConfig::new("http://localhost:7070/");
+        assert_eq!(config.endpoint, "http://localhost:7070");
+    }
+
+    #[test]
+    fn test_observatory_config_builder() {
+        let config = ObservatoryConfig::new("http://localhost:7070")
+            .with_flush_interval(50)
+            .with_buffer_size(512);
+        assert_eq!(config.flush_interval_ms, 50);
+        assert_eq!(config.buffer_size, 512);
+    }
+
+    #[tokio::test]
+    async fn test_layer_captures_span_on_close() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let layer = ObservatoryLayer::new(tx);
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Create a span and close it
+        {
+            let _span = tracing::info_span!("test_operation", agent = "my-agent").entered();
+            // span closes on drop
+        }
+
+        // The closed span should be in the channel
+        let record = rx.try_recv();
+        assert!(record.is_ok(), "Expected a SpanRecord to be sent");
+        let record = record.unwrap();
+        assert_eq!(record.name, "test_operation");
+        assert!(record.latency_us > 0);
+    }
+
+    #[tokio::test]
+    async fn test_layer_captures_token_count_from_event() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let layer = ObservatoryLayer::new(tx);
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        {
+            let _span = tracing::info_span!("llm_call").entered();
+            tracing::info!(tokens = 142u64, model = "gpt-4o", "LLM call completed");
+        }
+
+        let record = rx.try_recv().unwrap();
+        assert_eq!(record.name, "llm_call");
+        assert_eq!(record.tokens, Some(142));
+        assert_eq!(record.model.as_deref(), Some("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn test_layer_captures_parent_child_relationship() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let layer = ObservatoryLayer::new(tx);
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        {
+            let parent = tracing::info_span!("parent_span").entered();
+            {
+                let _child = tracing::info_span!("child_span").entered();
+            } // child closes first
+            drop(parent);
+        } // parent closes
+
+        // Collect both records
+        let mut records = Vec::new();
+        while let Ok(r) = rx.try_recv() {
+            records.push(r);
+        }
+
+        assert_eq!(records.len(), 2, "Expected 2 spans (child + parent)");
+        let child = records.iter().find(|r| r.name == "child_span").unwrap();
+        let parent = records.iter().find(|r| r.name == "parent_span").unwrap();
+        assert_eq!(child.parent_span_id.as_ref(), Some(&parent.span_id));
+    }
+
+    #[tokio::test]
+    async fn test_layer_target_is_captured() {
+        let (tx, mut rx) = mpsc::channel(32);
+        let layer = ObservatoryLayer::new(tx);
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        {
+            let _span = tracing::info_span!("my_op").entered();
+        }
+
+        let record = rx.try_recv().unwrap();
+        // target should be the module path
+        assert!(!record.target.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_transport_flush_sends_http_request() {
+        // This test verifies transport serialization, not the actual HTTP call.
+        // A real HTTP test would need a mock server.
+        let spans = vec![SpanRecord {
+            span_id: "abc123".to_string(),
+            parent_span_id: None,
+            trace_id: "trace001".to_string(),
+            target: "my_agent".to_string(),
+            name: "test_span".to_string(),
+            start_time_us: 1000,
+            end_time_us: 2000,
+            latency_us: 1000,
+            fields: vec![],
+            tokens: Some(10),
+            model: Some("gpt-4o".to_string()),
+        }];
+
+        // Verify it serializes cleanly
+        let json = serde_json::to_string(&spans).unwrap();
+        assert!(json.contains("test_span"));
+        assert!(json.contains("gpt-4o"));
+
+        // Verify it deserializes back
+        let decoded: Vec<SpanRecord> = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].tokens, Some(10));
+    }
+}

--- a/crates/mofa-monitoring/src/observatory/transport.rs
+++ b/crates/mofa-monitoring/src/observatory/transport.rs
@@ -1,0 +1,86 @@
+//! HTTP transport: batches SpanRecords and POSTs to `POST /v1/traces`.
+
+use super::types::{ObservatoryError, SpanRecord};
+use reqwest::Client;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// Background task that receives spans from the layer and POSTs them to the Observatory.
+pub struct ObservatoryTransport {
+    endpoint: String,
+    rx: mpsc::Receiver<SpanRecord>,
+    client: Client,
+}
+
+impl ObservatoryTransport {
+    pub fn new(endpoint: String, rx: mpsc::Receiver<SpanRecord>) -> Self {
+        Self {
+            endpoint,
+            rx,
+            client: Client::new(),
+        }
+    }
+
+    /// Run the transport loop. Drains the channel every `flush_interval_ms` milliseconds
+    /// and POSTs all buffered spans to `{endpoint}/v1/traces`.
+    ///
+    /// This method consumes `self` and should be spawned as a Tokio task:
+    /// ```rust,no_run
+    /// tokio::spawn(transport.run(100));
+    /// ```
+    pub async fn run(mut self, flush_interval_ms: u64) {
+        let interval = Duration::from_millis(flush_interval_ms);
+        let mut ticker = tokio::time::interval(interval);
+        let mut buffer: Vec<SpanRecord> = Vec::with_capacity(64);
+
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    if !buffer.is_empty() {
+                        let batch = std::mem::take(&mut buffer);
+                        if let Err(e) = self.flush(batch).await {
+                            warn!("Observatory flush error: {}", e);
+                        }
+                    }
+                }
+                Some(record) = self.rx.recv() => {
+                    buffer.push(record);
+                    // If buffer is large enough, flush eagerly without waiting
+                    if buffer.len() >= 512 {
+                        let batch = std::mem::take(&mut buffer);
+                        if let Err(e) = self.flush(batch).await {
+                            warn!("Observatory flush error (eager): {}", e);
+                        }
+                    }
+                }
+                else => {
+                    // Channel closed — flush remaining spans and exit
+                    if !buffer.is_empty() {
+                        let batch = std::mem::take(&mut buffer);
+                        let _ = self.flush(batch).await;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn flush(&self, spans: Vec<SpanRecord>) -> Result<(), ObservatoryError> {
+        let url = format!("{}/v1/traces", self.endpoint);
+        let body = serde_json::to_vec(&spans)
+            .map_err(|e| ObservatoryError::Serialization(e.to_string()))?;
+
+        debug!("Observatory: flushing {} spans to {}", spans.len(), url);
+
+        self.client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| ObservatoryError::Transport(e.to_string()))?;
+
+        Ok(())
+    }
+}

--- a/crates/mofa-monitoring/src/observatory/types.rs
+++ b/crates/mofa-monitoring/src/observatory/types.rs
@@ -1,0 +1,50 @@
+//! Data types for the Cognitive Observatory protocol.
+
+use serde::{Deserialize, Serialize};
+
+/// A recorded span sent to the Observatory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpanRecord {
+    /// Unique span ID (hex string).
+    pub span_id: String,
+    /// Parent span ID, if any.
+    pub parent_span_id: Option<String>,
+    /// Trace ID (hex string).
+    pub trace_id: String,
+    /// The tracing target (module path), used as agent name.
+    pub target: String,
+    /// The span name.
+    pub name: String,
+    /// Unix timestamp (microseconds) when the span started.
+    pub start_time_us: u64,
+    /// Unix timestamp (microseconds) when the span ended. Zero if still open.
+    pub end_time_us: u64,
+    /// Latency in microseconds (end_time_us - start_time_us). Zero if still open.
+    pub latency_us: u64,
+    /// Structured fields recorded on the span or its events.
+    pub fields: Vec<SpanField>,
+    /// Token count extracted from `tokens` field, if present.
+    pub tokens: Option<u64>,
+    /// Model name extracted from `model` field, if present.
+    pub model: Option<String>,
+}
+
+/// A key-value field recorded within a span.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpanField {
+    pub key: String,
+    pub value: String,
+}
+
+/// Errors from the Cognitive Observatory integration.
+#[derive(Debug, thiserror::Error)]
+pub enum ObservatoryError {
+    #[error("Failed to initialize tracing subscriber: {0}")]
+    SubscriberInit(String),
+
+    #[error("HTTP transport error: {0}")]
+    Transport(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+}

--- a/crates/mofa-monitoring/src/tracing/exporter.rs
+++ b/crates/mofa-monitoring/src/tracing/exporter.rs
@@ -666,7 +666,11 @@ impl BatchExporter {
             }
         });
 
-        Self { exporter, sender, _task: task }
+        Self {
+            exporter,
+            sender,
+            _task: task,
+        }
     }
 
     pub async fn record(&self, span: SpanData) -> Result<(), String> {

--- a/crates/mofa-monitoring/src/tracing/metrics_exporter.rs
+++ b/crates/mofa-monitoring/src/tracing/metrics_exporter.rs
@@ -260,21 +260,22 @@ struct OtlpRecorder {
 impl Drop for OtlpRecorder {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.meter_provider.lock()
-            && let Some(provider) = guard.take() {
-                // Shutdown in a background OS thread so we never block a tokio
-                // worker thread (e.g. when an async task holding this recorder
-                // is aborted).
-                std::thread::spawn(move || {
-                    let _ = provider.shutdown();
-                });
-            }
+            && let Some(provider) = guard.take()
+        {
+            // Shutdown in a background OS thread so we never block a tokio
+            // worker thread (e.g. when an async task holding this recorder
+            // is aborted).
+            std::thread::spawn(move || {
+                let _ = provider.shutdown();
+            });
+        }
     }
 }
 
 impl OtlpRecorder {
     fn new(config: &OtlpMetricsExporterConfig) -> Result<Self, OtlpMetricsExporterError> {
         use opentelemetry_otlp::WithExportConfig;
-        
+
         let exporter = opentelemetry_otlp::MetricExporter::builder()
             .with_http()
             .with_endpoint(config.endpoint.clone())
@@ -286,7 +287,7 @@ impl OtlpRecorder {
             .with_reader(
                 opentelemetry_sdk::metrics::PeriodicReader::builder(exporter, Tokio)
                     .with_interval(config.export_interval)
-                    .build()
+                    .build(),
             )
             .with_resource(Resource::new(vec![KeyValue::new(
                 "service.name",


### PR DESCRIPTION
## Summary

Closes #1270.

Implements a zero-config `tracing-subscriber` Layer in `mofa-monitoring` that automatically forwards all `tracing::Span` events to the Cognitive Observatory ingestion endpoint.

### What's included

- **`CognitiveObservatory::init(endpoint)`** — single-call global subscriber registration
- **`ObservatoryLayer`** — implements `tracing_subscriber::layer::Layer`, captures:
  - Span name and target (agent name)
  - Start/end timestamps and latency (microseconds)
  - Structured fields (`tokens`, `model`, custom keys) from `tracing::info!` macros
  - Parent-child span relationships for distributed trace reconstruction
- **`ObservatoryTransport`** — background Tokio task that batches spans and POSTs to `POST /v1/traces` every 100ms (configurable)
- **`ObservatoryConfig`** — builder for flush interval, buffer size, endpoint
- **`layer()` builder** — compose with existing subscribers via `.with()`

### Usage

```rust
// Zero additional instrumentation needed:
CognitiveObservatory::init("http://localhost:7070").await?;

// Existing tracing macros are automatically captured:
tracing::info!(tokens = 142, model = "gpt-4o", "LLM call completed");
```

### Composable with existing subscribers

```rust
let (layer, transport) = CognitiveObservatory::layer("http://localhost:7070").await;
tokio::spawn(transport.run(100));

tracing_subscriber::registry()
    .with(layer)
    .with(tracing_subscriber::fmt::layer())
    .init();
```

## Test plan

- [x] `test_observatory_config_defaults` — default endpoint, flush interval, buffer size
- [x] `test_observatory_config_trailing_slash_stripped` — endpoint normalisation
- [x] `test_observatory_config_builder` — `.with_flush_interval()` / `.with_buffer_size()`
- [x] `test_layer_captures_span_on_close` — `SpanRecord` emitted with correct name and latency > 0
- [x] `test_layer_captures_token_count_from_event` — `tokens` and `model` extracted from `tracing::info!` fields
- [x] `test_layer_captures_parent_child_relationship` — child `parent_span_id` matches parent `span_id`
- [x] `test_layer_target_is_captured` — `target` field is populated
- [x] `test_transport_flush_sends_http_request` — `SpanRecord` serialises/deserialises round-trip

All 69 tests in `mofa-monitoring` pass. No new clippy issues introduced.