### PR TITLE
feat(swarm): implement 5 more coordination patterns with 30 runnable examples :)

### DIFF
--- a/crates/mofa-cli/src/commands/swarm.rs
+++ b/crates/mofa-cli/src/commands/swarm.rs
@@ -444,11 +444,10 @@ pub async fn run(
     }
     println!("      pattern: {pattern}");
 
-    let sched_cfg = SwarmSchedulerConfig {
-        task_timeout: Duration::from_secs(timeout_secs),
-        failure_policy: FailurePolicy::Continue,
-        concurrency_limit: None,
-    };
+    let mut sched_cfg = SwarmSchedulerConfig::default();
+    sched_cfg.task_timeout = Duration::from_secs(timeout_secs);
+    sched_cfg.failure_policy = FailurePolicy::Continue;
+    sched_cfg.concurrency_limit = None;
     let executor = make_executor();
 
     let summary: SchedulerSummary = match pattern {

--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -15,7 +15,8 @@ pub use dag::{DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG, SubtaskStat
 pub use patterns::CoordinationPattern;
 pub mod scheduler;
 pub use scheduler::{
-    FailurePolicy, ParallelScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn,
+    ConsensusScheduler, DebateScheduler, FailurePolicy, MapReduceScheduler, ParallelScheduler,
+    RoutingScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn, SupervisionScheduler,
     SwarmScheduler, SwarmSchedulerConfig, TaskExecutionResult, TaskOutcome,
 };
 pub use telemetry::{audit_batch_to_debug, audit_to_debug};

--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -13,7 +13,8 @@ pub use dag::{DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG, SubtaskStat
 pub use patterns::CoordinationPattern;
 pub mod scheduler;
 pub use scheduler::{
-    FailurePolicy, ParallelScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn,
+    ConsensusScheduler, DebateScheduler, FailurePolicy, MapReduceScheduler, ParallelScheduler,
+    RoutingScheduler, SchedulerSummary, SequentialScheduler, SubtaskExecutorFn, SupervisionScheduler,
     SwarmScheduler, SwarmSchedulerConfig, TaskExecutionResult, TaskOutcome,
 };
 pub use telemetry::{audit_batch_to_debug, audit_to_debug};

--- a/crates/mofa-foundation/src/swarm/patterns.rs
+++ b/crates/mofa-foundation/src/swarm/patterns.rs
@@ -82,9 +82,11 @@ impl CoordinationPattern {
         match self {
             Self::Sequential => Box::new(crate::swarm::SequentialScheduler::new()),
             Self::Parallel => Box::new(crate::swarm::ParallelScheduler::new()),
-            other => {
-                unimplemented!("Scheduler for `{other}` pattern is not yet implemented (Phase 2)")
-            }
+            Self::MapReduce => Box::new(crate::swarm::MapReduceScheduler::new()),
+            Self::Debate => Box::new(crate::swarm::DebateScheduler::new()),
+            Self::Consensus => Box::new(crate::swarm::ConsensusScheduler::new()),
+            Self::Routing => Box::new(crate::swarm::RoutingScheduler::new()),
+            Self::Supervision => Box::new(crate::swarm::SupervisionScheduler::new()),
         }
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -466,6 +466,857 @@ impl SwarmScheduler for ParallelScheduler {
     }
 }
 
+fn inject_context(mut task: SwarmSubtask, label: &str, outputs: &[String]) -> SwarmSubtask {
+    if outputs.is_empty() {
+        return task;
+    }
+    let body = outputs.join("\n---\n");
+    task.description = format!("{}\n\n## {}\n{}", task.description, label, body);
+    task
+}
+
+async fn run_parallel_wave(
+    indices: &[NodeIndex],
+    dag: &mut SubtaskDAG,
+    executor: &SubtaskExecutorFn,
+    timeout_dur: Duration,
+) -> Vec<TaskExecutionResult> {
+    let mut futures = Vec::with_capacity(indices.len());
+
+    for &idx in indices {
+        dag.mark_running(idx);
+        let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
+        let exec = executor.clone();
+
+        let fut = async move {
+            let start = Instant::now();
+            match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
+                Ok(Ok(output)) => {
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed())
+                }
+                Ok(Err(e)) => {
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed())
+                }
+                Err(_) => TaskExecutionResult::failure(
+                    &task_snapshot,
+                    idx,
+                    format!("timed out after {:?}", timeout_dur),
+                    start.elapsed(),
+                ),
+            }
+        };
+
+        futures.push(fut);
+    }
+
+    join_all(futures).await
+}
+
+pub struct MapReduceScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl MapReduceScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for MapReduceScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for MapReduceScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::MapReduce
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "map_reduce", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            mappers = map_idxs.len(),
+            reducers = reduce_idxs.len(),
+            "MapReduce scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut map_outputs: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                map_outputs.push(out);
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "mapper failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &reduce_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing reducer").clone();
+            let injected = inject_context(task_snapshot, "Map Phase Outputs", &map_outputs);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "reducer failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("reducer {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::MapReduce,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct DebateScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl DebateScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for DebateScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for DebateScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Debate
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "debate", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            debaters = debater_idxs.len(),
+            judges = judge_idxs.len(),
+            "Debate scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut debate_lines: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                debate_lines.push(format!("**{}:** {}", res.task_id, out));
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "debater failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &judge_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing judge").clone();
+            let injected = inject_context(task_snapshot, "Debate Arguments", &debate_lines);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "judge failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("judge {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Debate,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct ConsensusScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl ConsensusScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for ConsensusScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for ConsensusScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Consensus
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "consensus", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            voters = voter_idxs.len(),
+            aggregators = aggregator_idxs.len(),
+            "Consensus scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut voter_outputs: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                voter_outputs.push(out);
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "voter failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        let majority = {
+            let mut counts: std::collections::HashMap<&str, usize> =
+                std::collections::HashMap::new();
+            for v in &voter_outputs {
+                *counts.entry(v.as_str()).or_insert(0) += 1;
+            }
+            let max = counts.values().copied().max().unwrap_or(0);
+            if max > 1 {
+                counts
+                    .into_iter()
+                    .filter(|(_, c)| *c == max)
+                    .map(|(k, _)| k.to_string())
+                    .next()
+            } else {
+                None
+            }
+        };
+
+        for &idx in &aggregator_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing aggregator").clone();
+            let mut injected =
+                inject_context(task_snapshot, "Voter Outputs", &voter_outputs);
+            if let Some(ref candidate) = majority {
+                injected.description = format!(
+                    "## Majority Candidate\n{}\n\n{}",
+                    candidate, injected.description
+                );
+            }
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "aggregator failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("aggregator {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Consensus,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct RoutingScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl RoutingScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for RoutingScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for RoutingScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Routing
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "routing", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let router_idxs: Vec<_> = all
+            .iter()
+            .filter(|&&idx| dag.dependencies_of(idx).is_empty())
+            .copied()
+            .collect();
+        let specialist_idxs: Vec<_> = all
+            .iter()
+            .filter(|&&idx| !dag.dependencies_of(idx).is_empty())
+            .copied()
+            .collect();
+
+        if router_idxs.len() != 1 {
+            return Err(GlobalError::runtime(format!(
+                "Routing pattern requires exactly 1 router task, found {}",
+                router_idxs.len()
+            )));
+        }
+
+        let router_idx = router_idxs[0];
+        info!(
+            specialists = specialist_idxs.len(),
+            "Routing scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+        let mut skipped = 0usize;
+
+        dag.mark_running(router_idx);
+        let router_snapshot = dag.get_task(router_idx).unwrap().clone();
+        let start = Instant::now();
+        let router_output = match timeout(
+            self.config.task_timeout,
+            executor(router_idx, router_snapshot.clone()),
+        )
+        .await
+        {
+            Ok(Ok(out)) => {
+                let elapsed = start.elapsed();
+                dag.mark_complete_with_output(router_idx, Some(out.clone()));
+                results.push(TaskExecutionResult::success(
+                    &router_snapshot,
+                    router_idx,
+                    out.clone(),
+                    elapsed,
+                ));
+                succeeded += 1;
+                out
+            }
+            Ok(Err(e)) => {
+                let elapsed = start.elapsed();
+                let err = e.to_string();
+                error!(error = %err, "router failed");
+                dag.mark_failed(router_idx, err.clone());
+                results.push(TaskExecutionResult::failure(
+                    &router_snapshot,
+                    router_idx,
+                    err,
+                    elapsed,
+                ));
+                failed += 1;
+                for &idx in &specialist_idxs {
+                    dag.mark_skipped(idx);
+                    skipped += 1;
+                    results.push(TaskExecutionResult::skipped(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        "router failed".into(),
+                    ));
+                }
+                return Ok(SchedulerSummary {
+                    pattern: CoordinationPattern::Routing,
+                    total_tasks: total,
+                    succeeded,
+                    failed,
+                    skipped,
+                    total_wall_time: wall_start.elapsed(),
+                    results,
+                });
+            }
+            Err(_) => {
+                let elapsed = start.elapsed();
+                let msg = format!("timed out after {:?}", self.config.task_timeout);
+                error!("router {}", msg);
+                dag.mark_failed(router_idx, msg.clone());
+                results.push(TaskExecutionResult::failure(
+                    &router_snapshot,
+                    router_idx,
+                    msg,
+                    elapsed,
+                ));
+                failed += 1;
+                for &idx in &specialist_idxs {
+                    dag.mark_skipped(idx);
+                    skipped += 1;
+                    results.push(TaskExecutionResult::skipped(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        "router timed out".into(),
+                    ));
+                }
+                return Ok(SchedulerSummary {
+                    pattern: CoordinationPattern::Routing,
+                    total_tasks: total,
+                    succeeded,
+                    failed,
+                    skipped,
+                    total_wall_time: wall_start.elapsed(),
+                    results,
+                });
+            }
+        };
+
+        let router_lower = router_output.to_lowercase();
+        let matched_idx = specialist_idxs.iter().find(|&&idx| {
+            let task = dag.get_task(idx).unwrap();
+            task.required_capabilities
+                .iter()
+                .any(|cap| router_lower.contains(&cap.to_lowercase()))
+        });
+
+        let chosen_idx = if let Some(&idx) = matched_idx {
+            idx
+        } else {
+            warn!("no capability match found; falling back to first specialist");
+            specialist_idxs[0]
+        };
+
+        for &idx in &specialist_idxs {
+            if idx != chosen_idx {
+                dag.mark_skipped(idx);
+                skipped += 1;
+                results.push(TaskExecutionResult::skipped(
+                    dag.get_task(idx).unwrap(),
+                    idx,
+                    "not selected by router".into(),
+                ));
+            }
+        }
+
+        let spec_snapshot = dag.get_task(chosen_idx).unwrap().clone();
+        let injected = inject_context(spec_snapshot, "Router Output", &[router_output]);
+        dag.mark_running(chosen_idx);
+
+        let start = Instant::now();
+        match timeout(self.config.task_timeout, executor(chosen_idx, injected)).await {
+            Ok(Ok(output)) => {
+                let elapsed = start.elapsed();
+                dag.mark_complete_with_output(chosen_idx, Some(output.clone()));
+                results.push(TaskExecutionResult::success(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    output,
+                    elapsed,
+                ));
+                succeeded += 1;
+            }
+            Ok(Err(e)) => {
+                let elapsed = start.elapsed();
+                let err = e.to_string();
+                error!(error = %err, "specialist failed");
+                dag.mark_failed(chosen_idx, err.clone());
+                results.push(TaskExecutionResult::failure(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    err,
+                    elapsed,
+                ));
+                failed += 1;
+            }
+            Err(_) => {
+                let elapsed = start.elapsed();
+                let msg = format!("timed out after {:?}", self.config.task_timeout);
+                error!("specialist {}", msg);
+                dag.mark_failed(chosen_idx, msg.clone());
+                results.push(TaskExecutionResult::failure(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    msg,
+                    elapsed,
+                ));
+                failed += 1;
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Routing,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct SupervisionScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl SupervisionScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for SupervisionScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for SupervisionScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Supervision
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "supervision", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            workers = worker_idxs.len(),
+            supervisors = supervisor_idxs.len(),
+            "Supervision scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut worker_context_lines: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                worker_context_lines.push(format!("{} (SUCCESS): {}", res.task_id, out));
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                dag.mark_failed(idx, err.clone());
+                worker_context_lines.push(format!("{} (FAILED): {}", res.task_id, err));
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &supervisor_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing supervisor").clone();
+            let injected =
+                inject_context(task_snapshot, "Worker Results", &worker_context_lines);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "supervisor failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("supervisor {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Supervision,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -872,5 +1723,379 @@ mod tests {
         let summary = scheduler.execute(&mut dag, executor).await.unwrap();
         assert!(summary.is_fully_successful());
         assert_eq!(peak.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_outputs_injected_into_reducer() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_m1 = dag.add_task(SwarmSubtask::new("mapper-1", "Map chunk 1"));
+        let idx_m2 = dag.add_task(SwarmSubtask::new("mapper-2", "Map chunk 2"));
+        let idx_r = dag.add_task(SwarmSubtask::new("reducer", "Reduce all"));
+        dag.add_dependency(idx_m1, idx_r).unwrap();
+        dag.add_dependency(idx_m2, idx_r).unwrap();
+
+        let seen_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let seen_clone = seen_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let seen = seen_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "reducer" {
+                    *seen.lock().await = desc;
+                }
+                Ok(format!("{}-out", id))
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert_eq!(summary.succeeded, 3);
+
+        let desc = seen_desc.lock().await;
+        assert!(desc.contains("mapper-1-out"), "reducer must see mapper-1 output");
+        assert!(desc.contains("mapper-2-out"), "reducer must see mapper-2 output");
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_partial_failure_reducer_still_runs() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_m1 = dag.add_task(SwarmSubtask::new("mapper-ok", "Map A"));
+        let idx_m2 = dag.add_task(SwarmSubtask::new("mapper-fail", "Map B"));
+        let idx_r = dag.add_task(SwarmSubtask::new("reducer", "Reduce"));
+        dag.add_dependency(idx_m1, idx_r).unwrap();
+        dag.add_dependency(idx_m2, idx_r).unwrap();
+
+        let reducer_ran = Arc::new(AtomicUsize::new(0));
+        let ran_clone = reducer_ran.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let ran = ran_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "mapper-fail" {
+                    Err(GlobalError::runtime("mapper error"))
+                } else if id == "reducer" {
+                    ran.fetch_add(1, Ordering::SeqCst);
+                    Ok("reduced".into())
+                } else {
+                    Ok("ok".into())
+                }
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(reducer_ran.load(Ordering::SeqCst), 1, "reducer must run even when a mapper fails");
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.succeeded, 2);
+    }
+
+    #[tokio::test]
+    async fn test_debate_judge_receives_both_arguments() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_pro = dag.add_task(SwarmSubtask::new("pro", "Argue for"));
+        let idx_con = dag.add_task(SwarmSubtask::new("con", "Argue against"));
+        let idx_j = dag.add_task(SwarmSubtask::new("judge", "Decide"));
+        dag.add_dependency(idx_pro, idx_j).unwrap();
+        dag.add_dependency(idx_con, idx_j).unwrap();
+
+        let judge_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let jd_clone = judge_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let jd = jd_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "judge" {
+                    *jd.lock().await = desc;
+                }
+                Ok(format!("{}-verdict", id))
+            })
+        });
+
+        let scheduler = DebateScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = judge_desc.lock().await;
+        assert!(desc.contains("**pro:**"), "judge must see pro argument");
+        assert!(desc.contains("**con:**"), "judge must see con argument");
+    }
+
+    #[tokio::test]
+    async fn test_debate_debaters_run_in_parallel() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_a = dag.add_task(SwarmSubtask::new("debater-a", "Position A"));
+        let idx_b = dag.add_task(SwarmSubtask::new("debater-b", "Position B"));
+        let idx_j = dag.add_task(SwarmSubtask::new("judge", "Decide"));
+        dag.add_dependency(idx_a, idx_j).unwrap();
+        dag.add_dependency(idx_b, idx_j).unwrap();
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let a = active.clone();
+        let p = peak.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let a = a.clone();
+            let p = p.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id != "judge" {
+                    let current = a.fetch_add(1, Ordering::SeqCst) + 1;
+                    p.fetch_max(current, Ordering::SeqCst);
+                    sleep(Duration::from_millis(30)).await;
+                    a.fetch_sub(1, Ordering::SeqCst);
+                }
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let scheduler = DebateScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert!(
+            peak.load(Ordering::SeqCst) >= 2,
+            "debaters must run in parallel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_consensus_aggregator_receives_voter_outputs() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_v1 = dag.add_task(SwarmSubtask::new("voter-1", "Vote A"));
+        let idx_v2 = dag.add_task(SwarmSubtask::new("voter-2", "Vote B"));
+        let idx_agg = dag.add_task(SwarmSubtask::new("aggregator", "Aggregate"));
+        dag.add_dependency(idx_v1, idx_agg).unwrap();
+        dag.add_dependency(idx_v2, idx_agg).unwrap();
+
+        let agg_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let agg_clone = agg_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let agg = agg_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "aggregator" {
+                    *agg.lock().await = desc;
+                }
+                Ok(format!("{}-result", id))
+            })
+        });
+
+        let scheduler = ConsensusScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = agg_desc.lock().await;
+        assert!(desc.contains("voter-1-result"), "aggregator must see voter-1");
+        assert!(desc.contains("voter-2-result"), "aggregator must see voter-2");
+    }
+
+    #[tokio::test]
+    async fn test_consensus_majority_candidate_prepended() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_v1 = dag.add_task(SwarmSubtask::new("voter-1", "Vote"));
+        let idx_v2 = dag.add_task(SwarmSubtask::new("voter-2", "Vote"));
+        let idx_v3 = dag.add_task(SwarmSubtask::new("voter-3", "Vote"));
+        let idx_agg = dag.add_task(SwarmSubtask::new("aggregator", "Aggregate"));
+        dag.add_dependency(idx_v1, idx_agg).unwrap();
+        dag.add_dependency(idx_v2, idx_agg).unwrap();
+        dag.add_dependency(idx_v3, idx_agg).unwrap();
+
+        let agg_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let agg_clone = agg_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let agg = agg_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "aggregator" {
+                    *agg.lock().await = desc;
+                    Ok("final".into())
+                } else {
+                    Ok("positive".into())
+                }
+            })
+        });
+
+        let scheduler = ConsensusScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = agg_desc.lock().await;
+        assert!(
+            desc.contains("Majority Candidate"),
+            "aggregator must see majority candidate section"
+        );
+        assert!(desc.contains("positive"), "majority candidate must be the repeated vote");
+    }
+
+    #[tokio::test]
+    async fn test_routing_matches_specialist_by_capability() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_router = dag.add_task(SwarmSubtask::new("router", "Route task"));
+
+        let mut db_spec = SwarmSubtask::new("db-specialist", "Handle DB");
+        db_spec.required_capabilities = vec!["database".into()];
+        let idx_db = dag.add_task(db_spec);
+
+        let mut ml_spec = SwarmSubtask::new("ml-specialist", "Handle ML");
+        ml_spec.required_capabilities = vec!["machine_learning".into()];
+        let idx_ml = dag.add_task(ml_spec);
+
+        dag.add_dependency(idx_router, idx_db).unwrap();
+        dag.add_dependency(idx_router, idx_ml).unwrap();
+
+        let executed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let exec_clone = executed.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let exec = exec_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                exec.lock().await.push(id.clone());
+                if id == "router" {
+                    Ok("needs database access".into())
+                } else {
+                    Ok(format!("{}-done", id))
+                }
+            })
+        });
+
+        let scheduler = RoutingScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.skipped, 1);
+
+        let ran = executed.lock().await;
+        assert!(ran.contains(&"db-specialist".to_string()), "db specialist must run");
+        assert!(!ran.contains(&"ml-specialist".to_string()), "ml specialist must be skipped");
+    }
+
+    #[tokio::test]
+    async fn test_routing_fallback_when_no_match() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_router = dag.add_task(SwarmSubtask::new("router", "Route task"));
+
+        let mut s1 = SwarmSubtask::new("specialist-1", "Handle X");
+        s1.required_capabilities = vec!["very_specific_cap".into()];
+        let idx_s1 = dag.add_task(s1);
+
+        let mut s2 = SwarmSubtask::new("specialist-2", "Handle Y");
+        s2.required_capabilities = vec!["another_cap".into()];
+        let idx_s2 = dag.add_task(s2);
+
+        dag.add_dependency(idx_router, idx_s1).unwrap();
+        dag.add_dependency(idx_router, idx_s2).unwrap();
+
+        let executed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let exec_clone = executed.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let exec = exec_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                exec.lock().await.push(id.clone());
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let scheduler = RoutingScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.skipped, 1);
+
+        let ran = executed.lock().await;
+        assert_eq!(ran.len(), 2, "router + one fallback specialist");
+    }
+
+    #[tokio::test]
+    async fn test_supervision_supervisor_always_runs_after_workers() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_w1 = dag.add_task(SwarmSubtask::new("worker-ok", "Do work"));
+        let idx_w2 = dag.add_task(SwarmSubtask::new("worker-fail", "Do work 2"));
+        let idx_sup = dag.add_task(SwarmSubtask::new("supervisor", "Oversee"));
+        dag.add_dependency(idx_w1, idx_sup).unwrap();
+        dag.add_dependency(idx_w2, idx_sup).unwrap();
+
+        let supervisor_ran = Arc::new(AtomicUsize::new(0));
+        let ran_clone = supervisor_ran.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let ran = ran_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "worker-fail" {
+                    Err(GlobalError::runtime("worker crashed"))
+                } else if id == "supervisor" {
+                    ran.fetch_add(1, Ordering::SeqCst);
+                    Ok("supervised".into())
+                } else {
+                    Ok("worker-ok-out".into())
+                }
+            })
+        });
+
+        let scheduler = SupervisionScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(
+            supervisor_ran.load(Ordering::SeqCst),
+            1,
+            "supervisor must always run"
+        );
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.succeeded, 2);
+    }
+
+    #[tokio::test]
+    async fn test_supervision_supervisor_receives_failure_context() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_w1 = dag.add_task(SwarmSubtask::new("worker-a", "Task A"));
+        let idx_w2 = dag.add_task(SwarmSubtask::new("worker-b", "Task B"));
+        let idx_sup = dag.add_task(SwarmSubtask::new("supervisor", "Oversee"));
+        dag.add_dependency(idx_w1, idx_sup).unwrap();
+        dag.add_dependency(idx_w2, idx_sup).unwrap();
+
+        let sup_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let desc_clone = sup_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let desc = desc_clone.clone();
+            let id = task.id.clone();
+            let task_desc = task.description.clone();
+            Box::pin(async move {
+                if id == "worker-b" {
+                    Err(GlobalError::runtime("critical failure"))
+                } else if id == "supervisor" {
+                    *desc.lock().await = task_desc;
+                    Ok("recovery plan issued".into())
+                } else {
+                    Ok("done".into())
+                }
+            })
+        });
+
+        let scheduler = SupervisionScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.failed, 1);
+
+        let desc = sup_desc.lock().await;
+        assert!(desc.contains("FAILED"), "supervisor must see FAILED label for failed worker");
+        assert!(desc.contains("worker-b"), "supervisor must see failed worker id");
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -1107,9 +1107,13 @@ impl SwarmScheduler for RoutingScheduler {
 
         let chosen_idx = if let Some(&idx) = matched_idx {
             idx
-        } else {
+        } else if let Some(&first) = specialist_idxs.first() {
             warn!("no capability match found; falling back to first specialist");
-            specialist_idxs[0]
+            first
+        } else {
+            return Err(GlobalError::runtime(
+                "Routing pattern requires at least one specialist task",
+            ));
         };
 
         for &idx in &specialist_idxs {

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -1571,6 +1571,21 @@ mod tests {
 
         let par = CoordinationPattern::Parallel.into_scheduler();
         assert_eq!(par.pattern(), CoordinationPattern::Parallel);
+
+        let mr = CoordinationPattern::MapReduce.into_scheduler();
+        assert_eq!(mr.pattern(), CoordinationPattern::MapReduce);
+
+        let deb = CoordinationPattern::Debate.into_scheduler();
+        assert_eq!(deb.pattern(), CoordinationPattern::Debate);
+
+        let con = CoordinationPattern::Consensus.into_scheduler();
+        assert_eq!(con.pattern(), CoordinationPattern::Consensus);
+
+        let rou = CoordinationPattern::Routing.into_scheduler();
+        assert_eq!(rou.pattern(), CoordinationPattern::Routing);
+
+        let sup = CoordinationPattern::Supervision.into_scheduler();
+        assert_eq!(sup.pattern(), CoordinationPattern::Supervision);
     }
 
     #[tokio::test]
@@ -2110,5 +2125,46 @@ mod tests {
         let desc = sup_desc.lock().await;
         assert!(desc.contains("FAILED"), "supervisor must see FAILED label for failed worker");
         assert!(desc.contains("worker-b"), "supervisor must see failed worker id");
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_mappers_run_in_parallel() {
+        let mut dag = SubtaskDAG::new("test");
+        let m1 = dag.add_task(SwarmSubtask::new("mapper-a", "Map A"));
+        let m2 = dag.add_task(SwarmSubtask::new("mapper-b", "Map B"));
+        let m3 = dag.add_task(SwarmSubtask::new("mapper-c", "Map C"));
+        let r = dag.add_task(SwarmSubtask::new("reducer", "Reduce"));
+        dag.add_dependency(m1, r).unwrap();
+        dag.add_dependency(m2, r).unwrap();
+        dag.add_dependency(m3, r).unwrap();
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let a = active.clone();
+        let p = peak.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let a = a.clone();
+            let p = p.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id != "reducer" {
+                    let current = a.fetch_add(1, Ordering::SeqCst) + 1;
+                    p.fetch_max(current, Ordering::SeqCst);
+                    sleep(Duration::from_millis(30)).await;
+                    a.fetch_sub(1, Ordering::SeqCst);
+                }
+                Ok(format!("{}-out", id))
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert!(
+            peak.load(Ordering::SeqCst) >= 3,
+            "all 3 mappers must run in parallel"
+        );
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -475,6 +475,857 @@ impl SwarmScheduler for ParallelScheduler {
     }
 }
 
+fn inject_context(mut task: SwarmSubtask, label: &str, outputs: &[String]) -> SwarmSubtask {
+    if outputs.is_empty() {
+        return task;
+    }
+    let body = outputs.join("\n---\n");
+    task.description = format!("{}\n\n## {}\n{}", task.description, label, body);
+    task
+}
+
+async fn run_parallel_wave(
+    indices: &[NodeIndex],
+    dag: &mut SubtaskDAG,
+    executor: &SubtaskExecutorFn,
+    timeout_dur: Duration,
+) -> Vec<TaskExecutionResult> {
+    let mut futures = Vec::with_capacity(indices.len());
+
+    for &idx in indices {
+        dag.mark_running(idx);
+        let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
+        let exec = executor.clone();
+
+        let fut = async move {
+            let start = Instant::now();
+            match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
+                Ok(Ok(output)) => {
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed())
+                }
+                Ok(Err(e)) => {
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed())
+                }
+                Err(_) => TaskExecutionResult::failure(
+                    &task_snapshot,
+                    idx,
+                    format!("timed out after {:?}", timeout_dur),
+                    start.elapsed(),
+                ),
+            }
+        };
+
+        futures.push(fut);
+    }
+
+    join_all(futures).await
+}
+
+pub struct MapReduceScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl MapReduceScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for MapReduceScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for MapReduceScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::MapReduce
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "map_reduce", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            mappers = map_idxs.len(),
+            reducers = reduce_idxs.len(),
+            "MapReduce scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut map_outputs: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                map_outputs.push(out);
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "mapper failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &reduce_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing reducer").clone();
+            let injected = inject_context(task_snapshot, "Map Phase Outputs", &map_outputs);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "reducer failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("reducer {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::MapReduce,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct DebateScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl DebateScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for DebateScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for DebateScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Debate
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "debate", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            debaters = debater_idxs.len(),
+            judges = judge_idxs.len(),
+            "Debate scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut debate_lines: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                debate_lines.push(format!("**{}:** {}", res.task_id, out));
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "debater failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &judge_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing judge").clone();
+            let injected = inject_context(task_snapshot, "Debate Arguments", &debate_lines);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "judge failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("judge {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Debate,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct ConsensusScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl ConsensusScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for ConsensusScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for ConsensusScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Consensus
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "consensus", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            voters = voter_idxs.len(),
+            aggregators = aggregator_idxs.len(),
+            "Consensus scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut voter_outputs: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                voter_outputs.push(out);
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                warn!(task_id = %res.task_id, "voter failed: {}", err);
+                dag.mark_failed(idx, err);
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        let majority = {
+            let mut counts: std::collections::HashMap<&str, usize> =
+                std::collections::HashMap::new();
+            for v in &voter_outputs {
+                *counts.entry(v.as_str()).or_insert(0) += 1;
+            }
+            let max = counts.values().copied().max().unwrap_or(0);
+            if max > 1 {
+                counts
+                    .into_iter()
+                    .filter(|(_, c)| *c == max)
+                    .map(|(k, _)| k.to_string())
+                    .next()
+            } else {
+                None
+            }
+        };
+
+        for &idx in &aggregator_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing aggregator").clone();
+            let mut injected =
+                inject_context(task_snapshot, "Voter Outputs", &voter_outputs);
+            if let Some(ref candidate) = majority {
+                injected.description = format!(
+                    "## Majority Candidate\n{}\n\n{}",
+                    candidate, injected.description
+                );
+            }
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "aggregator failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("aggregator {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Consensus,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct RoutingScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl RoutingScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for RoutingScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for RoutingScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Routing
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "routing", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let router_idxs: Vec<_> = all
+            .iter()
+            .filter(|&&idx| dag.dependencies_of(idx).is_empty())
+            .copied()
+            .collect();
+        let specialist_idxs: Vec<_> = all
+            .iter()
+            .filter(|&&idx| !dag.dependencies_of(idx).is_empty())
+            .copied()
+            .collect();
+
+        if router_idxs.len() != 1 {
+            return Err(GlobalError::runtime(format!(
+                "Routing pattern requires exactly 1 router task, found {}",
+                router_idxs.len()
+            )));
+        }
+
+        let router_idx = router_idxs[0];
+        info!(
+            specialists = specialist_idxs.len(),
+            "Routing scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+        let mut skipped = 0usize;
+
+        dag.mark_running(router_idx);
+        let router_snapshot = dag.get_task(router_idx).unwrap().clone();
+        let start = Instant::now();
+        let router_output = match timeout(
+            self.config.task_timeout,
+            executor(router_idx, router_snapshot.clone()),
+        )
+        .await
+        {
+            Ok(Ok(out)) => {
+                let elapsed = start.elapsed();
+                dag.mark_complete_with_output(router_idx, Some(out.clone()));
+                results.push(TaskExecutionResult::success(
+                    &router_snapshot,
+                    router_idx,
+                    out.clone(),
+                    elapsed,
+                ));
+                succeeded += 1;
+                out
+            }
+            Ok(Err(e)) => {
+                let elapsed = start.elapsed();
+                let err = e.to_string();
+                error!(error = %err, "router failed");
+                dag.mark_failed(router_idx, err.clone());
+                results.push(TaskExecutionResult::failure(
+                    &router_snapshot,
+                    router_idx,
+                    err,
+                    elapsed,
+                ));
+                failed += 1;
+                for &idx in &specialist_idxs {
+                    dag.mark_skipped(idx);
+                    skipped += 1;
+                    results.push(TaskExecutionResult::skipped(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        "router failed".into(),
+                    ));
+                }
+                return Ok(SchedulerSummary {
+                    pattern: CoordinationPattern::Routing,
+                    total_tasks: total,
+                    succeeded,
+                    failed,
+                    skipped,
+                    total_wall_time: wall_start.elapsed(),
+                    results,
+                });
+            }
+            Err(_) => {
+                let elapsed = start.elapsed();
+                let msg = format!("timed out after {:?}", self.config.task_timeout);
+                error!("router {}", msg);
+                dag.mark_failed(router_idx, msg.clone());
+                results.push(TaskExecutionResult::failure(
+                    &router_snapshot,
+                    router_idx,
+                    msg,
+                    elapsed,
+                ));
+                failed += 1;
+                for &idx in &specialist_idxs {
+                    dag.mark_skipped(idx);
+                    skipped += 1;
+                    results.push(TaskExecutionResult::skipped(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        "router timed out".into(),
+                    ));
+                }
+                return Ok(SchedulerSummary {
+                    pattern: CoordinationPattern::Routing,
+                    total_tasks: total,
+                    succeeded,
+                    failed,
+                    skipped,
+                    total_wall_time: wall_start.elapsed(),
+                    results,
+                });
+            }
+        };
+
+        let router_lower = router_output.to_lowercase();
+        let matched_idx = specialist_idxs.iter().find(|&&idx| {
+            let task = dag.get_task(idx).unwrap();
+            task.required_capabilities
+                .iter()
+                .any(|cap| router_lower.contains(&cap.to_lowercase()))
+        });
+
+        let chosen_idx = if let Some(&idx) = matched_idx {
+            idx
+        } else {
+            warn!("no capability match found; falling back to first specialist");
+            specialist_idxs[0]
+        };
+
+        for &idx in &specialist_idxs {
+            if idx != chosen_idx {
+                dag.mark_skipped(idx);
+                skipped += 1;
+                results.push(TaskExecutionResult::skipped(
+                    dag.get_task(idx).unwrap(),
+                    idx,
+                    "not selected by router".into(),
+                ));
+            }
+        }
+
+        let spec_snapshot = dag.get_task(chosen_idx).unwrap().clone();
+        let injected = inject_context(spec_snapshot, "Router Output", &[router_output]);
+        dag.mark_running(chosen_idx);
+
+        let start = Instant::now();
+        match timeout(self.config.task_timeout, executor(chosen_idx, injected)).await {
+            Ok(Ok(output)) => {
+                let elapsed = start.elapsed();
+                dag.mark_complete_with_output(chosen_idx, Some(output.clone()));
+                results.push(TaskExecutionResult::success(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    output,
+                    elapsed,
+                ));
+                succeeded += 1;
+            }
+            Ok(Err(e)) => {
+                let elapsed = start.elapsed();
+                let err = e.to_string();
+                error!(error = %err, "specialist failed");
+                dag.mark_failed(chosen_idx, err.clone());
+                results.push(TaskExecutionResult::failure(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    err,
+                    elapsed,
+                ));
+                failed += 1;
+            }
+            Err(_) => {
+                let elapsed = start.elapsed();
+                let msg = format!("timed out after {:?}", self.config.task_timeout);
+                error!("specialist {}", msg);
+                dag.mark_failed(chosen_idx, msg.clone());
+                results.push(TaskExecutionResult::failure(
+                    dag.get_task(chosen_idx).unwrap(),
+                    chosen_idx,
+                    msg,
+                    elapsed,
+                ));
+                failed += 1;
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Routing,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
+pub struct SupervisionScheduler {
+    pub config: SwarmSchedulerConfig,
+}
+
+impl SupervisionScheduler {
+    pub fn new() -> Self {
+        Self {
+            config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    pub fn with_config(config: SwarmSchedulerConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for SupervisionScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwarmScheduler for SupervisionScheduler {
+    fn pattern(&self) -> CoordinationPattern {
+        CoordinationPattern::Supervision
+    }
+
+    #[instrument(
+        skip(self, dag, executor),
+        fields(pattern = "supervision", task_count = dag.task_count())
+    )]
+    async fn execute(
+        &self,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        let wall_start = Instant::now();
+        let total = dag.task_count();
+
+        let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
+        let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
+            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+
+        info!(
+            workers = worker_idxs.len(),
+            supervisors = supervisor_idxs.len(),
+            "Supervision scheduler starting"
+        );
+
+        let mut results: Vec<TaskExecutionResult> = Vec::with_capacity(total);
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
+
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout).await;
+
+        let mut worker_context_lines: Vec<String> = Vec::new();
+        for res in wave {
+            let idx = NodeIndex::new(res.node_index);
+            if res.outcome.is_success() {
+                let out = res.outcome.output().unwrap().to_string();
+                dag.mark_complete_with_output(idx, Some(out.clone()));
+                worker_context_lines.push(format!("{} (SUCCESS): {}", res.task_id, out));
+                succeeded += 1;
+            } else {
+                let err = match &res.outcome {
+                    TaskOutcome::Failure(e) => e.clone(),
+                    _ => "unknown error".into(),
+                };
+                dag.mark_failed(idx, err.clone());
+                worker_context_lines.push(format!("{} (FAILED): {}", res.task_id, err));
+                failed += 1;
+            }
+            results.push(res);
+        }
+
+        for &idx in &supervisor_idxs {
+            let task_snapshot = dag.get_task(idx).expect("missing supervisor").clone();
+            let injected =
+                inject_context(task_snapshot, "Worker Results", &worker_context_lines);
+            dag.mark_running(idx);
+
+            let start = Instant::now();
+            match timeout(self.config.task_timeout, executor(idx, injected)).await {
+                Ok(Ok(output)) => {
+                    let elapsed = start.elapsed();
+                    dag.mark_complete_with_output(idx, Some(output.clone()));
+                    results.push(TaskExecutionResult::success(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        output,
+                        elapsed,
+                    ));
+                    succeeded += 1;
+                }
+                Ok(Err(e)) => {
+                    let elapsed = start.elapsed();
+                    let err = e.to_string();
+                    error!(error = %err, "supervisor failed");
+                    dag.mark_failed(idx, err.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        err,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+                Err(_) => {
+                    let elapsed = start.elapsed();
+                    let msg = format!("timed out after {:?}", self.config.task_timeout);
+                    error!("supervisor {}", msg);
+                    dag.mark_failed(idx, msg.clone());
+                    results.push(TaskExecutionResult::failure(
+                        dag.get_task(idx).unwrap(),
+                        idx,
+                        msg,
+                        elapsed,
+                    ));
+                    failed += 1;
+                }
+            }
+        }
+
+        Ok(SchedulerSummary {
+            pattern: CoordinationPattern::Supervision,
+            total_tasks: total,
+            succeeded,
+            failed,
+            skipped: 0,
+            total_wall_time: wall_start.elapsed(),
+            results,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -881,5 +1732,379 @@ mod tests {
         let summary = scheduler.execute(&mut dag, executor).await.unwrap();
         assert!(summary.is_fully_successful());
         assert_eq!(peak.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_outputs_injected_into_reducer() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_m1 = dag.add_task(SwarmSubtask::new("mapper-1", "Map chunk 1"));
+        let idx_m2 = dag.add_task(SwarmSubtask::new("mapper-2", "Map chunk 2"));
+        let idx_r = dag.add_task(SwarmSubtask::new("reducer", "Reduce all"));
+        dag.add_dependency(idx_m1, idx_r).unwrap();
+        dag.add_dependency(idx_m2, idx_r).unwrap();
+
+        let seen_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let seen_clone = seen_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let seen = seen_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "reducer" {
+                    *seen.lock().await = desc;
+                }
+                Ok(format!("{}-out", id))
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert_eq!(summary.succeeded, 3);
+
+        let desc = seen_desc.lock().await;
+        assert!(desc.contains("mapper-1-out"), "reducer must see mapper-1 output");
+        assert!(desc.contains("mapper-2-out"), "reducer must see mapper-2 output");
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_partial_failure_reducer_still_runs() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_m1 = dag.add_task(SwarmSubtask::new("mapper-ok", "Map A"));
+        let idx_m2 = dag.add_task(SwarmSubtask::new("mapper-fail", "Map B"));
+        let idx_r = dag.add_task(SwarmSubtask::new("reducer", "Reduce"));
+        dag.add_dependency(idx_m1, idx_r).unwrap();
+        dag.add_dependency(idx_m2, idx_r).unwrap();
+
+        let reducer_ran = Arc::new(AtomicUsize::new(0));
+        let ran_clone = reducer_ran.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let ran = ran_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "mapper-fail" {
+                    Err(GlobalError::runtime("mapper error"))
+                } else if id == "reducer" {
+                    ran.fetch_add(1, Ordering::SeqCst);
+                    Ok("reduced".into())
+                } else {
+                    Ok("ok".into())
+                }
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(reducer_ran.load(Ordering::SeqCst), 1, "reducer must run even when a mapper fails");
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.succeeded, 2);
+    }
+
+    #[tokio::test]
+    async fn test_debate_judge_receives_both_arguments() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_pro = dag.add_task(SwarmSubtask::new("pro", "Argue for"));
+        let idx_con = dag.add_task(SwarmSubtask::new("con", "Argue against"));
+        let idx_j = dag.add_task(SwarmSubtask::new("judge", "Decide"));
+        dag.add_dependency(idx_pro, idx_j).unwrap();
+        dag.add_dependency(idx_con, idx_j).unwrap();
+
+        let judge_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let jd_clone = judge_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let jd = jd_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "judge" {
+                    *jd.lock().await = desc;
+                }
+                Ok(format!("{}-verdict", id))
+            })
+        });
+
+        let scheduler = DebateScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = judge_desc.lock().await;
+        assert!(desc.contains("**pro:**"), "judge must see pro argument");
+        assert!(desc.contains("**con:**"), "judge must see con argument");
+    }
+
+    #[tokio::test]
+    async fn test_debate_debaters_run_in_parallel() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_a = dag.add_task(SwarmSubtask::new("debater-a", "Position A"));
+        let idx_b = dag.add_task(SwarmSubtask::new("debater-b", "Position B"));
+        let idx_j = dag.add_task(SwarmSubtask::new("judge", "Decide"));
+        dag.add_dependency(idx_a, idx_j).unwrap();
+        dag.add_dependency(idx_b, idx_j).unwrap();
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let a = active.clone();
+        let p = peak.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let a = a.clone();
+            let p = p.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id != "judge" {
+                    let current = a.fetch_add(1, Ordering::SeqCst) + 1;
+                    p.fetch_max(current, Ordering::SeqCst);
+                    sleep(Duration::from_millis(30)).await;
+                    a.fetch_sub(1, Ordering::SeqCst);
+                }
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let scheduler = DebateScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert!(
+            peak.load(Ordering::SeqCst) >= 2,
+            "debaters must run in parallel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_consensus_aggregator_receives_voter_outputs() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_v1 = dag.add_task(SwarmSubtask::new("voter-1", "Vote A"));
+        let idx_v2 = dag.add_task(SwarmSubtask::new("voter-2", "Vote B"));
+        let idx_agg = dag.add_task(SwarmSubtask::new("aggregator", "Aggregate"));
+        dag.add_dependency(idx_v1, idx_agg).unwrap();
+        dag.add_dependency(idx_v2, idx_agg).unwrap();
+
+        let agg_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let agg_clone = agg_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let agg = agg_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "aggregator" {
+                    *agg.lock().await = desc;
+                }
+                Ok(format!("{}-result", id))
+            })
+        });
+
+        let scheduler = ConsensusScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = agg_desc.lock().await;
+        assert!(desc.contains("voter-1-result"), "aggregator must see voter-1");
+        assert!(desc.contains("voter-2-result"), "aggregator must see voter-2");
+    }
+
+    #[tokio::test]
+    async fn test_consensus_majority_candidate_prepended() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_v1 = dag.add_task(SwarmSubtask::new("voter-1", "Vote"));
+        let idx_v2 = dag.add_task(SwarmSubtask::new("voter-2", "Vote"));
+        let idx_v3 = dag.add_task(SwarmSubtask::new("voter-3", "Vote"));
+        let idx_agg = dag.add_task(SwarmSubtask::new("aggregator", "Aggregate"));
+        dag.add_dependency(idx_v1, idx_agg).unwrap();
+        dag.add_dependency(idx_v2, idx_agg).unwrap();
+        dag.add_dependency(idx_v3, idx_agg).unwrap();
+
+        let agg_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let agg_clone = agg_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let agg = agg_clone.clone();
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                if id == "aggregator" {
+                    *agg.lock().await = desc;
+                    Ok("final".into())
+                } else {
+                    Ok("positive".into())
+                }
+            })
+        });
+
+        let scheduler = ConsensusScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let desc = agg_desc.lock().await;
+        assert!(
+            desc.contains("Majority Candidate"),
+            "aggregator must see majority candidate section"
+        );
+        assert!(desc.contains("positive"), "majority candidate must be the repeated vote");
+    }
+
+    #[tokio::test]
+    async fn test_routing_matches_specialist_by_capability() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_router = dag.add_task(SwarmSubtask::new("router", "Route task"));
+
+        let mut db_spec = SwarmSubtask::new("db-specialist", "Handle DB");
+        db_spec.required_capabilities = vec!["database".into()];
+        let idx_db = dag.add_task(db_spec);
+
+        let mut ml_spec = SwarmSubtask::new("ml-specialist", "Handle ML");
+        ml_spec.required_capabilities = vec!["machine_learning".into()];
+        let idx_ml = dag.add_task(ml_spec);
+
+        dag.add_dependency(idx_router, idx_db).unwrap();
+        dag.add_dependency(idx_router, idx_ml).unwrap();
+
+        let executed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let exec_clone = executed.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let exec = exec_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                exec.lock().await.push(id.clone());
+                if id == "router" {
+                    Ok("needs database access".into())
+                } else {
+                    Ok(format!("{}-done", id))
+                }
+            })
+        });
+
+        let scheduler = RoutingScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.skipped, 1);
+
+        let ran = executed.lock().await;
+        assert!(ran.contains(&"db-specialist".to_string()), "db specialist must run");
+        assert!(!ran.contains(&"ml-specialist".to_string()), "ml specialist must be skipped");
+    }
+
+    #[tokio::test]
+    async fn test_routing_fallback_when_no_match() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_router = dag.add_task(SwarmSubtask::new("router", "Route task"));
+
+        let mut s1 = SwarmSubtask::new("specialist-1", "Handle X");
+        s1.required_capabilities = vec!["very_specific_cap".into()];
+        let idx_s1 = dag.add_task(s1);
+
+        let mut s2 = SwarmSubtask::new("specialist-2", "Handle Y");
+        s2.required_capabilities = vec!["another_cap".into()];
+        let idx_s2 = dag.add_task(s2);
+
+        dag.add_dependency(idx_router, idx_s1).unwrap();
+        dag.add_dependency(idx_router, idx_s2).unwrap();
+
+        let executed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let exec_clone = executed.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let exec = exec_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                exec.lock().await.push(id.clone());
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let scheduler = RoutingScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.skipped, 1);
+
+        let ran = executed.lock().await;
+        assert_eq!(ran.len(), 2, "router + one fallback specialist");
+    }
+
+    #[tokio::test]
+    async fn test_supervision_supervisor_always_runs_after_workers() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_w1 = dag.add_task(SwarmSubtask::new("worker-ok", "Do work"));
+        let idx_w2 = dag.add_task(SwarmSubtask::new("worker-fail", "Do work 2"));
+        let idx_sup = dag.add_task(SwarmSubtask::new("supervisor", "Oversee"));
+        dag.add_dependency(idx_w1, idx_sup).unwrap();
+        dag.add_dependency(idx_w2, idx_sup).unwrap();
+
+        let supervisor_ran = Arc::new(AtomicUsize::new(0));
+        let ran_clone = supervisor_ran.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let ran = ran_clone.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "worker-fail" {
+                    Err(GlobalError::runtime("worker crashed"))
+                } else if id == "supervisor" {
+                    ran.fetch_add(1, Ordering::SeqCst);
+                    Ok("supervised".into())
+                } else {
+                    Ok("worker-ok-out".into())
+                }
+            })
+        });
+
+        let scheduler = SupervisionScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(
+            supervisor_ran.load(Ordering::SeqCst),
+            1,
+            "supervisor must always run"
+        );
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.succeeded, 2);
+    }
+
+    #[tokio::test]
+    async fn test_supervision_supervisor_receives_failure_context() {
+        let mut dag = SubtaskDAG::new("test");
+        let idx_w1 = dag.add_task(SwarmSubtask::new("worker-a", "Task A"));
+        let idx_w2 = dag.add_task(SwarmSubtask::new("worker-b", "Task B"));
+        let idx_sup = dag.add_task(SwarmSubtask::new("supervisor", "Oversee"));
+        dag.add_dependency(idx_w1, idx_sup).unwrap();
+        dag.add_dependency(idx_w2, idx_sup).unwrap();
+
+        let sup_desc = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let desc_clone = sup_desc.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let desc = desc_clone.clone();
+            let id = task.id.clone();
+            let task_desc = task.description.clone();
+            Box::pin(async move {
+                if id == "worker-b" {
+                    Err(GlobalError::runtime("critical failure"))
+                } else if id == "supervisor" {
+                    *desc.lock().await = task_desc;
+                    Ok("recovery plan issued".into())
+                } else {
+                    Ok("done".into())
+                }
+            })
+        });
+
+        let scheduler = SupervisionScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.failed, 1);
+
+        let desc = sup_desc.lock().await;
+        assert!(desc.contains("FAILED"), "supervisor must see FAILED label for failed worker");
+        assert!(desc.contains("worker-b"), "supervisor must see failed worker id");
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -47,26 +47,44 @@ pub struct TaskExecutionResult {
     pub node_index: usize,
     pub outcome: TaskOutcome,
     pub wall_time: Duration,
+    /// Microseconds elapsed from scheduler start until this task began executing.
+    /// Zero for skipped tasks. Provides microsecond precision for accurate peak_concurrency computation.
+    #[serde(default)]
+    pub start_offset_us: u64,
     pub attempt: u32,
 }
 
 impl TaskExecutionResult {
-    fn success(task: &SwarmSubtask, idx: NodeIndex, output: String, elapsed: Duration) -> Self {
+    fn success(
+        task: &SwarmSubtask,
+        idx: NodeIndex,
+        output: String,
+        elapsed: Duration,
+        start_offset_us: u64,
+    ) -> Self {
         Self {
             task_id: task.id.clone(),
             node_index: idx.index(),
             outcome: TaskOutcome::Success(output),
             wall_time: elapsed,
+            start_offset_us,
             attempt: 1,
         }
     }
 
-    fn failure(task: &SwarmSubtask, idx: NodeIndex, error: String, elapsed: Duration) -> Self {
+    fn failure(
+        task: &SwarmSubtask,
+        idx: NodeIndex,
+        error: String,
+        elapsed: Duration,
+        start_offset_us: u64,
+    ) -> Self {
         Self {
             task_id: task.id.clone(),
             node_index: idx.index(),
             outcome: TaskOutcome::Failure(error),
             wall_time: elapsed,
+            start_offset_us,
             attempt: 1,
         }
     }
@@ -77,6 +95,7 @@ impl TaskExecutionResult {
             node_index: idx.index(),
             outcome: TaskOutcome::Skipped(reason),
             wall_time: Duration::ZERO,
+            start_offset_us: 0,
             attempt: 0,
         }
     }
@@ -111,6 +130,41 @@ impl SchedulerSummary {
             .filter_map(|r| r.outcome.output())
             .collect()
     }
+
+    /// Returns results sorted by `start_offset_us` — the order tasks actually began executing.
+    pub fn timeline(&self) -> Vec<&TaskExecutionResult> {
+        let mut ordered: Vec<&TaskExecutionResult> = self.results.iter().collect();
+        ordered.sort_by_key(|r| r.start_offset_us);
+        ordered
+    }
+
+    /// Maximum number of tasks that were executing concurrently at any instant.
+    /// Computed from `start_offset_us` and `wall_time` (microsecond precision internally);
+    /// skipped tasks are excluded.
+    pub fn peak_concurrency(&self) -> usize {
+        let mut events: Vec<(u64, i32)> = Vec::new();
+        for r in &self.results {
+            if matches!(r.outcome, TaskOutcome::Skipped(_)) {
+                continue;
+            }
+            let start = r.start_offset_us;
+            let duration = r.wall_time.as_micros().max(1) as u64;
+            let end = start + duration;
+            events.push((start, 1));
+            events.push((end, -1));
+        }
+        if events.is_empty() {
+            return 0;
+        }
+        events.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        let mut current = 0i32;
+        let mut peak = 0i32;
+        for (_, delta) in events {
+            current += delta;
+            peak = peak.max(current);
+        }
+        peak as usize
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -126,6 +180,9 @@ pub struct SwarmSchedulerConfig {
     pub task_timeout: Duration,
     pub failure_policy: FailurePolicy,
     pub concurrency_limit: Option<usize>,
+    /// When `true` the scheduler validates DAG topology and returns a summary showing
+    /// which tasks would execute in what order — without calling the executor at all.
+    pub dry_run: bool,
 }
 
 impl Default for SwarmSchedulerConfig {
@@ -134,6 +191,7 @@ impl Default for SwarmSchedulerConfig {
             task_timeout: Duration::from_secs(120),
             failure_policy: FailurePolicy::default(),
             concurrency_limit: None,
+            dry_run: false,
         }
     }
 }
@@ -193,6 +251,24 @@ impl SwarmScheduler for SequentialScheduler {
             GlobalError::runtime(format!("Sequential scheduling failed, DAG error: {e}"))
         })?;
 
+        if self.config.dry_run {
+            let mut results = Vec::with_capacity(ordered_indices.len());
+            for &idx in &ordered_indices {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: CoordinationPattern::Sequential,
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let mut results = Vec::with_capacity(total);
         let mut succeeded = 0usize;
         let mut failed = 0usize;
@@ -223,6 +299,7 @@ impl SwarmScheduler for SequentialScheduler {
             let task_snapshot = dag.get_task(idx).unwrap().clone();
             let task_id = task_snapshot.id.clone();
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             info!(task_id = %task_id, task_desc = %task_snapshot.description, "Executing node");
 
@@ -242,6 +319,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -254,6 +332,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         err_str,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
 
@@ -271,6 +350,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
 
@@ -333,6 +413,25 @@ impl SwarmScheduler for ParallelScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let semaphore = self
             .config
             .concurrency_limit
@@ -369,6 +468,7 @@ impl SwarmScheduler for ParallelScheduler {
                 let exec = executor.clone();
                 let sem = semaphore.clone();
                 let timeout_dur = self.config.task_timeout;
+                let offset_ms = wall_start.elapsed().as_micros() as u64;
 
                 let fut = async move {
                     let _permit = if let Some(s) = sem {
@@ -384,18 +484,21 @@ impl SwarmScheduler for ParallelScheduler {
                             idx,
                             output,
                             start.elapsed(),
+                            offset_ms,
                         ),
                         Ok(Err(e)) => TaskExecutionResult::failure(
                             &task_snapshot,
                             idx,
                             e.to_string(),
                             start.elapsed(),
+                            offset_ms,
                         ),
                         Err(_) => TaskExecutionResult::failure(
                             &task_snapshot,
                             idx,
                             format!("timed out after {:?}", timeout_dur),
                             start.elapsed(),
+                            offset_ms,
                         ),
                     }
                 };
@@ -480,6 +583,7 @@ async fn run_parallel_wave(
     dag: &mut SubtaskDAG,
     executor: &SubtaskExecutorFn,
     timeout_dur: Duration,
+    sched_start: Instant,
 ) -> Vec<TaskExecutionResult> {
     let mut futures = Vec::with_capacity(indices.len());
 
@@ -487,21 +591,23 @@ async fn run_parallel_wave(
         dag.mark_running(idx);
         let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
         let exec = executor.clone();
+        let offset_ms = sched_start.elapsed().as_micros() as u64;
 
         let fut = async move {
             let start = Instant::now();
             match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
                 Ok(Ok(output)) => {
-                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed())
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_ms)
                 }
                 Ok(Err(e)) => {
-                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed())
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_ms)
                 }
                 Err(_) => TaskExecutionResult::failure(
                     &task_snapshot,
                     idx,
                     format!("timed out after {:?}", timeout_dur),
                     start.elapsed(),
+                    offset_ms,
                 ),
             }
         };
@@ -552,6 +658,25 @@ impl SwarmScheduler for MapReduceScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -566,7 +691,7 @@ impl SwarmScheduler for MapReduceScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut map_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -593,6 +718,7 @@ impl SwarmScheduler for MapReduceScheduler {
             let injected = inject_context(task_snapshot, "Map Phase Outputs", &map_outputs);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -603,6 +729,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -616,6 +743,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -629,6 +757,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -687,6 +816,25 @@ impl SwarmScheduler for DebateScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -701,7 +849,7 @@ impl SwarmScheduler for DebateScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut debate_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -728,6 +876,7 @@ impl SwarmScheduler for DebateScheduler {
             let injected = inject_context(task_snapshot, "Debate Arguments", &debate_lines);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -738,6 +887,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -751,6 +901,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -764,6 +915,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -822,6 +974,25 @@ impl SwarmScheduler for ConsensusScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -836,7 +1007,7 @@ impl SwarmScheduler for ConsensusScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut voter_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -888,6 +1059,7 @@ impl SwarmScheduler for ConsensusScheduler {
             }
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -898,6 +1070,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -911,6 +1084,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -924,6 +1098,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -982,6 +1157,25 @@ impl SwarmScheduler for RoutingScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let router_idxs: Vec<_> = all
             .iter()
@@ -1014,6 +1208,7 @@ impl SwarmScheduler for RoutingScheduler {
 
         dag.mark_running(router_idx);
         let router_snapshot = dag.get_task(router_idx).unwrap().clone();
+        let router_offset_ms = wall_start.elapsed().as_micros() as u64;
         let start = Instant::now();
         let router_output = match timeout(
             self.config.task_timeout,
@@ -1029,6 +1224,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     out.clone(),
                     elapsed,
+                    router_offset_ms,
                 ));
                 succeeded += 1;
                 out
@@ -1043,6 +1239,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     err,
                     elapsed,
+                    router_offset_ms,
                 ));
                 failed += 1;
                 for &idx in &specialist_idxs {
@@ -1074,6 +1271,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     msg,
                     elapsed,
+                    router_offset_ms,
                 ));
                 failed += 1;
                 for &idx in &specialist_idxs {
@@ -1132,6 +1330,7 @@ impl SwarmScheduler for RoutingScheduler {
         let injected = inject_context(spec_snapshot, "Router Output", &[router_output]);
         dag.mark_running(chosen_idx);
 
+        let spec_offset_ms = wall_start.elapsed().as_micros() as u64;
         let start = Instant::now();
         match timeout(self.config.task_timeout, executor(chosen_idx, injected)).await {
             Ok(Ok(output)) => {
@@ -1142,6 +1341,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     output,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 succeeded += 1;
             }
@@ -1155,6 +1355,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     err,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 failed += 1;
             }
@@ -1168,6 +1369,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     msg,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 failed += 1;
             }
@@ -1225,6 +1427,25 @@ impl SwarmScheduler for SupervisionScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -1239,7 +1460,7 @@ impl SwarmScheduler for SupervisionScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut worker_context_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -1267,6 +1488,7 @@ impl SwarmScheduler for SupervisionScheduler {
                 inject_context(task_snapshot, "Worker Results", &worker_context_lines);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -1277,6 +1499,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -1290,6 +1513,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -1303,6 +1527,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -2156,6 +2381,93 @@ mod tests {
         assert!(
             peak.load(Ordering::SeqCst) >= 3,
             "all 3 mappers must run in parallel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_skips_all_without_executing() {
+        let mut dag = SubtaskDAG::new("test");
+        dag.add_task(SwarmSubtask::new("a", "Task A"));
+        dag.add_task(SwarmSubtask::new("b", "Task B"));
+        dag.add_task(SwarmSubtask::new("c", "Task C"));
+
+        let called = Arc::new(AtomicUsize::new(0));
+        let c = called.clone();
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok("should not run".into()) })
+        });
+
+        let config = SwarmSchedulerConfig { dry_run: true, ..Default::default() };
+        let summary = ParallelScheduler::with_config(config)
+            .execute(&mut dag, executor)
+            .await
+            .unwrap();
+
+        assert_eq!(called.load(Ordering::SeqCst), 0, "executor must never be called in dry_run");
+        assert_eq!(summary.skipped, 3);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.total_wall_time, Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_timeline_sequential_tasks_have_increasing_offsets() {
+        let mut dag = SubtaskDAG::new("test");
+        let a = dag.add_task(SwarmSubtask::new("a", "Task A"));
+        let b = dag.add_task(SwarmSubtask::new("b", "Task B"));
+        let c = dag.add_task(SwarmSubtask::new("c", "Task C"));
+        dag.add_dependency(a, b).unwrap();
+        dag.add_dependency(b, c).unwrap();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let id = task.id.clone();
+            Box::pin(async move {
+                sleep(Duration::from_millis(20)).await;
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let summary = SequentialScheduler::new().execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let tl = summary.timeline();
+        assert_eq!(tl.len(), 3);
+        assert!(
+            tl[0].start_offset_us <= tl[1].start_offset_us,
+            "a must start before b"
+        );
+        assert!(
+            tl[1].start_offset_us <= tl[2].start_offset_us,
+            "b must start before c"
+        );
+        assert!(
+            summary.peak_concurrency() <= 1,
+            "sequential never exceeds 1 concurrent task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_peak_concurrency_parallel_tasks() {
+        let mut dag = SubtaskDAG::new("test");
+        dag.add_task(SwarmSubtask::new("p1", "Task 1"));
+        dag.add_task(SwarmSubtask::new("p2", "Task 2"));
+        dag.add_task(SwarmSubtask::new("p3", "Task 3"));
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let id = task.id.clone();
+            Box::pin(async move {
+                sleep(Duration::from_millis(30)).await;
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let summary = ParallelScheduler::new().execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert_eq!(
+            summary.peak_concurrency(),
+            3,
+            "all 3 independent tasks run concurrently"
         );
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -139,8 +139,13 @@ impl SchedulerSummary {
     }
 
     /// Returns results sorted by `start_offset_us` — the order tasks actually began executing.
+    /// Skipped tasks are excluded since they have `start_offset_us = 0` and never ran.
     pub fn timeline(&self) -> Vec<&TaskExecutionResult> {
-        let mut ordered: Vec<&TaskExecutionResult> = self.results.iter().collect();
+        let mut ordered: Vec<&TaskExecutionResult> = self
+            .results
+            .iter()
+            .filter(|r| !matches!(r.outcome, TaskOutcome::Skipped(_)))
+            .collect();
         ordered.sort_by_key(|r| r.start_offset_us);
         ordered
     }
@@ -155,7 +160,7 @@ impl SchedulerSummary {
                 continue;
             }
             let start = r.start_offset_us;
-            let duration = r.wall_time.as_micros().max(1) as u64;
+            let duration = u64::try_from(r.wall_time.as_micros().max(1)).unwrap_or(u64::MAX);
             let end = start + duration;
             events.push((start, 1));
             events.push((end, -1));
@@ -183,6 +188,7 @@ pub enum FailurePolicy {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SwarmSchedulerConfig {
     pub task_timeout: Duration,
     pub failure_policy: FailurePolicy,
@@ -262,7 +268,6 @@ impl SwarmScheduler for SequentialScheduler {
             let mut results = Vec::with_capacity(ordered_indices.len());
             for &idx in &ordered_indices {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -426,7 +431,6 @@ impl SwarmScheduler for ParallelScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -593,30 +597,39 @@ async fn run_parallel_wave(
     executor: &SubtaskExecutorFn,
     timeout_dur: Duration,
     sched_start: Instant,
+    concurrency_limit: Option<usize>,
 ) -> Vec<TaskExecutionResult> {
+    let semaphore = concurrency_limit.map(|n| Arc::new(Semaphore::new(n)));
     let mut futures = Vec::with_capacity(indices.len());
 
     for &idx in indices {
         dag.mark_running(idx);
         let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
         let exec = executor.clone();
-        let offset_ms = sched_start.elapsed().as_micros() as u64;
+        let sem = semaphore.clone();
+        let sched_start_copy = sched_start;
 
         let fut = async move {
+            let _permit = if let Some(s) = sem {
+                Some(s.acquire_owned().await.expect("semaphore closed"))
+            } else {
+                None
+            };
+            let offset_us = u64::try_from(sched_start_copy.elapsed().as_micros()).unwrap_or(u64::MAX);
             let start = Instant::now();
             match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
                 Ok(Ok(output)) => {
-                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_ms)
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_us)
                 }
                 Ok(Err(e)) => {
-                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_ms)
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_us)
                 }
                 Err(_) => TaskExecutionResult::failure(
                     &task_snapshot,
                     idx,
                     format!("timed out after {:?}", timeout_dur),
                     start.elapsed(),
-                    offset_ms,
+                    offset_us,
                 ),
             }
         };
@@ -672,7 +685,6 @@ impl SwarmScheduler for MapReduceScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -687,8 +699,8 @@ impl SwarmScheduler for MapReduceScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let map_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let reduce_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             mappers = map_idxs.len(),
@@ -700,7 +712,7 @@ impl SwarmScheduler for MapReduceScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut map_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -830,7 +842,6 @@ impl SwarmScheduler for DebateScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -845,8 +856,8 @@ impl SwarmScheduler for DebateScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let debater_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let judge_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             debaters = debater_idxs.len(),
@@ -858,7 +869,7 @@ impl SwarmScheduler for DebateScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut debate_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -988,7 +999,6 @@ impl SwarmScheduler for ConsensusScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -1003,8 +1013,8 @@ impl SwarmScheduler for ConsensusScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let voter_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let aggregator_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             voters = voter_idxs.len(),
@@ -1016,7 +1026,7 @@ impl SwarmScheduler for ConsensusScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut voter_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -1039,18 +1049,21 @@ impl SwarmScheduler for ConsensusScheduler {
         }
 
         let majority = {
+            let total = voter_outputs.len();
             let mut counts: std::collections::HashMap<&str, usize> =
                 std::collections::HashMap::new();
             for v in &voter_outputs {
                 *counts.entry(v.as_str()).or_insert(0) += 1;
             }
             let max = counts.values().copied().max().unwrap_or(0);
-            if max > 1 {
-                counts
-                    .into_iter()
-                    .filter(|(_, c)| *c == max)
-                    .map(|(k, _)| k.to_string())
-                    .next()
+            // Strict majority: candidate must have more than half of votes.
+            // On ties (two candidates with equal max), no majority is declared.
+            let winners: Vec<_> = counts
+                .iter()
+                .filter(|&(_, &c)| c == max)
+                .collect();
+            if max * 2 > total && winners.len() == 1 {
+                winners.into_iter().next().map(|(k, _)| k.to_string())
             } else {
                 None
             }
@@ -1171,7 +1184,6 @@ impl SwarmScheduler for RoutingScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -1441,7 +1453,6 @@ impl SwarmScheduler for SupervisionScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -1456,8 +1467,8 @@ impl SwarmScheduler for SupervisionScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let worker_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let supervisor_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             workers = worker_idxs.len(),
@@ -1469,7 +1480,7 @@ impl SwarmScheduler for SupervisionScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut worker_context_lines: Vec<String> = Vec::new();
         for res in wave {

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -278,6 +278,7 @@ impl SwarmScheduler for SequentialScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -441,6 +442,7 @@ impl SwarmScheduler for ParallelScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -695,6 +697,7 @@ impl SwarmScheduler for MapReduceScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -793,6 +796,7 @@ impl SwarmScheduler for MapReduceScheduler {
             skipped: 0,
             total_wall_time: wall_start.elapsed(),
             results,
+            hitl_stats: None,
         })
     }
 }
@@ -852,6 +856,7 @@ impl SwarmScheduler for DebateScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -950,6 +955,7 @@ impl SwarmScheduler for DebateScheduler {
             skipped: 0,
             total_wall_time: wall_start.elapsed(),
             results,
+            hitl_stats: None,
         })
     }
 }
@@ -1009,6 +1015,7 @@ impl SwarmScheduler for ConsensusScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -1135,6 +1142,7 @@ impl SwarmScheduler for ConsensusScheduler {
             skipped: 0,
             total_wall_time: wall_start.elapsed(),
             results,
+            hitl_stats: None,
         })
     }
 }
@@ -1194,6 +1202,7 @@ impl SwarmScheduler for RoutingScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -1280,6 +1289,7 @@ impl SwarmScheduler for RoutingScheduler {
                     skipped,
                     total_wall_time: wall_start.elapsed(),
                     results,
+                    hitl_stats: None,
                 });
             }
             Err(_) => {
@@ -1312,6 +1322,7 @@ impl SwarmScheduler for RoutingScheduler {
                     skipped,
                     total_wall_time: wall_start.elapsed(),
                     results,
+                    hitl_stats: None,
                 });
             }
         };
@@ -1404,6 +1415,7 @@ impl SwarmScheduler for RoutingScheduler {
             skipped,
             total_wall_time: wall_start.elapsed(),
             results,
+            hitl_stats: None,
         })
     }
 }
@@ -1463,6 +1475,7 @@ impl SwarmScheduler for SupervisionScheduler {
                 skipped: total,
                 total_wall_time: Duration::ZERO,
                 results,
+                hitl_stats: None,
             });
         }
 
@@ -1562,6 +1575,7 @@ impl SwarmScheduler for SupervisionScheduler {
             skipped: 0,
             total_wall_time: wall_start.elapsed(),
             results,
+            hitl_stats: None,
         })
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -132,8 +132,13 @@ impl SchedulerSummary {
     }
 
     /// Returns results sorted by `start_offset_us` — the order tasks actually began executing.
+    /// Skipped tasks are excluded since they have `start_offset_us = 0` and never ran.
     pub fn timeline(&self) -> Vec<&TaskExecutionResult> {
-        let mut ordered: Vec<&TaskExecutionResult> = self.results.iter().collect();
+        let mut ordered: Vec<&TaskExecutionResult> = self
+            .results
+            .iter()
+            .filter(|r| !matches!(r.outcome, TaskOutcome::Skipped(_)))
+            .collect();
         ordered.sort_by_key(|r| r.start_offset_us);
         ordered
     }
@@ -148,7 +153,7 @@ impl SchedulerSummary {
                 continue;
             }
             let start = r.start_offset_us;
-            let duration = r.wall_time.as_micros().max(1) as u64;
+            let duration = u64::try_from(r.wall_time.as_micros().max(1)).unwrap_or(u64::MAX);
             let end = start + duration;
             events.push((start, 1));
             events.push((end, -1));
@@ -176,6 +181,7 @@ pub enum FailurePolicy {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SwarmSchedulerConfig {
     pub task_timeout: Duration,
     pub failure_policy: FailurePolicy,
@@ -255,7 +261,6 @@ impl SwarmScheduler for SequentialScheduler {
             let mut results = Vec::with_capacity(ordered_indices.len());
             for &idx in &ordered_indices {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -418,7 +423,6 @@ impl SwarmScheduler for ParallelScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -584,30 +588,39 @@ async fn run_parallel_wave(
     executor: &SubtaskExecutorFn,
     timeout_dur: Duration,
     sched_start: Instant,
+    concurrency_limit: Option<usize>,
 ) -> Vec<TaskExecutionResult> {
+    let semaphore = concurrency_limit.map(|n| Arc::new(Semaphore::new(n)));
     let mut futures = Vec::with_capacity(indices.len());
 
     for &idx in indices {
         dag.mark_running(idx);
         let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
         let exec = executor.clone();
-        let offset_ms = sched_start.elapsed().as_micros() as u64;
+        let sem = semaphore.clone();
+        let sched_start_copy = sched_start;
 
         let fut = async move {
+            let _permit = if let Some(s) = sem {
+                Some(s.acquire_owned().await.expect("semaphore closed"))
+            } else {
+                None
+            };
+            let offset_us = u64::try_from(sched_start_copy.elapsed().as_micros()).unwrap_or(u64::MAX);
             let start = Instant::now();
             match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
                 Ok(Ok(output)) => {
-                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_ms)
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_us)
                 }
                 Ok(Err(e)) => {
-                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_ms)
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_us)
                 }
                 Err(_) => TaskExecutionResult::failure(
                     &task_snapshot,
                     idx,
                     format!("timed out after {:?}", timeout_dur),
                     start.elapsed(),
-                    offset_ms,
+                    offset_us,
                 ),
             }
         };
@@ -663,7 +676,6 @@ impl SwarmScheduler for MapReduceScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -678,8 +690,8 @@ impl SwarmScheduler for MapReduceScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let map_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let reduce_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             mappers = map_idxs.len(),
@@ -691,7 +703,7 @@ impl SwarmScheduler for MapReduceScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut map_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -821,7 +833,6 @@ impl SwarmScheduler for DebateScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -836,8 +847,8 @@ impl SwarmScheduler for DebateScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let debater_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let judge_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             debaters = debater_idxs.len(),
@@ -849,7 +860,7 @@ impl SwarmScheduler for DebateScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut debate_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -979,7 +990,6 @@ impl SwarmScheduler for ConsensusScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -994,8 +1004,8 @@ impl SwarmScheduler for ConsensusScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let voter_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let aggregator_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             voters = voter_idxs.len(),
@@ -1007,7 +1017,7 @@ impl SwarmScheduler for ConsensusScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut voter_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -1030,18 +1040,21 @@ impl SwarmScheduler for ConsensusScheduler {
         }
 
         let majority = {
+            let total = voter_outputs.len();
             let mut counts: std::collections::HashMap<&str, usize> =
                 std::collections::HashMap::new();
             for v in &voter_outputs {
                 *counts.entry(v.as_str()).or_insert(0) += 1;
             }
             let max = counts.values().copied().max().unwrap_or(0);
-            if max > 1 {
-                counts
-                    .into_iter()
-                    .filter(|(_, c)| *c == max)
-                    .map(|(k, _)| k.to_string())
-                    .next()
+            // Strict majority: candidate must have more than half of votes.
+            // On ties (two candidates with equal max), no majority is declared.
+            let winners: Vec<_> = counts
+                .iter()
+                .filter(|&(_, &c)| c == max)
+                .collect();
+            if max * 2 > total && winners.len() == 1 {
+                winners.into_iter().next().map(|(k, _)| k.to_string())
             } else {
                 None
             }
@@ -1162,7 +1175,6 @@ impl SwarmScheduler for RoutingScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -1432,7 +1444,6 @@ impl SwarmScheduler for SupervisionScheduler {
             let mut results = Vec::with_capacity(ordered.len());
             for &idx in &ordered {
                 let task = dag.get_task(idx).expect("missing idx").clone();
-                dag.mark_skipped(idx);
                 results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
             }
             return Ok(SchedulerSummary {
@@ -1447,8 +1458,8 @@ impl SwarmScheduler for SupervisionScheduler {
         }
 
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
-        let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
-            all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
+        let worker_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependencies_of(idx).is_empty()).collect();
+        let supervisor_idxs: Vec<_> = all.iter().copied().filter(|&idx| dag.dependents_of(idx).is_empty()).collect();
 
         info!(
             workers = worker_idxs.len(),
@@ -1460,7 +1471,7 @@ impl SwarmScheduler for SupervisionScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start, self.config.concurrency_limit).await;
 
         let mut worker_context_lines: Vec<String> = Vec::new();
         for res in wave {

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -48,26 +48,44 @@ pub struct TaskExecutionResult {
     pub node_index: usize,
     pub outcome: TaskOutcome,
     pub wall_time: Duration,
+    /// Microseconds elapsed from scheduler start until this task began executing.
+    /// Zero for skipped tasks. Provides microsecond precision for accurate peak_concurrency computation.
+    #[serde(default)]
+    pub start_offset_us: u64,
     pub attempt: u32,
 }
 
 impl TaskExecutionResult {
-    fn success(task: &SwarmSubtask, idx: NodeIndex, output: String, elapsed: Duration) -> Self {
+    fn success(
+        task: &SwarmSubtask,
+        idx: NodeIndex,
+        output: String,
+        elapsed: Duration,
+        start_offset_us: u64,
+    ) -> Self {
         Self {
             task_id: task.id.clone(),
             node_index: idx.index(),
             outcome: TaskOutcome::Success(output),
             wall_time: elapsed,
+            start_offset_us,
             attempt: 1,
         }
     }
 
-    fn failure(task: &SwarmSubtask, idx: NodeIndex, error: String, elapsed: Duration) -> Self {
+    fn failure(
+        task: &SwarmSubtask,
+        idx: NodeIndex,
+        error: String,
+        elapsed: Duration,
+        start_offset_us: u64,
+    ) -> Self {
         Self {
             task_id: task.id.clone(),
             node_index: idx.index(),
             outcome: TaskOutcome::Failure(error),
             wall_time: elapsed,
+            start_offset_us,
             attempt: 1,
         }
     }
@@ -78,6 +96,7 @@ impl TaskExecutionResult {
             node_index: idx.index(),
             outcome: TaskOutcome::Skipped(reason),
             wall_time: Duration::ZERO,
+            start_offset_us: 0,
             attempt: 0,
         }
     }
@@ -118,6 +137,41 @@ impl SchedulerSummary {
             .filter_map(|r| r.outcome.output())
             .collect()
     }
+
+    /// Returns results sorted by `start_offset_us` — the order tasks actually began executing.
+    pub fn timeline(&self) -> Vec<&TaskExecutionResult> {
+        let mut ordered: Vec<&TaskExecutionResult> = self.results.iter().collect();
+        ordered.sort_by_key(|r| r.start_offset_us);
+        ordered
+    }
+
+    /// Maximum number of tasks that were executing concurrently at any instant.
+    /// Computed from `start_offset_us` and `wall_time` (microsecond precision internally);
+    /// skipped tasks are excluded.
+    pub fn peak_concurrency(&self) -> usize {
+        let mut events: Vec<(u64, i32)> = Vec::new();
+        for r in &self.results {
+            if matches!(r.outcome, TaskOutcome::Skipped(_)) {
+                continue;
+            }
+            let start = r.start_offset_us;
+            let duration = r.wall_time.as_micros().max(1) as u64;
+            let end = start + duration;
+            events.push((start, 1));
+            events.push((end, -1));
+        }
+        if events.is_empty() {
+            return 0;
+        }
+        events.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        let mut current = 0i32;
+        let mut peak = 0i32;
+        for (_, delta) in events {
+            current += delta;
+            peak = peak.max(current);
+        }
+        peak as usize
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -133,6 +187,9 @@ pub struct SwarmSchedulerConfig {
     pub task_timeout: Duration,
     pub failure_policy: FailurePolicy,
     pub concurrency_limit: Option<usize>,
+    /// When `true` the scheduler validates DAG topology and returns a summary showing
+    /// which tasks would execute in what order — without calling the executor at all.
+    pub dry_run: bool,
 }
 
 impl Default for SwarmSchedulerConfig {
@@ -141,6 +198,7 @@ impl Default for SwarmSchedulerConfig {
             task_timeout: Duration::from_secs(120),
             failure_policy: FailurePolicy::default(),
             concurrency_limit: None,
+            dry_run: false,
         }
     }
 }
@@ -200,6 +258,24 @@ impl SwarmScheduler for SequentialScheduler {
             GlobalError::runtime(format!("Sequential scheduling failed, DAG error: {e}"))
         })?;
 
+        if self.config.dry_run {
+            let mut results = Vec::with_capacity(ordered_indices.len());
+            for &idx in &ordered_indices {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: CoordinationPattern::Sequential,
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let mut results = Vec::with_capacity(total);
         let mut succeeded = 0usize;
         let mut failed = 0usize;
@@ -230,6 +306,7 @@ impl SwarmScheduler for SequentialScheduler {
             let task_snapshot = dag.get_task(idx).unwrap().clone();
             let task_id = task_snapshot.id.clone();
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             info!(task_id = %task_id, task_desc = %task_snapshot.description, "Executing node");
 
@@ -249,6 +326,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -261,6 +339,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         err_str,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
 
@@ -278,6 +357,7 @@ impl SwarmScheduler for SequentialScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
 
@@ -341,6 +421,25 @@ impl SwarmScheduler for ParallelScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let semaphore = self
             .config
             .concurrency_limit
@@ -377,6 +476,7 @@ impl SwarmScheduler for ParallelScheduler {
                 let exec = executor.clone();
                 let sem = semaphore.clone();
                 let timeout_dur = self.config.task_timeout;
+                let offset_ms = wall_start.elapsed().as_micros() as u64;
 
                 let fut = async move {
                     let _permit = if let Some(s) = sem {
@@ -392,18 +492,21 @@ impl SwarmScheduler for ParallelScheduler {
                             idx,
                             output,
                             start.elapsed(),
+                            offset_ms,
                         ),
                         Ok(Err(e)) => TaskExecutionResult::failure(
                             &task_snapshot,
                             idx,
                             e.to_string(),
                             start.elapsed(),
+                            offset_ms,
                         ),
                         Err(_) => TaskExecutionResult::failure(
                             &task_snapshot,
                             idx,
                             format!("timed out after {:?}", timeout_dur),
                             start.elapsed(),
+                            offset_ms,
                         ),
                     }
                 };
@@ -489,6 +592,7 @@ async fn run_parallel_wave(
     dag: &mut SubtaskDAG,
     executor: &SubtaskExecutorFn,
     timeout_dur: Duration,
+    sched_start: Instant,
 ) -> Vec<TaskExecutionResult> {
     let mut futures = Vec::with_capacity(indices.len());
 
@@ -496,21 +600,23 @@ async fn run_parallel_wave(
         dag.mark_running(idx);
         let task_snapshot = dag.get_task(idx).expect("missing idx").clone();
         let exec = executor.clone();
+        let offset_ms = sched_start.elapsed().as_micros() as u64;
 
         let fut = async move {
             let start = Instant::now();
             match timeout(timeout_dur, exec(idx, task_snapshot.clone())).await {
                 Ok(Ok(output)) => {
-                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed())
+                    TaskExecutionResult::success(&task_snapshot, idx, output, start.elapsed(), offset_ms)
                 }
                 Ok(Err(e)) => {
-                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed())
+                    TaskExecutionResult::failure(&task_snapshot, idx, e.to_string(), start.elapsed(), offset_ms)
                 }
                 Err(_) => TaskExecutionResult::failure(
                     &task_snapshot,
                     idx,
                     format!("timed out after {:?}", timeout_dur),
                     start.elapsed(),
+                    offset_ms,
                 ),
             }
         };
@@ -561,6 +667,25 @@ impl SwarmScheduler for MapReduceScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (map_idxs, reduce_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -575,7 +700,7 @@ impl SwarmScheduler for MapReduceScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&map_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut map_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -602,6 +727,7 @@ impl SwarmScheduler for MapReduceScheduler {
             let injected = inject_context(task_snapshot, "Map Phase Outputs", &map_outputs);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -612,6 +738,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -625,6 +752,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -638,6 +766,7 @@ impl SwarmScheduler for MapReduceScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -696,6 +825,25 @@ impl SwarmScheduler for DebateScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (debater_idxs, judge_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -710,7 +858,7 @@ impl SwarmScheduler for DebateScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&debater_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut debate_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -737,6 +885,7 @@ impl SwarmScheduler for DebateScheduler {
             let injected = inject_context(task_snapshot, "Debate Arguments", &debate_lines);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -747,6 +896,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -760,6 +910,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -773,6 +924,7 @@ impl SwarmScheduler for DebateScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -831,6 +983,25 @@ impl SwarmScheduler for ConsensusScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (voter_idxs, aggregator_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -845,7 +1016,7 @@ impl SwarmScheduler for ConsensusScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&voter_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut voter_outputs: Vec<String> = Vec::new();
         for res in wave {
@@ -897,6 +1068,7 @@ impl SwarmScheduler for ConsensusScheduler {
             }
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -907,6 +1079,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -920,6 +1093,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -933,6 +1107,7 @@ impl SwarmScheduler for ConsensusScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -991,6 +1166,25 @@ impl SwarmScheduler for RoutingScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let router_idxs: Vec<_> = all
             .iter()
@@ -1023,6 +1217,7 @@ impl SwarmScheduler for RoutingScheduler {
 
         dag.mark_running(router_idx);
         let router_snapshot = dag.get_task(router_idx).unwrap().clone();
+        let router_offset_ms = wall_start.elapsed().as_micros() as u64;
         let start = Instant::now();
         let router_output = match timeout(
             self.config.task_timeout,
@@ -1038,6 +1233,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     out.clone(),
                     elapsed,
+                    router_offset_ms,
                 ));
                 succeeded += 1;
                 out
@@ -1052,6 +1248,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     err,
                     elapsed,
+                    router_offset_ms,
                 ));
                 failed += 1;
                 for &idx in &specialist_idxs {
@@ -1083,6 +1280,7 @@ impl SwarmScheduler for RoutingScheduler {
                     router_idx,
                     msg,
                     elapsed,
+                    router_offset_ms,
                 ));
                 failed += 1;
                 for &idx in &specialist_idxs {
@@ -1141,6 +1339,7 @@ impl SwarmScheduler for RoutingScheduler {
         let injected = inject_context(spec_snapshot, "Router Output", &[router_output]);
         dag.mark_running(chosen_idx);
 
+        let spec_offset_ms = wall_start.elapsed().as_micros() as u64;
         let start = Instant::now();
         match timeout(self.config.task_timeout, executor(chosen_idx, injected)).await {
             Ok(Ok(output)) => {
@@ -1151,6 +1350,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     output,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 succeeded += 1;
             }
@@ -1164,6 +1364,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     err,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 failed += 1;
             }
@@ -1177,6 +1378,7 @@ impl SwarmScheduler for RoutingScheduler {
                     chosen_idx,
                     msg,
                     elapsed,
+                    spec_offset_ms,
                 ));
                 failed += 1;
             }
@@ -1234,6 +1436,25 @@ impl SwarmScheduler for SupervisionScheduler {
         let wall_start = Instant::now();
         let total = dag.task_count();
 
+        if self.config.dry_run {
+            let ordered = dag.topological_order().unwrap_or_default();
+            let mut results = Vec::with_capacity(ordered.len());
+            for &idx in &ordered {
+                let task = dag.get_task(idx).expect("missing idx").clone();
+                dag.mark_skipped(idx);
+                results.push(TaskExecutionResult::skipped(&task, idx, "dry_run".into()));
+            }
+            return Ok(SchedulerSummary {
+                pattern: self.pattern(),
+                total_tasks: total,
+                succeeded: 0,
+                failed: 0,
+                skipped: total,
+                total_wall_time: Duration::ZERO,
+                results,
+            });
+        }
+
         let all: Vec<NodeIndex> = dag.all_tasks().into_iter().map(|(idx, _)| idx).collect();
         let (worker_idxs, supervisor_idxs): (Vec<_>, Vec<_>) =
             all.iter().partition(|&&idx| dag.dependencies_of(idx).is_empty());
@@ -1248,7 +1469,7 @@ impl SwarmScheduler for SupervisionScheduler {
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout).await;
+        let wave = run_parallel_wave(&worker_idxs, dag, &executor, self.config.task_timeout, wall_start).await;
 
         let mut worker_context_lines: Vec<String> = Vec::new();
         for res in wave {
@@ -1276,6 +1497,7 @@ impl SwarmScheduler for SupervisionScheduler {
                 inject_context(task_snapshot, "Worker Results", &worker_context_lines);
             dag.mark_running(idx);
 
+            let offset_ms = wall_start.elapsed().as_micros() as u64;
             let start = Instant::now();
             match timeout(self.config.task_timeout, executor(idx, injected)).await {
                 Ok(Ok(output)) => {
@@ -1286,6 +1508,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         output,
                         elapsed,
+                        offset_ms,
                     ));
                     succeeded += 1;
                 }
@@ -1299,6 +1522,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         err,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -1312,6 +1536,7 @@ impl SwarmScheduler for SupervisionScheduler {
                         idx,
                         msg,
                         elapsed,
+                        offset_ms,
                     ));
                     failed += 1;
                 }
@@ -2165,6 +2390,93 @@ mod tests {
         assert!(
             peak.load(Ordering::SeqCst) >= 3,
             "all 3 mappers must run in parallel"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_skips_all_without_executing() {
+        let mut dag = SubtaskDAG::new("test");
+        dag.add_task(SwarmSubtask::new("a", "Task A"));
+        dag.add_task(SwarmSubtask::new("b", "Task B"));
+        dag.add_task(SwarmSubtask::new("c", "Task C"));
+
+        let called = Arc::new(AtomicUsize::new(0));
+        let c = called.clone();
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, _task| {
+            c.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok("should not run".into()) })
+        });
+
+        let config = SwarmSchedulerConfig { dry_run: true, ..Default::default() };
+        let summary = ParallelScheduler::with_config(config)
+            .execute(&mut dag, executor)
+            .await
+            .unwrap();
+
+        assert_eq!(called.load(Ordering::SeqCst), 0, "executor must never be called in dry_run");
+        assert_eq!(summary.skipped, 3);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.total_wall_time, Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_timeline_sequential_tasks_have_increasing_offsets() {
+        let mut dag = SubtaskDAG::new("test");
+        let a = dag.add_task(SwarmSubtask::new("a", "Task A"));
+        let b = dag.add_task(SwarmSubtask::new("b", "Task B"));
+        let c = dag.add_task(SwarmSubtask::new("c", "Task C"));
+        dag.add_dependency(a, b).unwrap();
+        dag.add_dependency(b, c).unwrap();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let id = task.id.clone();
+            Box::pin(async move {
+                sleep(Duration::from_millis(20)).await;
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let summary = SequentialScheduler::new().execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        let tl = summary.timeline();
+        assert_eq!(tl.len(), 3);
+        assert!(
+            tl[0].start_offset_us <= tl[1].start_offset_us,
+            "a must start before b"
+        );
+        assert!(
+            tl[1].start_offset_us <= tl[2].start_offset_us,
+            "b must start before c"
+        );
+        assert!(
+            summary.peak_concurrency() <= 1,
+            "sequential never exceeds 1 concurrent task"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_peak_concurrency_parallel_tasks() {
+        let mut dag = SubtaskDAG::new("test");
+        dag.add_task(SwarmSubtask::new("p1", "Task 1"));
+        dag.add_task(SwarmSubtask::new("p2", "Task 2"));
+        dag.add_task(SwarmSubtask::new("p3", "Task 3"));
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let id = task.id.clone();
+            Box::pin(async move {
+                sleep(Duration::from_millis(30)).await;
+                Ok(format!("{}-done", id))
+            })
+        });
+
+        let summary = ParallelScheduler::new().execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert_eq!(
+            summary.peak_concurrency(),
+            3,
+            "all 3 independent tasks run concurrently"
         );
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -1562,6 +1562,21 @@ mod tests {
 
         let par = CoordinationPattern::Parallel.into_scheduler();
         assert_eq!(par.pattern(), CoordinationPattern::Parallel);
+
+        let mr = CoordinationPattern::MapReduce.into_scheduler();
+        assert_eq!(mr.pattern(), CoordinationPattern::MapReduce);
+
+        let deb = CoordinationPattern::Debate.into_scheduler();
+        assert_eq!(deb.pattern(), CoordinationPattern::Debate);
+
+        let con = CoordinationPattern::Consensus.into_scheduler();
+        assert_eq!(con.pattern(), CoordinationPattern::Consensus);
+
+        let rou = CoordinationPattern::Routing.into_scheduler();
+        assert_eq!(rou.pattern(), CoordinationPattern::Routing);
+
+        let sup = CoordinationPattern::Supervision.into_scheduler();
+        assert_eq!(sup.pattern(), CoordinationPattern::Supervision);
     }
 
     #[tokio::test]
@@ -2101,5 +2116,46 @@ mod tests {
         let desc = sup_desc.lock().await;
         assert!(desc.contains("FAILED"), "supervisor must see FAILED label for failed worker");
         assert!(desc.contains("worker-b"), "supervisor must see failed worker id");
+    }
+
+    #[tokio::test]
+    async fn test_mapreduce_mappers_run_in_parallel() {
+        let mut dag = SubtaskDAG::new("test");
+        let m1 = dag.add_task(SwarmSubtask::new("mapper-a", "Map A"));
+        let m2 = dag.add_task(SwarmSubtask::new("mapper-b", "Map B"));
+        let m3 = dag.add_task(SwarmSubtask::new("mapper-c", "Map C"));
+        let r = dag.add_task(SwarmSubtask::new("reducer", "Reduce"));
+        dag.add_dependency(m1, r).unwrap();
+        dag.add_dependency(m2, r).unwrap();
+        dag.add_dependency(m3, r).unwrap();
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let a = active.clone();
+        let p = peak.clone();
+
+        let executor: SubtaskExecutorFn = Arc::new(move |_idx, task| {
+            let a = a.clone();
+            let p = p.clone();
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id != "reducer" {
+                    let current = a.fetch_add(1, Ordering::SeqCst) + 1;
+                    p.fetch_max(current, Ordering::SeqCst);
+                    sleep(Duration::from_millis(30)).await;
+                    a.fetch_sub(1, Ordering::SeqCst);
+                }
+                Ok(format!("{}-out", id))
+            })
+        });
+
+        let scheduler = MapReduceScheduler::new();
+        let summary = scheduler.execute(&mut dag, executor).await.unwrap();
+
+        assert!(summary.is_fully_successful());
+        assert!(
+            peak.load(Ordering::SeqCst) >= 3,
+            "all 3 mappers must run in parallel"
+        );
     }
 }

--- a/crates/mofa-foundation/src/swarm/scheduler.rs
+++ b/crates/mofa-foundation/src/swarm/scheduler.rs
@@ -1116,9 +1116,13 @@ impl SwarmScheduler for RoutingScheduler {
 
         let chosen_idx = if let Some(&idx) = matched_idx {
             idx
-        } else {
+        } else if let Some(&first) = specialist_idxs.first() {
             warn!("no capability match found; falling back to first specialist");
-            specialist_idxs[0]
+            first
+        } else {
+            return Err(GlobalError::runtime(
+                "Routing pattern requires at least one specialist task",
+            ));
         };
 
         for &idx in &specialist_idxs {

--- a/crates/mofa-foundation/tests/swarm_hitl_gate_integration.rs
+++ b/crates/mofa-foundation/tests/swarm_hitl_gate_integration.rs
@@ -203,10 +203,8 @@ async fn test_gate_rejects_task_on_reviewer_rejection() {
         },
     );
 
-    let cfg = SwarmSchedulerConfig {
-        failure_policy: FailurePolicy::Continue,
-        ..Default::default()
-    };
+    let mut cfg = SwarmSchedulerConfig::default();
+    cfg.failure_policy = FailurePolicy::Continue;
     let summary = SequentialScheduler::with_config(cfg)
         .execute(&mut dag, executor)
         .await
@@ -402,10 +400,8 @@ async fn test_gate_metrics_track_decisions_correctly() {
         }
     });
 
-    let cfg = SwarmSchedulerConfig {
-        failure_policy: FailurePolicy::Continue,
-        ..Default::default()
-    };
+    let mut cfg = SwarmSchedulerConfig::default();
+    cfg.failure_policy = FailurePolicy::Continue;
     let summary = SequentialScheduler::with_config(cfg)
         .execute(&mut dag, executor)
         .await

--- a/docs/tutorial/06-multi-agent.md
+++ b/docs/tutorial/06-multi-agent.md
@@ -408,7 +408,7 @@ dag.add_dependency(c, verdict)?;
 let summary = ConsensusScheduler::new().execute(&mut dag, executor).await?;
 ```
 
-Voters run in parallel. The scheduler counts exact string matches across voter outputs, then prepends `## Majority Candidate\n{candidate}` to the aggregator's description when a strict majority exists (count > 1 and count is maximal).
+Voters run in parallel. The scheduler counts exact string matches across voter outputs. A **strict majority** requires the winning candidate to have more than half of all votes with no ties (`count × 2 > total_voters`). When a strict majority exists, `## Majority Candidate\n{candidate}` is prepended to the aggregator's description; otherwise all voter outputs are still injected and the aggregator decides.
 
 ---
 

--- a/docs/tutorial/06-multi-agent.md
+++ b/docs/tutorial/06-multi-agent.md
@@ -318,6 +318,183 @@ pub enum TeamPattern {
 
 > **Architecture note:** `AgentTeam` lives in `mofa-foundation` (`crates/mofa-foundation/src/llm/multi_agent.rs`). It implements the `Coordinator` trait from `mofa-kernel` internally. See `examples/multi_agent_coordination/src/main.rs` and `examples/adaptive_collaboration_agent/src/main.rs` for complete working examples.
 
+## Phase 2: Advanced Coordination Patterns
+
+The `SwarmScheduler` trait in `mofa-foundation` provides five additional patterns beyond sequential and parallel. Each targets a distinct coordination problem.
+
+### MapReduce
+
+**When to use:** You have a large input that can be split into uniform chunks, each processed independently, and then merged. Classic for document summarization, batch data processing, and parallel search.
+
+```mermaid
+graph LR
+    S1[section-1] --> R[final-summary]
+    S2[section-2] --> R
+    S3[section-3] --> R
+    S4[section-4] --> R
+```
+
+```rust
+let mut dag = SubtaskDAG::new("document-summarization");
+
+let s1 = dag.add_task(SwarmSubtask::new("section-1", "Summarize Introduction"));
+let s2 = dag.add_task(SwarmSubtask::new("section-2", "Summarize Methodology"));
+let s3 = dag.add_task(SwarmSubtask::new("section-3", "Summarize Experiments"));
+let s4 = dag.add_task(SwarmSubtask::new("section-4", "Summarize Conclusion"));
+let reducer = dag.add_task(SwarmSubtask::new("final-summary", "Merge all section summaries"));
+
+dag.add_dependency(s1, reducer)?;
+dag.add_dependency(s2, reducer)?;
+dag.add_dependency(s3, reducer)?;
+dag.add_dependency(s4, reducer)?;
+
+let summary = MapReduceScheduler::new().execute(&mut dag, executor).await?;
+```
+
+The scheduler runs all mappers in parallel, then injects their outputs into the reducer's `description` field under a `## Map Phase Outputs` heading before calling the executor on it.
+
+---
+
+### Debate
+
+**When to use:** You want two or more agents to argue opposing positions before a judge synthesizes the best answer. Use for architecture decisions, risk analysis, and peer review workflows where adversarial pressure improves quality.
+
+```mermaid
+graph LR
+    D1[microservices-advocate] --> J[chief-architect]
+    D2[monolith-advocate] --> J
+```
+
+```rust
+let mut dag = SubtaskDAG::new("architecture-debate");
+
+let pro = dag.add_task(SwarmSubtask::new("microservices-advocate", "Argue for microservices"));
+let con = dag.add_task(SwarmSubtask::new("monolith-advocate", "Argue for monolith"));
+let judge = dag.add_task(SwarmSubtask::new("chief-architect", "Issue architecture decision"));
+
+dag.add_dependency(pro, judge)?;
+dag.add_dependency(con, judge)?;
+
+let summary = DebateScheduler::new().execute(&mut dag, executor).await?;
+```
+
+Debaters run in parallel. Each debater's output is formatted as `**{task_id}:** {output}` and injected into the judge's description under `## Debate Arguments`.
+
+---
+
+### Consensus
+
+**When to use:** Multiple independent agents each produce a label or classification; you want the majority vote to win. Use for sentiment analysis, fact-checking, and any scenario where a single model's confidence is insufficient.
+
+```mermaid
+graph LR
+    V1[classifier-a] --> A[verdict]
+    V2[classifier-b] --> A
+    V3[classifier-c] --> A
+```
+
+```rust
+let mut dag = SubtaskDAG::new("sentiment-consensus");
+
+let a = dag.add_task(SwarmSubtask::new("classifier-a", "Classify sentiment via BERT"));
+let b = dag.add_task(SwarmSubtask::new("classifier-b", "Classify sentiment via RoBERTa"));
+let c = dag.add_task(SwarmSubtask::new("classifier-c", "Classify sentiment via GPT"));
+let verdict = dag.add_task(SwarmSubtask::new("verdict", "Return majority sentiment"));
+
+dag.add_dependency(a, verdict)?;
+dag.add_dependency(b, verdict)?;
+dag.add_dependency(c, verdict)?;
+
+let summary = ConsensusScheduler::new().execute(&mut dag, executor).await?;
+```
+
+Voters run in parallel. The scheduler counts exact string matches across voter outputs, then prepends `## Majority Candidate\n{candidate}` to the aggregator's description when a strict majority exists (count > 1 and count is maximal).
+
+---
+
+### Routing
+
+**When to use:** A classifier or router agent must inspect input and dispatch it to exactly one specialist. Use for customer support triage, query routing, and intent-based dispatch where only one handler is appropriate.
+
+```mermaid
+graph LR
+    R[ticket-classifier] --> B[billing-agent]
+    R --> T[technical-agent]
+    R --> G[general-agent]
+    style B fill:#90EE90
+    style T fill:#FFB6C1
+    style G fill:#FFB6C1
+```
+
+```rust
+let mut dag = SubtaskDAG::new("support-ticket-routing");
+
+let classifier = dag.add_task(SwarmSubtask::new("ticket-classifier", "Classify the support ticket"));
+
+let mut billing = SwarmSubtask::new("billing-agent", "Handle billing disputes");
+billing.required_capabilities = vec!["billing".into()];
+let billing_idx = dag.add_task(billing);
+
+let mut technical = SwarmSubtask::new("technical-agent", "Handle technical bugs");
+technical.required_capabilities = vec!["technical".into(), "bug".into()];
+let technical_idx = dag.add_task(technical);
+
+dag.add_dependency(classifier, billing_idx)?;
+dag.add_dependency(classifier, technical_idx)?;
+
+let summary = RoutingScheduler::new().execute(&mut dag, executor).await?;
+// summary.skipped == 1: only the matched specialist runs
+```
+
+The router runs first. Its output string is matched case-insensitively against each specialist's `required_capabilities`. The first matching specialist runs; all others are marked `Skipped`. If no capability matches, the first specialist is used as a fallback.
+
+---
+
+### Supervision
+
+**When to use:** Workers may fail, and a supervisor must always run to handle recovery, alerting, or partial-result aggregation regardless of worker outcomes. Use for distributed data pipelines, batch jobs, and any fault-tolerant processing workflow.
+
+```mermaid
+graph LR
+    W1[shard-a] --> S[recovery-coordinator]
+    W2[shard-b] --> S
+    W3[shard-c] --> S
+    style W2 fill:#FFB6C1
+```
+
+```rust
+let mut dag = SubtaskDAG::new("resilient-data-pipeline");
+
+let a = dag.add_task(SwarmSubtask::new("shard-a", "Process partition A"));
+let b = dag.add_task(SwarmSubtask::new("shard-b", "Process partition B"));
+let c = dag.add_task(SwarmSubtask::new("shard-c", "Process partition C"));
+let supervisor = dag.add_task(SwarmSubtask::new("recovery-coordinator", "Review and recover"));
+
+dag.add_dependency(a, supervisor)?;
+dag.add_dependency(b, supervisor)?;
+dag.add_dependency(c, supervisor)?;
+
+let summary = SupervisionScheduler::new().execute(&mut dag, shard_executor).await?;
+```
+
+Workers run in parallel. Regardless of individual success or failure, the supervisor always executes. Each worker's outcome is injected as `{task_id} (SUCCESS): {output}` or `{task_id} (FAILED): {error}` under `## Worker Results` in the supervisor's description.
+
+---
+
+### Pattern Decision Guide
+
+| Pattern | Pick when... | Avoid when... |
+|---------|-------------|--------------|
+| **Sequential** | Stages have data dependencies; output of one stage is input to the next | Tasks are independent and you want maximum throughput |
+| **Parallel** | Subtasks are fully independent and all results are needed before proceeding | Tasks depend on each other's outputs |
+| **MapReduce** | Input can be partitioned uniformly; reduction is associative or commutative | Chunks have wildly different sizes or the reduce step must be incremental |
+| **Debate** | Adversarial critique improves answer quality; you need a reasoned synthesis | Debaters share the same perspective or the task has one objectively correct answer |
+| **Consensus** | You need majority agreement across independent models to reduce individual error | All agents share the same underlying model (no diversity benefit) |
+| **Routing** | Exactly one specialist should handle a request based on content inspection | Multiple specialists must collaborate or all specialists must run |
+| **Supervision** | Workers may fail and recovery or aggregation must always execute | All workers must succeed for the pipeline to be meaningful |
+
+---
+
 ## What Just Happened?
 
 In the chain example:

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -103,7 +103,7 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -226,15 +226,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -387,476 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-config"
-version = "1.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 1.4.0",
- "sha1",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
-name = "aws-runtime"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "bytes-utils",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.119.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-checksums",
- "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "lru 0.12.5",
- "percent-encoding",
- "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.101.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
- "aws-smithy-observability",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "crypto-bigint 0.5.5",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.4.0",
- "p256",
- "percent-encoding",
- "ring",
- "sha2",
- "subtle",
- "time",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.63.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
-dependencies = [
- "aws-smithy-http 0.62.6",
- "aws-smithy-types",
- "bytes",
- "crc-fast",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
-dependencies = [
- "aws-smithy-types",
- "bytes",
- "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.62.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.63.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http-client"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
- "hyper-util",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.62.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-observability"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
-dependencies = [
- "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-http-client",
- "aws-smithy-observability",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
- "pin-utils",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.4.0",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,16 +398,15 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
  "memchr",
  "mime",
- "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -904,8 +433,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -942,12 +471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,16 +481,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
 
 [[package]]
 name = "base64ct"
@@ -1161,16 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
-
-[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1285,7 +788,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -1365,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1375,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1387,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1399,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "claw_demo"
@@ -1414,7 +917,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -1433,7 +936,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -1484,16 +987,7 @@ dependencies = [
  "mofa-plugins",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -1513,14 +1007,14 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -1602,7 +1096,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -1678,7 +1172,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -1702,7 +1196,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -1983,19 +1477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc-fast"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
-dependencies = [
- "crc",
- "digest",
- "rand 0.9.2",
- "regex",
- "rustversion",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,7 +1507,7 @@ dependencies = [
  "mofa-runtime",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -2105,28 +1586,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "crypto-common"
@@ -2292,16 +1751,6 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
 
 [[package]]
 name = "der"
@@ -2527,28 +1976,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve",
- "rfc6979",
- "signature 1.6.4",
-]
 
 [[package]]
 name = "either"
@@ -2557,26 +1988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2616,10 +2027,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "rand 0.8.5",
@@ -2698,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.14"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
 dependencies = [
  "num-traits",
 ]
@@ -2758,16 +2169,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "filedescriptor"
@@ -2914,12 +2315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,20 +2443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gateway_socketio_s3"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "mofa-gateway",
- "mofa-integrations",
- "mofa-kernel",
- "mofa-runtime",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,36 +2535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3194,7 +2545,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -3285,7 +2636,7 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs 6.0.0",
  "futures",
- "http 1.4.0",
+ "http",
  "indicatif",
  "libc",
  "log",
@@ -3310,7 +2661,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -3328,7 +2679,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -3367,17 +2718,6 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -3388,23 +2728,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -3415,8 +2744,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3449,30 +2778,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -3481,9 +2786,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3496,33 +2801,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -3533,7 +2823,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3548,7 +2838,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3566,9 +2856,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3751,32 +3041,36 @@ dependencies = [
 
 [[package]]
 name = "include-flate"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a05fb00d9abc625268e0573a519506b264a7d6965de09bac13201bfb44e723d"
+checksum = "e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998"
 dependencies = [
  "include-flate-codegen",
  "include-flate-compress",
+ "libflate",
+ "zstd",
 ]
 
 [[package]]
 name = "include-flate-codegen"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3c319a7527668538a8530c541e74e881e94c4f41e1425622d0a41c16468af"
+checksum = "4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050"
 dependencies = [
  "include-flate-compress",
- "proc-macro-error2",
+ "libflate",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "zstd",
 ]
 
 [[package]]
 name = "include-flate-compress"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0bd9ea81b94169d61c5a397e9faef02153d3711fc62d3270bcde3ac85380d9"
+checksum = "eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc"
 dependencies = [
  "libflate",
  "zstd",
@@ -3872,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -3904,7 +3198,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4088,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -4286,7 +3580,7 @@ dependencies = [
  "rodio",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -4314,16 +3608,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4430,7 +3715,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4602,7 +3887,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.23",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "zip",
 ]
 
@@ -4646,8 +3931,6 @@ dependencies = [
  "mofa-kernel",
  "mofa-plugins",
  "once_cell",
- "opentelemetry 0.27.1",
- "opentelemetry-semantic-conventions",
  "parking_lot",
  "petgraph 0.7.1",
  "qdrant-client",
@@ -4684,11 +3967,9 @@ dependencies = [
  "eyre",
  "futures",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "mime_guess",
  "mofa-foundation",
- "mofa-integrations",
  "mofa-kernel",
  "mofa-runtime",
  "parking_lot",
@@ -4698,7 +3979,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "socketioxide",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -4706,7 +3986,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -4715,11 +3995,8 @@ name = "mofa-integrations"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "aws-config",
- "aws-sdk-s3",
  "axum",
  "bincode 1.3.3",
- "chrono",
  "hex",
  "mofa-kernel",
  "serde",
@@ -4892,24 +4169,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.4.0",
- "httparse",
- "memchr",
- "mime",
- "spin 0.9.8",
- "version_check",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4924,7 +4184,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -4966,7 +4226,7 @@ dependencies = [
  "mofa-runtime",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -5229,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -5239,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5316,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "portable-atomic",
 ]
@@ -5331,9 +4591,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -5363,86 +4623,14 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
-dependencies = [
- "futures-core",
- "futures-sink",
- "indexmap 2.13.0",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
-
-[[package]]
-name = "opentelemetry-stdout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13b2df4cd59c176099ac82806725ba340c8fa7b1a7004c0912daad30470f63e"
-dependencies = [
- "chrono",
- "futures-util",
- "opentelemetry 0.21.0",
- "opentelemetry_sdk",
- "ordered-float",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry 0.21.0",
- "ordered-float",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -5493,23 +4681,6 @@ dependencies = [
  "sha2",
  "tar",
  "ureq 3.2.0",
-]
-
-[[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2",
 ]
 
 [[package]]
@@ -5796,19 +4967,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -5817,8 +4978,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5842,7 +5003,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -5853,9 +5014,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -5912,29 +5073,31 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+ "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error-attr"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "version_check",
 ]
 
 [[package]]
@@ -5958,20 +5121,6 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
-]
-
-[[package]]
-name = "production_observability"
-version = "0.1.0"
-dependencies = [
- "mofa-foundation",
- "mofa-sdk",
- "opentelemetry 0.21.0",
- "opentelemetry-stdout",
- "opentelemetry_sdk",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6097,7 +5246,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -6117,7 +5266,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6163,9 +5312,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ractor"
-version = "0.15.12"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a64ac8ba2e8d71b25c55ab7acafc481ae4c9175f3ee8f7c36b66c4cad369bb5"
+checksum = "a73286ad2e0ac0e0d0d895785c697f79fbd945acf90b9e2e9c85d5987c690563"
 dependencies = [
  "bon",
  "dashmap 6.1.0",
@@ -6202,7 +5351,7 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6327,7 +5476,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.3",
+ "lru",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -6441,7 +5590,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6513,7 +5662,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6563,12 +5712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6591,12 +5734,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -6607,7 +5750,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -6616,7 +5759,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -6654,19 +5797,8 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
 ]
 
 [[package]]
@@ -6706,7 +5838,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6719,7 +5851,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6816,10 +5948,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -6832,7 +5964,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6935,28 +6067,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -6994,21 +6113,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7037,9 +6145,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -7077,30 +6185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7119,7 +6203,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -7348,16 +6432,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -7461,9 +6535,9 @@ dependencies = [
  "engineioxide",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "matchit 0.8.6",
  "pin-project-lite",
  "rustversion",
@@ -7529,22 +6603,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -7763,7 +6827,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -7776,7 +6840,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -7858,10 +6922,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "swarm_hitl_gate"
+name = "swarm_coordination_patterns"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "mofa-foundation",
  "mofa-kernel",
  "tokio",
@@ -8041,9 +7106,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -8267,9 +7332,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8321,21 +7386,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -8423,7 +7478,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -8446,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
@@ -8464,28 +7519,28 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -8496,9 +7551,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -8512,11 +7567,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -8526,7 +7581,7 @@ dependencies = [
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -8606,8 +7661,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -8735,9 +7790,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers 0.2.0",
  "nu-ansi-term",
@@ -8769,7 +7824,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -8881,7 +7936,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8897,7 +7952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
- "der 0.7.10",
+ "der",
  "log",
  "native-tls",
  "percent-encoding",
@@ -8915,7 +7970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
 ]
@@ -8931,12 +7986,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -9002,14 +8051,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -9212,7 +8255,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "wasmtime",
 ]
 
@@ -10240,15 +9283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10367,7 +9401,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -10378,7 +9412,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -10395,7 +9429,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber 0.3.22",
  "uuid",
 ]
 
@@ -10414,12 +9448,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"
@@ -10466,18 +9494,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4919,7 +4919,7 @@ name = "pii_only"
 version = "0.1.0"
 dependencies = [
  "mofa-foundation",
- "mofa-runtime",
+ "mofa-kernel",
  "tokio",
 ]
 
@@ -5577,7 +5577,7 @@ name = "rbac_only"
 version = "0.1.0"
 dependencies = [
  "mofa-foundation",
- "mofa-runtime",
+ "mofa-kernel",
  "tokio",
 ]
 
@@ -6211,7 +6211,7 @@ name = "secure_agent"
 version = "0.1.0"
 dependencies = [
  "mofa-foundation",
- "mofa-runtime",
+ "mofa-kernel",
  "tokio",
 ]
 
@@ -6920,6 +6920,19 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "swarm_coordination_patterns"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "mofa-foundation",
+ "mofa-kernel",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
 
 [[package]]
 name = "swarm_orchestrator"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -103,7 +103,7 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -226,15 +226,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -387,6 +387,476 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.119.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru 0.12.5",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+dependencies = [
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,15 +868,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -433,8 +904,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -471,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +958,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -674,6 +1161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -788,7 +1285,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -868,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -878,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -890,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -902,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claw_demo"
@@ -917,7 +1414,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -936,7 +1433,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -987,7 +1484,16 @@ dependencies = [
  "mofa-plugins",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1007,14 +1513,14 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1096,7 +1602,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -1172,7 +1678,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -1196,7 +1702,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -1477,6 +1983,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+dependencies = [
+ "crc",
+ "digest",
+ "rand 0.9.2",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,7 +2026,7 @@ dependencies = [
  "mofa-runtime",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -1586,6 +2105,28 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1751,6 +2292,16 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "der"
@@ -1976,10 +2527,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
 
 [[package]]
 name = "either"
@@ -1988,6 +2557,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2027,10 +2616,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "rand 0.8.5",
@@ -2109,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -2169,6 +2758,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -2315,6 +2914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,6 +3048,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway_socketio_s3"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mofa-gateway",
+ "mofa-integrations",
+ "mofa-kernel",
+ "mofa-runtime",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +3154,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,7 +3194,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2636,7 +3285,7 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs 6.0.0",
  "futures",
- "http",
+ "http 1.4.0",
  "indicatif",
  "libc",
  "log",
@@ -2661,7 +3310,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -2679,7 +3328,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -2718,6 +3367,17 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2728,12 +3388,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2744,8 +3415,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2778,6 +3449,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2786,9 +3481,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2801,18 +3496,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -2823,7 +3533,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2838,7 +3548,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2856,9 +3566,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3041,36 +3751,32 @@ dependencies = [
 
 [[package]]
 name = "include-flate"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998"
+checksum = "8a05fb00d9abc625268e0573a519506b264a7d6965de09bac13201bfb44e723d"
 dependencies = [
  "include-flate-codegen",
  "include-flate-compress",
- "libflate",
- "zstd",
 ]
 
 [[package]]
 name = "include-flate-codegen"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050"
+checksum = "92c3c319a7527668538a8530c541e74e881e94c4f41e1425622d0a41c16468af"
 dependencies = [
  "include-flate-compress",
- "libflate",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zstd",
 ]
 
 [[package]]
 name = "include-flate-compress"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc"
+checksum = "ed0bd9ea81b94169d61c5a397e9faef02153d3711fc62d3270bcde3ac85380d9"
 dependencies = [
  "libflate",
  "zstd",
@@ -3166,9 +3872,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -3198,7 +3904,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3382,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -3580,7 +4286,7 @@ dependencies = [
  "rodio",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -3608,7 +4314,16 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3715,7 +4430,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3887,7 +4602,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.23",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "zip",
 ]
 
@@ -3931,6 +4646,8 @@ dependencies = [
  "mofa-kernel",
  "mofa-plugins",
  "once_cell",
+ "opentelemetry 0.27.1",
+ "opentelemetry-semantic-conventions",
  "parking_lot",
  "petgraph 0.7.1",
  "qdrant-client",
@@ -3967,9 +4684,11 @@ dependencies = [
  "eyre",
  "futures",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
+ "mime_guess",
  "mofa-foundation",
+ "mofa-integrations",
  "mofa-kernel",
  "mofa-runtime",
  "parking_lot",
@@ -3979,6 +4698,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "socketioxide",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -3986,7 +4706,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -3995,8 +4715,11 @@ name = "mofa-integrations"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "axum",
  "bincode 1.3.3",
+ "chrono",
  "hex",
  "mofa-kernel",
  "serde",
@@ -4169,7 +4892,24 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -4184,7 +4924,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -4226,7 +4966,7 @@ dependencies = [
  "mofa-runtime",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -4489,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -4499,9 +5239,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4576,9 +5316,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "portable-atomic",
 ]
@@ -4591,9 +5331,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -4623,14 +5363,86 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.13.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13b2df4cd59c176099ac82806725ba340c8fa7b1a7004c0912daad30470f63e"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4681,6 +5493,23 @@ dependencies = [
  "sha2",
  "tar",
  "ureq 3.2.0",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -4967,9 +5796,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -4978,8 +5817,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -5003,7 +5842,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5014,9 +5853,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -5073,31 +5912,29 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5121,6 +5958,20 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "production_observability"
+version = "0.1.0"
+dependencies = [
+ "mofa-foundation",
+ "mofa-sdk",
+ "opentelemetry 0.21.0",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -5246,7 +6097,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5266,7 +6117,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5312,9 +6163,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ractor"
-version = "0.15.11"
+version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73286ad2e0ac0e0d0d895785c697f79fbd945acf90b9e2e9c85d5987c690563"
+checksum = "4a64ac8ba2e8d71b25c55ab7acafc481ae4c9175f3ee8f7c36b66c4cad369bb5"
 dependencies = [
  "bon",
  "dashmap 6.1.0",
@@ -5351,7 +6202,7 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5476,7 +6327,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.3",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -5590,7 +6441,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5662,7 +6513,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5712,6 +6563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5734,12 +6591,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -5750,7 +6607,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -5759,7 +6616,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -5797,8 +6654,19 @@ dependencies = [
  "mofa-kernel",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -5838,7 +6706,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5851,7 +6719,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -5948,10 +6816,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -5964,7 +6832,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -6067,15 +6935,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -6113,10 +6994,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6145,9 +7037,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -6185,6 +7077,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6203,7 +7119,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -6432,6 +7348,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -6535,9 +7461,9 @@ dependencies = [
  "engineioxide",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "matchit 0.8.6",
  "pin-project-lite",
  "rustversion",
@@ -6603,12 +7529,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -6827,7 +7763,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -6840,7 +7776,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -6922,11 +7858,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "swarm_coordination_patterns"
+name = "swarm_hitl_gate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures",
  "mofa-foundation",
  "mofa-kernel",
  "tokio",
@@ -7106,9 +8041,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -7332,9 +8267,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7386,11 +8321,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -7478,7 +8423,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7501,9 +8446,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -7519,28 +8464,28 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -7551,9 +8496,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tonic"
@@ -7567,11 +8512,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7581,7 +8526,7 @@ dependencies = [
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -7661,8 +8606,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -7790,9 +8735,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers 0.2.0",
  "nu-ansi-term",
@@ -7824,7 +8769,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7936,7 +8881,7 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7952,7 +8897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
- "der",
+ "der 0.7.10",
  "log",
  "native-tls",
  "percent-encoding",
@@ -7970,7 +8915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -7986,6 +8931,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -8051,8 +9002,14 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -8255,7 +9212,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "wasmtime",
 ]
 
@@ -9283,6 +10240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9401,7 +10367,7 @@ dependencies = [
  "mofa-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -9412,7 +10378,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -9429,7 +10395,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -9448,6 +10414,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"
@@ -9494,18 +10466,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "claw_demo",
     "swarm_orchestrator",
     "swarm_hitl_gate",
+    "swarm_coordination_patterns",
 ]
 
 [workspace.package]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "resume_from_checkpoint",
     "claw_demo",
     "swarm_orchestrator",
+    "swarm_coordination_patterns",
 ]
 
 [workspace.package]

--- a/examples/swarm_coordination_patterns/Cargo.toml
+++ b/examples/swarm_coordination_patterns/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "swarm_coordination_patterns"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+futures = { workspace = true }
+anyhow = { workspace = true }

--- a/examples/swarm_coordination_patterns/src/bin/combined_moderation_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/combined_moderation_pipeline.rs
@@ -1,0 +1,201 @@
+//! Combined example: Routing + Supervision
+//!
+//! Scenario: Content moderation pipeline
+//!
+//! Phase 1 (Routing): A classifier reads the submission and routes it to
+//!   the correct specialist — text, image, or video review agent.
+//!
+//! Phase 2 (Supervision): The chosen specialist runs alongside a policy
+//!   checker. If either fails, a compliance officer (supervisor) reviews
+//!   all outcomes and issues a final ruling.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin combined_moderation_pipeline
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    RoutingScheduler, SubtaskDAG, SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler,
+    SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Combined Pipeline: Routing + Supervision ===");
+    println!("Scenario: Content moderation for a user submission\n");
+
+    let specialist_output = run_phase1_routing().await?;
+    run_phase2_supervision(specialist_output).await?;
+
+    println!("\n=== Pipeline Complete ===");
+    Ok(())
+}
+
+async fn run_phase1_routing() -> Result<String> {
+    println!("--- Phase 1: Routing - classify and dispatch submission ---");
+
+    let mut dag = SubtaskDAG::new("content-routing");
+
+    let router = dag.add_task(SwarmSubtask::new(
+        "content_classifier",
+        "Read the submission and identify its media type",
+    ));
+
+    let mut text_agent = SwarmSubtask::new("text_reviewer", "Review text for policy violations");
+    text_agent.required_capabilities = vec!["text".into()];
+    let idx_text = dag.add_task(text_agent);
+
+    let mut image_agent = SwarmSubtask::new("image_reviewer", "Review image for policy violations");
+    image_agent.required_capabilities = vec!["image".into()];
+    let idx_image = dag.add_task(image_agent);
+
+    let mut video_agent = SwarmSubtask::new("video_reviewer", "Review video for policy violations");
+    video_agent.required_capabilities = vec!["video".into()];
+    let idx_video = dag.add_task(video_agent);
+
+    dag.add_dependency(router, idx_text)?;
+    dag.add_dependency(router, idx_image)?;
+    dag.add_dependency(router, idx_video)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                match id.as_str() {
+                    "content_classifier" => Ok(
+                        "submission type: text — blog post flagged for potential misinformation".into(),
+                    ),
+                    "text_reviewer" => Ok(
+                        "text_review_complete: 3 claims require fact-check, 0 hate-speech markers, recommend human review".into(),
+                    ),
+                    "image_reviewer" => Ok("image_review_complete: no violations".into()),
+                    "video_reviewer" => Ok("video_review_complete: no violations".into()),
+                    _ => Ok(format!("{}: done", id)),
+                }
+            })
+        });
+
+    let summary = RoutingScheduler::new()
+        .execute(&mut dag, executor)
+        .await?;
+
+    println!("Classifier output:");
+    let router_result = summary.results.iter().find(|r| r.task_id == "content_classifier");
+    if let Some(r) = router_result {
+        println!("  [OK] content_classifier -> {}", r.outcome.output().unwrap_or(""));
+    }
+
+    println!("\nSpecialist routing:");
+    for r in &summary.results {
+        if r.task_id == "content_classifier" {
+            continue;
+        }
+        let label = match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Success(s) => format!("[SELECTED] {}", s),
+            mofa_foundation::swarm::TaskOutcome::Skipped(_) => "[SKIPPED]".into(),
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => format!("[FAIL] {}", e),
+        };
+        println!("  {} -> {}", r.task_id, label);
+    }
+
+    println!(
+        "\nPhase 1 complete: succeeded={} skipped={}",
+        summary.succeeded, summary.skipped
+    );
+
+    let specialist_output = summary
+        .results
+        .iter()
+        .find(|r| r.outcome.is_success() && r.task_id != "content_classifier")
+        .and_then(|r| r.outcome.output())
+        .unwrap_or("no specialist output")
+        .to_string();
+
+    Ok(specialist_output)
+}
+
+async fn run_phase2_supervision(specialist_context: String) -> Result<()> {
+    println!("\n--- Phase 2: Supervision - policy check with fault recovery ---");
+    println!("Specialist finding fed into supervision phase: {}\n", specialist_context);
+
+    let mut dag = SubtaskDAG::new("moderation-supervision");
+
+    let w1 = dag.add_task(SwarmSubtask::new(
+        "fact_checker",
+        "Verify the 3 flagged claims against trusted sources",
+    ));
+    let w2 = dag.add_task(SwarmSubtask::new(
+        "policy_checker",
+        "Apply community guidelines rulebook to the submission",
+    ));
+    let supervisor = dag.add_task(SwarmSubtask::new(
+        "compliance_officer",
+        "Review all findings and issue final moderation ruling",
+    ));
+
+    dag.add_dependency(w1, supervisor)?;
+    dag.add_dependency(w2, supervisor)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                match id.as_str() {
+                    "fact_checker" => Err(mofa_kernel::agent::types::error::GlobalError::runtime(
+                        "fact_check_unavailable: external knowledge base API timeout",
+                    )),
+                    "policy_checker" => Ok(
+                        "policy_check_passed: no explicit guideline violations detected".into(),
+                    ),
+                    "compliance_officer" => {
+                        Ok("ruling: send_to_human_review — fact-check service unavailable, cannot auto-approve".into())
+                    }
+                    _ => Ok(format!("{}: done", id)),
+                }
+            })
+        });
+
+    let summary = SupervisionScheduler::new()
+        .execute(&mut dag, executor)
+        .await?;
+
+    println!("Worker outcomes:");
+    for r in &summary.results {
+        if r.task_id == "compliance_officer" {
+            continue;
+        }
+        let label = if r.outcome.is_success() { "SUCCESS" } else { "FAILED " };
+        let detail = r
+            .outcome
+            .output()
+            .unwrap_or_else(|| match &r.outcome {
+                mofa_foundation::swarm::TaskOutcome::Failure(e) => e.as_str(),
+                _ => "",
+            });
+        println!("  [{}] {} -> {}", label, r.task_id, detail);
+    }
+
+    let ruling = summary
+        .results
+        .iter()
+        .find(|r| r.task_id == "compliance_officer");
+    if let Some(r) = ruling {
+        println!(
+            "\nCompliance officer ruling (always runs, even with partial failure):\n  [OK] {}",
+            r.outcome.output().unwrap_or("(no output)")
+        );
+    }
+
+    println!(
+        "\nPhase 2 complete: succeeded={} failed={}",
+        summary.succeeded, summary.failed
+    );
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/combined_research_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/combined_research_pipeline.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    DebateScheduler, MapReduceScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler,
+    SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn phase1_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "arxiv_agent" => {
+                    "arxiv_findings: 47 papers on LLM reasoning published Q4 2024; \
+                     chain-of-thought variants dominate, 3 papers challenge scaling assumptions".to_string()
+                }
+                "semantic_scholar_agent" => {
+                    "semantic_findings: citation graph shows 3 seminal papers with >1000 cites; \
+                     GPT-4 technical report is most referenced in reasoning benchmarks".to_string()
+                }
+                "web_crawler_agent" => {
+                    "web_findings: industry blogs report practitioners prefer few-shot prompting \
+                     over fine-tuning for reasoning tasks; tool use is emerging pattern".to_string()
+                }
+                "research_consolidator" => {
+                    let has_map_outputs = desc.contains("Map Phase Outputs");
+                    format!(
+                        "consolidated_corpus: unified knowledge base from 3 sources covering \
+                         47 papers, citation graph, and practitioner reports. \
+                         Ready for debate analysis. Map outputs integrated: {}",
+                        has_map_outputs
+                    )
+                }
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+fn phase2_executor(phase1_output: String) -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        let corpus = phase1_output.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "scaling_optimist" => {
+                    format!(
+                        "optimist_position: Evidence from corpus ({} chars) supports continued \
+                         scaling: benchmark improvements correlate with parameter count, \
+                         reasoning emerges at sufficient scale",
+                        corpus.len()
+                    )
+                }
+                "efficiency_realist" => {
+                    format!(
+                        "realist_position: Corpus ({} chars) shows diminishing returns above 70B params; \
+                         mixture-of-experts and retrieval augmentation outperform raw scaling \
+                         per FLOP on reasoning tasks",
+                        corpus.len()
+                    )
+                }
+                "synthesis_lead" => {
+                    let has_debate = desc.contains("Debate Arguments");
+                    format!(
+                        "synthesis_conclusion: Both perspectives valid. Recommendation: scale to \
+                         sweet spot (~30-70B), then invest in retrieval and tool-use infrastructure. \
+                         Debate context received: {}",
+                        has_debate
+                    )
+                }
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Combined Pipeline: MapReduce + Debate for Research Synthesis ===\n");
+
+    println!("--- Phase 1: MapReduce - Gather and consolidate research data ---");
+
+    let mut phase1_dag = SubtaskDAG::new("research-gathering");
+
+    let arxiv = phase1_dag.add_task(SwarmSubtask::new(
+        "arxiv_agent",
+        "Query arXiv for recent LLM reasoning papers",
+    ));
+    let semantic = phase1_dag.add_task(SwarmSubtask::new(
+        "semantic_scholar_agent",
+        "Query Semantic Scholar for citation graph analysis",
+    ));
+    let web = phase1_dag.add_task(SwarmSubtask::new(
+        "web_crawler_agent",
+        "Crawl tech blogs and forums for practitioner insights",
+    ));
+    let consolidator = phase1_dag.add_task(SwarmSubtask::new(
+        "research_consolidator",
+        "Merge all source findings into unified research corpus",
+    ));
+
+    phase1_dag.add_dependency(arxiv, consolidator)?;
+    phase1_dag.add_dependency(semantic, consolidator)?;
+    phase1_dag.add_dependency(web, consolidator)?;
+
+    let phase1_summary = MapReduceScheduler::new()
+        .execute(&mut phase1_dag, phase1_executor())
+        .await?;
+
+    println!("Data gathering agents:");
+    for r in &phase1_summary.results {
+        if r.task_id == "research_consolidator" {
+            continue;
+        }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    let consolidated_output = phase1_summary.results.iter()
+        .find(|r| r.task_id == "research_consolidator")
+        .and_then(|r| r.outcome.output())
+        .unwrap_or("empty corpus")
+        .to_string();
+
+    println!("\nConsolidated corpus:");
+    println!("  research_consolidator -> {}", consolidated_output);
+    println!("\nPhase 1 complete: succeeded={} failed={}", phase1_summary.succeeded, phase1_summary.failed);
+
+    println!("\n--- Phase 2: Debate - Analysts argue over the consolidated findings ---");
+
+    let mut phase2_dag = SubtaskDAG::new("findings-debate");
+
+    let optimist = phase2_dag.add_task(SwarmSubtask::new(
+        "scaling_optimist",
+        "Argue that scaling LLMs remains the primary path to better reasoning",
+    ));
+    let realist = phase2_dag.add_task(SwarmSubtask::new(
+        "efficiency_realist",
+        "Argue that architectural improvements outperform raw scaling",
+    ));
+    let synthesis = phase2_dag.add_task(SwarmSubtask::new(
+        "synthesis_lead",
+        "Synthesize the debate and issue actionable research recommendation",
+    ));
+
+    phase2_dag.add_dependency(optimist, synthesis)?;
+    phase2_dag.add_dependency(realist, synthesis)?;
+
+    let phase2_summary = DebateScheduler::new()
+        .execute(&mut phase2_dag, phase2_executor(consolidated_output))
+        .await?;
+
+    println!("Analysts (debate based on Phase 1 corpus):");
+    for r in &phase2_summary.results {
+        if r.task_id == "synthesis_lead" {
+            continue;
+        }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} ->\n    {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    let synthesis_result = phase2_summary.results.iter()
+        .find(|r| r.task_id == "synthesis_lead");
+    if let Some(r) = synthesis_result {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nSynthesis lead (receives debate arguments injected into description):");
+        println!("  [{}] {} ->\n    {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nPhase 2 complete: succeeded={} failed={}", phase2_summary.succeeded, phase2_summary.failed);
+
+    println!("\n=== Combined Pipeline Complete ===");
+    println!("Phase 1 (MapReduce): {} tasks", phase1_summary.total_tasks);
+    println!("Phase 2 (Debate):    {} tasks", phase2_summary.total_tasks);
+    println!("Total wall time:     Phase1={:?}, Phase2={:?}",
+        phase1_summary.total_wall_time, phase2_summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/consensus_code_approval.rs
+++ b/examples/swarm_coordination_patterns/src/bin/consensus_code_approval.rs
@@ -1,0 +1,79 @@
+//! Consensus: Pull Request Approval
+//!
+//! Scenario: Three code reviewers independently vote approve or request-changes
+//! on a pull request. The merge bot reads all votes and applies majority
+//! rule to decide whether to merge or block.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin consensus_code_approval
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ConsensusScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Consensus: Pull Request Approval ===");
+    println!("DAG: reviewer_a, reviewer_b, reviewer_c (voters) -> merge_bot (aggregator)\n");
+
+    let mut dag = SubtaskDAG::new("pr-approval");
+
+    let ra = dag.add_task(SwarmSubtask::new("reviewer_a", "Review PR #1398 for correctness and safety"));
+    let rb = dag.add_task(SwarmSubtask::new("reviewer_b", "Review PR #1398 for style and test coverage"));
+    let rc = dag.add_task(SwarmSubtask::new("reviewer_c", "Review PR #1398 for performance implications"));
+    let mb = dag.add_task(SwarmSubtask::new("merge_bot",  "Apply majority vote to decide merge or block for PR #1398"));
+
+    dag.add_dependency(ra, mb)?;
+    dag.add_dependency(rb, mb)?;
+    dag.add_dependency(rc, mb)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "reviewer_a" => "approve".to_string(),
+                    "reviewer_b" => "approve".to_string(),
+                    "reviewer_c" => "request_changes: missing benchmark for MapReduceScheduler parallel wave".to_string(),
+                    "merge_bot"  => {
+                        let has_context = desc.contains("Voter Outputs");
+                        format!(
+                            "merge_decision: MERGE — {} 2/3 reviewers approved (majority). reviewer_c's benchmark concern logged as follow-up issue #1401.",
+                            if has_context { "all votes received." } else { "no votes." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out)
+            })
+        });
+
+    let summary = ConsensusScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Reviewers (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "merge_bot" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "merge_bot") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nMerge bot decision (receives all votes injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/consensus_fraud_detection.rs
+++ b/examples/swarm_coordination_patterns/src/bin/consensus_fraud_detection.rs
@@ -1,0 +1,80 @@
+//! Consensus: Transaction Fraud Detection
+//!
+//! Scenario: Three ML models independently classify a payment transaction
+//! as fraudulent or legitimate. A risk adjudicator reads all three verdicts
+//! and applies majority rule to issue the final fraud flag.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin consensus_fraud_detection
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ConsensusScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Consensus: Transaction Fraud Detection ===");
+    println!("DAG: model_xgb, model_lstm, model_rules (voters) -> risk_adjudicator (aggregator)\n");
+    println!("Transaction: $4,200 card-not-present purchase, new device, overseas IP\n");
+
+    let mut dag = SubtaskDAG::new("fraud-detection");
+
+    let xgb   = dag.add_task(SwarmSubtask::new("model_xgb",   "XGBoost classifier: score this transaction for fraud probability"));
+    let lstm  = dag.add_task(SwarmSubtask::new("model_lstm",  "LSTM sequence model: analyse spending pattern anomaly for fraud"));
+    let rules = dag.add_task(SwarmSubtask::new("model_rules", "Rules engine: apply velocity and geo-mismatch fraud rules"));
+    let adj   = dag.add_task(SwarmSubtask::new("risk_adjudicator", "Combine all model verdicts and issue final fraud flag"));
+
+    dag.add_dependency(xgb, adj)?;
+    dag.add_dependency(lstm, adj)?;
+    dag.add_dependency(rules, adj)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "model_xgb"   => "fraud".to_string(),
+                    "model_lstm"  => "fraud".to_string(),
+                    "model_rules" => "legitimate: geo-mismatch flagged but within 30-day travel window".to_string(),
+                    "risk_adjudicator" => {
+                        let has_context = desc.contains("Voter Outputs");
+                        format!(
+                            "fraud_verdict: FRAUD — {} 2/3 models flagged fraud (majority). Transaction blocked. Card step-up challenge sent to cardholder. Case ref: FRAUD-2024-8821.",
+                            if has_context { "all model outputs reviewed." } else { "no model data." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = ConsensusScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Models (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "risk_adjudicator" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "risk_adjudicator") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nRisk adjudicator (receives all votes injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/consensus_sentiment.rs
+++ b/examples/swarm_coordination_patterns/src/bin/consensus_sentiment.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ConsensusScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn classifier_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "classifier_a" => "positive".to_string(),
+                "classifier_b" => "positive".to_string(),
+                "classifier_c" => "positive".to_string(),
+                "verdict" => {
+                    let has_majority = desc.contains("Majority Candidate");
+                    let majority_label = if has_majority {
+                        let start = desc.find("Majority Candidate\n").map(|i| i + "Majority Candidate\n".len()).unwrap_or(0);
+                        let end = desc[start..].find('\n').map(|i| i + start).unwrap_or(desc.len());
+                        desc[start..end].trim().to_string()
+                    } else {
+                        "no majority".to_string()
+                    };
+                    format!("final_verdict: {} (majority consensus reached)", majority_label)
+                }
+                _ => format!("{}: classified", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("sentiment-consensus");
+
+    let a = dag.add_task(SwarmSubtask::new(
+        "classifier_a",
+        "Classify product review sentiment using BERT model",
+    ));
+    let b = dag.add_task(SwarmSubtask::new(
+        "classifier_b",
+        "Classify product review sentiment using RoBERTa model",
+    ));
+    let c = dag.add_task(SwarmSubtask::new(
+        "classifier_c",
+        "Classify product review sentiment using GPT-based classifier",
+    ));
+    let verdict = dag.add_task(SwarmSubtask::new(
+        "verdict",
+        "Aggregate classifier votes and announce majority sentiment",
+    ));
+
+    dag.add_dependency(a, verdict)?;
+    dag.add_dependency(b, verdict)?;
+    dag.add_dependency(c, verdict)?;
+
+    println!("=== Consensus: Product Review Sentiment Classification ===");
+    println!("DAG: classifier_a, classifier_b, classifier_c (voters) -> verdict (aggregator)\n");
+
+    let summary = ConsensusScheduler::new()
+        .execute(&mut dag, classifier_executor())
+        .await?;
+
+    let voters: Vec<_> = summary.results.iter()
+        .filter(|r| r.task_id != "verdict")
+        .collect();
+    let verdict_result = summary.results.iter().find(|r| r.task_id == "verdict");
+
+    println!("Voters (ran in parallel):");
+    for r in &voters {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    let votes: Vec<_> = voters.iter()
+        .filter_map(|r| r.outcome.output())
+        .collect();
+    println!("\nVote tally: {:?}", votes);
+    println!("Majority candidate: positive (3/3 votes)");
+
+    if let Some(r) = verdict_result {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nAggregator (majority candidate injected into description):");
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/consensus_topic_classification.rs
+++ b/examples/swarm_coordination_patterns/src/bin/consensus_topic_classification.rs
@@ -1,0 +1,80 @@
+//! Consensus: Support Ticket Topic Classification
+//!
+//! Scenario: Three classifier agents independently label an inbound
+//! support ticket. The ticket router reads all labels and picks the
+//! majority category to determine the correct queue.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin consensus_topic_classification
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ConsensusScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Consensus: Support Ticket Topic Classification ===");
+    println!("DAG: classifier_bert, classifier_fasttext, classifier_rules (voters) -> ticket_router (aggregator)\n");
+    println!("Ticket: 'My invoice shows a charge I didn't authorise from last month'\n");
+
+    let mut dag = SubtaskDAG::new("ticket-classification");
+
+    let bert      = dag.add_task(SwarmSubtask::new("classifier_bert",     "BERT-based classifier: label the support ticket topic"));
+    let fasttext  = dag.add_task(SwarmSubtask::new("classifier_fasttext", "FastText classifier: label the support ticket topic"));
+    let rules_clf = dag.add_task(SwarmSubtask::new("classifier_rules",    "Keyword rules classifier: label the support ticket topic"));
+    let router    = dag.add_task(SwarmSubtask::new("ticket_router",       "Apply majority label to route ticket to the correct support queue"));
+
+    dag.add_dependency(bert, router)?;
+    dag.add_dependency(fasttext, router)?;
+    dag.add_dependency(rules_clf, router)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "classifier_bert"     => "billing".to_string(),
+                    "classifier_fasttext" => "billing".to_string(),
+                    "classifier_rules"    => "dispute".to_string(),
+                    "ticket_router" => {
+                        let has_context = desc.contains("Voter Outputs");
+                        format!(
+                            "routing_decision: BILLING — {} 2/3 classifiers agree on 'billing' (majority). Ticket TKT-00492 assigned to billing-disputes queue. SLA: 4h first response.",
+                            if has_context { "all classifier outputs reviewed." } else { "no classifier data." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = ConsensusScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Classifiers (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "ticket_router" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "ticket_router") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nTicket router (receives all labels injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/debate_architecture.rs
+++ b/examples/swarm_coordination_patterns/src/bin/debate_architecture.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    DebateScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn debate_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "microservices_advocate" => {
+                    "microservices_argument: Independent deployability reduces blast radius, \
+                     polyglot persistence enables best-fit storage per domain, \
+                     horizontal scaling per service optimizes cost under variable load".to_string()
+                }
+                "monolith_advocate" => {
+                    "monolith_argument: Single deployment unit eliminates distributed systems \
+                     overhead, shared memory transactions are simpler than saga patterns, \
+                     developer onboarding time is 3x faster with one codebase".to_string()
+                }
+                "chief_architect" => {
+                    let received_context = if desc.contains("Debate Arguments") {
+                        "both sides received"
+                    } else {
+                        "no context"
+                    };
+                    format!(
+                        "verdict: Given team size <10 and MVP timeline, monolith is recommended. \
+                         Revisit microservices at >50k DAU. Context: {}.",
+                        received_context
+                    )
+                }
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("architecture-debate");
+
+    let micro = dag.add_task(SwarmSubtask::new(
+        "microservices_advocate",
+        "Argue for microservices architecture",
+    ));
+    let mono = dag.add_task(SwarmSubtask::new(
+        "monolith_advocate",
+        "Argue for monolithic architecture",
+    ));
+    let judge = dag.add_task(SwarmSubtask::new(
+        "chief_architect",
+        "Synthesize both arguments and issue architecture decision",
+    ));
+
+    dag.add_dependency(micro, judge)?;
+    dag.add_dependency(mono, judge)?;
+
+    println!("=== Debate: Microservices vs Monolith Architecture Decision ===");
+    println!("DAG: microservices_advocate, monolith_advocate (parallel) -> chief_architect\n");
+
+    let summary = DebateScheduler::new()
+        .execute(&mut dag, debate_executor())
+        .await?;
+
+    let debaters: Vec<_> = summary.results.iter()
+        .filter(|r| r.task_id != "chief_architect")
+        .collect();
+    let judge_result = summary.results.iter().find(|r| r.task_id == "chief_architect");
+
+    println!("Debaters (ran in parallel):");
+    for r in &debaters {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} ->\n    {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = judge_result {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nJudge (receives both arguments injected into description):");
+        println!("  [{}] {} ->\n    {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/debate_hiring_decision.rs
+++ b/examples/swarm_coordination_patterns/src/bin/debate_hiring_decision.rs
@@ -1,0 +1,76 @@
+//! Debate: Hiring Decision
+//!
+//! Scenario: Two recruiters present opposing cases for a senior engineer
+//! candidate — one argues hire, one argues pass. The hiring manager
+//! (judge) reads both arguments and issues the final decision.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin debate_hiring_decision
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    DebateScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Debate: Hiring Decision ===");
+    println!("DAG: pro_recruiter, con_recruiter (parallel) -> hiring_manager\n");
+
+    let mut dag = SubtaskDAG::new("hiring-debate");
+
+    let pro     = dag.add_task(SwarmSubtask::new("pro_recruiter", "Argue why the candidate should be hired based on their profile"));
+    let con     = dag.add_task(SwarmSubtask::new("con_recruiter", "Argue why the candidate should not be hired based on their profile"));
+    let manager = dag.add_task(SwarmSubtask::new("hiring_manager", "Read both arguments and issue the final hire/no-hire decision with rationale"));
+
+    dag.add_dependency(pro, manager)?;
+    dag.add_dependency(con, manager)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "pro_recruiter" => "HIRE: 8 yrs distributed systems, led migration of monolith to microservices at scale (3M RPS), open-source contributor to tokio, strong system design, culture-fit score 9/10".to_string(),
+                    "con_recruiter" => "PASS: no Rust production experience (our primary stack), asked for 30% above band, 3 job changes in 4 years, take-home assignment incomplete — missing error handling section".to_string(),
+                    "hiring_manager" => {
+                        let has_context = desc.contains("Debate Arguments");
+                        format!(
+                            "decision: CONDITIONAL_OFFER — {} Strong distributed systems background outweighs Rust gap (trainable in 3 months). Offer at band top. Require completed take-home before signing.",
+                            if has_context { "reviewed both arguments." } else { "no arguments received." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = DebateScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Recruiters (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "hiring_manager" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "hiring_manager") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nHiring manager decision (receives both arguments injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/debate_product_pricing.rs
+++ b/examples/swarm_coordination_patterns/src/bin/debate_product_pricing.rs
@@ -1,0 +1,76 @@
+//! Debate: Product Pricing Strategy
+//!
+//! Scenario: Growth team argues for a lower price to maximise adoption;
+//! Revenue team argues for a higher price to maximise margin. The CEO
+//! reads both cases and sets the final pricing strategy.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin debate_product_pricing
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    DebateScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Debate: Product Pricing Strategy ===");
+    println!("DAG: growth_team, revenue_team (parallel) -> ceo\n");
+
+    let mut dag = SubtaskDAG::new("pricing-debate");
+
+    let growth  = dag.add_task(SwarmSubtask::new("growth_team",  "Argue for a lower price point to maximise user acquisition and market share"));
+    let revenue = dag.add_task(SwarmSubtask::new("revenue_team", "Argue for a higher price point to maximise per-seat margin and signal premium quality"));
+    let ceo     = dag.add_task(SwarmSubtask::new("ceo",          "Review both pricing arguments and set the final go-to-market price"));
+
+    dag.add_dependency(growth, ceo)?;
+    dag.add_dependency(revenue, ceo)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "growth_team"  => "LOWER_PRICE ($29/seat/mo): competitors at $49-79, price-sensitivity survey shows 68% of prospects drop off above $35, PLG motion needs low friction, land-and-expand works better with volume".to_string(),
+                    "revenue_team" => "HIGHER_PRICE ($79/seat/mo): enterprise ACV increases 2.4x, support load per dollar drops, positions us away from SMB churn risk, comp analysis shows room up to $89 for feature set".to_string(),
+                    "ceo" => {
+                        let has_context = desc.contains("Debate Arguments");
+                        format!(
+                            "pricing_decision: {} — Launch at $49/seat/mo. Free tier for ≤5 seats (PLG motion). Enterprise custom pricing >50 seats. Revisit after 6 months of ARR data.",
+                            if has_context { "both arguments reviewed." } else { "no context." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = DebateScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Teams (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "ceo" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "ceo") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nCEO decision (receives both arguments injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/debate_tech_stack.rs
+++ b/examples/swarm_coordination_patterns/src/bin/debate_tech_stack.rs
@@ -1,0 +1,76 @@
+//! Debate: Frontend Framework Selection
+//!
+//! Scenario: Two engineers advocate for React and Vue respectively.
+//! The CTO reads both arguments and picks the frontend framework
+//! for the next product generation.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin debate_tech_stack
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    DebateScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Debate: Frontend Framework Selection ===");
+    println!("DAG: react_advocate, vue_advocate (parallel) -> cto\n");
+
+    let mut dag = SubtaskDAG::new("framework-debate");
+
+    let react = dag.add_task(SwarmSubtask::new("react_advocate", "Argue why React is the best choice for the new frontend"));
+    let vue   = dag.add_task(SwarmSubtask::new("vue_advocate",   "Argue why Vue is the best choice for the new frontend"));
+    let cto   = dag.add_task(SwarmSubtask::new("cto",            "Evaluate both arguments and select the frontend framework"));
+
+    dag.add_dependency(react, cto)?;
+    dag.add_dependency(vue, cto)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "react_advocate" => "REACT: largest ecosystem (npm downloads 4x Vue), team already has 3 React engineers, Next.js gives SSR out of the box, React Native reuse for mobile, hiring pool 2x larger".to_string(),
+                    "vue_advocate"   => "VUE: gentler learning curve (faster onboarding), single-file components reduce context switching, Nuxt.js equally capable SSR, smaller bundle baseline, better TypeScript DX in Vue 3 Composition API".to_string(),
+                    "cto" => {
+                        let has_context = desc.contains("Debate Arguments");
+                        format!(
+                            "framework_decision: REACT — {} Existing team expertise and hiring market depth outweigh Vue's DX advantage. Adopt Next.js 14 App Router. Run Vue skill-share session for team awareness.",
+                            if has_context { "both arguments considered." } else { "no context." }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = DebateScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Advocates (ran in parallel):");
+    for r in &summary.results {
+        if r.task_id == "cto" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "cto") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nCTO decision (receives both arguments injected):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/mapreduce_codebase_audit.rs
+++ b/examples/swarm_coordination_patterns/src/bin/mapreduce_codebase_audit.rs
@@ -1,0 +1,82 @@
+//! MapReduce: Codebase Security Audit
+//!
+//! Scenario: Four module auditors scan different areas of the codebase
+//! in parallel (map phase) looking for vulnerabilities. The reducer
+//! compiles all findings into a single prioritised security report.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin mapreduce_codebase_audit
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    MapReduceScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== MapReduce: Codebase Security Audit ===");
+    println!("DAG: audit_auth, audit_api, audit_db, audit_deps (mappers) -> security_report (reducer)\n");
+
+    let mut dag = SubtaskDAG::new("security-audit");
+
+    let auth = dag.add_task(SwarmSubtask::new("audit_auth", "Audit authentication and session management code for vulnerabilities"));
+    let api  = dag.add_task(SwarmSubtask::new("audit_api",  "Scan API layer for injection, CORS misconfiguration, and rate-limit gaps"));
+    let db   = dag.add_task(SwarmSubtask::new("audit_db",   "Review database access patterns for SQL injection and over-privileged queries"));
+    let deps = dag.add_task(SwarmSubtask::new("audit_deps", "Check Cargo.lock for known CVEs in third-party dependencies"));
+    let r    = dag.add_task(SwarmSubtask::new("security_report", "Compile all module findings into a prioritised security report"));
+
+    dag.add_dependency(auth, r)?;
+    dag.add_dependency(api, r)?;
+    dag.add_dependency(db, r)?;
+    dag.add_dependency(deps, r)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "audit_auth" => "auth_audit: 1 HIGH (session token not rotated on privilege escalation), 2 MEDIUM (missing MFA enforcement on admin routes)".to_string(),
+                    "audit_api"  => "api_audit: 0 HIGH, 1 MEDIUM (CORS wildcard on /internal/* routes), 3 LOW (missing rate-limit on password-reset endpoint)".to_string(),
+                    "audit_db"   => "db_audit: 0 HIGH, 0 MEDIUM — all queries use parameterised statements. 1 INFO: db user has DROP TABLE privilege (unnecessary)".to_string(),
+                    "audit_deps" => "deps_audit: 2 HIGH CVEs (RUSTSEC-2024-0031 in rustls 0.21.6, RUSTSEC-2024-0019 in h2 0.3.20) — upgrade required".to_string(),
+                    "security_report" => {
+                        let has_context = desc.contains("Map Phase Outputs");
+                        format!(
+                            "security_report_ok: {} — CRITICAL actions: upgrade rustls+h2, rotate session tokens on escalation. MEDIUM: fix CORS, enforce MFA. Full report: 3 HIGH, 4 MEDIUM, 3 LOW, 1 INFO.",
+                            if has_context { "all 4 modules audited" } else { "no module data" }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = MapReduceScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Map phase (parallel module auditors):");
+    for r in &summary.results {
+        if r.task_id == "security_report" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "security_report") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nReduce phase (security compiler):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/mapreduce_document_summary.rs
+++ b/examples/swarm_coordination_patterns/src/bin/mapreduce_document_summary.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    MapReduceScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn summary_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "section_1" => "section_1_summary: Introduction covers transformer architecture motivation and prior work on attention mechanisms".to_string(),
+                "section_2" => "section_2_summary: Methodology details multi-head attention, positional encoding, and encoder-decoder stack".to_string(),
+                "section_3" => "section_3_summary: Experiments show BLEU score improvements of 2.0 over previous SOTA on WMT 2014 En-De".to_string(),
+                "section_4" => "section_4_summary: Conclusion argues self-attention generalizes beyond NLP to vision and reinforcement learning".to_string(),
+                "final_summary" => {
+                    format!(
+                        "final_paper_summary: Paper presents the Transformer model ({}). All 4 sections integrated.",
+                        if desc.contains("Map Phase Outputs") { "context received from mappers" } else { "no context" }
+                    )
+                }
+                _ => format!("{}: summarized", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("document-summarization");
+
+    let s1 = dag.add_task(SwarmSubtask::new("section_1", "Summarize Introduction section"));
+    let s2 = dag.add_task(SwarmSubtask::new("section_2", "Summarize Methodology section"));
+    let s3 = dag.add_task(SwarmSubtask::new("section_3", "Summarize Experiments section"));
+    let s4 = dag.add_task(SwarmSubtask::new("section_4", "Summarize Conclusion section"));
+    let reducer = dag.add_task(SwarmSubtask::new("final_summary", "Merge all section summaries into paper abstract"));
+
+    dag.add_dependency(s1, reducer)?;
+    dag.add_dependency(s2, reducer)?;
+    dag.add_dependency(s3, reducer)?;
+    dag.add_dependency(s4, reducer)?;
+
+    println!("=== MapReduce: Research Paper Summarization ===");
+    println!("DAG: section_1, section_2, section_3, section_4 (mappers) -> final_summary (reducer)\n");
+
+    let summary = MapReduceScheduler::new()
+        .execute(&mut dag, summary_executor())
+        .await?;
+
+    let mappers: Vec<_> = summary.results.iter()
+        .filter(|r| r.task_id != "final_summary")
+        .collect();
+    let reducer_result = summary.results.iter().find(|r| r.task_id == "final_summary");
+
+    println!("Map phase (parallel section summarizers):");
+    for r in &mappers {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = reducer_result {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nReduce phase (all mapper outputs injected into description):");
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/mapreduce_log_analysis.rs
+++ b/examples/swarm_coordination_patterns/src/bin/mapreduce_log_analysis.rs
@@ -1,0 +1,82 @@
+//! MapReduce: Distributed Log Analysis
+//!
+//! Scenario: Four server log shards are parsed in parallel (map phase).
+//! Each shard extracts its error summary. The reducer aggregates all
+//! shard summaries into a single incident report.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin mapreduce_log_analysis
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    MapReduceScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== MapReduce: Distributed Log Analysis ===");
+    println!("DAG: shard_1, shard_2, shard_3, shard_4 (mappers) -> incident_report (reducer)\n");
+
+    let mut dag = SubtaskDAG::new("log-analysis");
+
+    let s1 = dag.add_task(SwarmSubtask::new("shard_1", "Parse /var/log/app/app.log.1 for ERROR and WARN entries"));
+    let s2 = dag.add_task(SwarmSubtask::new("shard_2", "Parse /var/log/app/app.log.2 for ERROR and WARN entries"));
+    let s3 = dag.add_task(SwarmSubtask::new("shard_3", "Parse /var/log/app/app.log.3 for ERROR and WARN entries"));
+    let s4 = dag.add_task(SwarmSubtask::new("shard_4", "Parse /var/log/app/app.log.4 for ERROR and WARN entries"));
+    let r  = dag.add_task(SwarmSubtask::new("incident_report", "Aggregate all shard summaries into a prioritised incident report"));
+
+    dag.add_dependency(s1, r)?;
+    dag.add_dependency(s2, r)?;
+    dag.add_dependency(s3, r)?;
+    dag.add_dependency(s4, r)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "shard_1" => "shard_1_summary: 12 ERRORs (db_connection_timeout x8, auth_failure x4), 31 WARNs".to_string(),
+                    "shard_2" => "shard_2_summary: 3 ERRORs (disk_full x3), 5 WARNs — spike at 02:14 UTC".to_string(),
+                    "shard_3" => "shard_3_summary: 0 ERRORs, 2 WARNs — clean period".to_string(),
+                    "shard_4" => "shard_4_summary: 7 ERRORs (oom_killed x7), 18 WARNs — memory pressure detected".to_string(),
+                    "incident_report" => {
+                        let has_context = desc.contains("Map Phase Outputs");
+                        format!(
+                            "incident_report_ok: {} — top issues: db_connection_timeout (8), oom_killed (7), disk_full (3). Recommend: scale db pool, add swap, expand disk.",
+                            if has_context { "all 4 shards aggregated" } else { "no shard context" }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = MapReduceScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Map phase (parallel shard parsers):");
+    for r in &summary.results {
+        if r.task_id == "incident_report" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "incident_report") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nReduce phase (incident aggregator):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/mapreduce_sales_report.rs
+++ b/examples/swarm_coordination_patterns/src/bin/mapreduce_sales_report.rs
@@ -1,0 +1,82 @@
+//! MapReduce: Regional Sales Aggregation
+//!
+//! Scenario: Four regional sales agents process their territory data in
+//! parallel (map phase). The reducer merges all regional figures into a
+//! global quarterly revenue summary.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin mapreduce_sales_report
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    MapReduceScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== MapReduce: Regional Sales Aggregation ===");
+    println!("DAG: region_na, region_emea, region_apac, region_latam (mappers) -> global_summary (reducer)\n");
+
+    let mut dag = SubtaskDAG::new("sales-report");
+
+    let na    = dag.add_task(SwarmSubtask::new("region_na",      "Compute Q4 revenue, deals closed, and churn for North America"));
+    let emea  = dag.add_task(SwarmSubtask::new("region_emea",    "Compute Q4 revenue, deals closed, and churn for EMEA"));
+    let apac  = dag.add_task(SwarmSubtask::new("region_apac",    "Compute Q4 revenue, deals closed, and churn for APAC"));
+    let latam = dag.add_task(SwarmSubtask::new("region_latam",   "Compute Q4 revenue, deals closed, and churn for LATAM"));
+    let r     = dag.add_task(SwarmSubtask::new("global_summary", "Aggregate all regional figures into a global Q4 revenue summary"));
+
+    dag.add_dependency(na, r)?;
+    dag.add_dependency(emea, r)?;
+    dag.add_dependency(apac, r)?;
+    dag.add_dependency(latam, r)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "region_na"      => "na_q4: revenue=$4.2M, deals=318, churn=2.1%, top_product=mofa-enterprise".to_string(),
+                    "region_emea"    => "emea_q4: revenue=$2.8M, deals=201, churn=3.4%, top_product=mofa-cloud".to_string(),
+                    "region_apac"    => "apac_q4: revenue=$1.9M, deals=154, churn=1.8%, top_product=mofa-edge".to_string(),
+                    "region_latam"   => "latam_q4: revenue=$0.7M, deals=63, churn=4.2%, top_product=mofa-cloud".to_string(),
+                    "global_summary" => {
+                        let has_context = desc.contains("Map Phase Outputs");
+                        format!(
+                            "global_q4_summary: {} — total_revenue=$9.6M, total_deals=736, blended_churn=2.9%. Best region: NA. Fastest growth: APAC (+38% QoQ).",
+                            if has_context { "all 4 regions consolidated" } else { "no regional data" }
+                        )
+                    }
+                    _ => "done".to_string(),
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = MapReduceScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Map phase (parallel regional agents):");
+    for r in &summary.results {
+        if r.task_id == "global_summary" { continue; }
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "global_summary") {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nReduce phase (global aggregator):\n  [{}] {} -> {}",
+            status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/parallel_code_review.rs
+++ b/examples/swarm_coordination_patterns/src/bin/parallel_code_review.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn reviewer_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "lint_check" => "lint_passed: 0 errors, 3 style warnings (unused imports)".to_string(),
+                "security_scan" => "security_passed: no CVEs found, 1 low-severity advisory (outdated dep)".to_string(),
+                "perf_check" => "perf_passed: O(n^2) hotspot in sort loop flagged, memory allocation within bounds".to_string(),
+                "review_summary" => {
+                    let desc = task.description.clone();
+                    format!("review_complete: aggregated {} chars of reviewer feedback", desc.len())
+                }
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("parallel-code-review");
+
+    let lint = dag.add_task(SwarmSubtask::new("lint_check", "Run linter across all modified files"));
+    let security = dag.add_task(SwarmSubtask::new("security_scan", "Scan dependencies and code for vulnerabilities"));
+    let perf = dag.add_task(SwarmSubtask::new("perf_check", "Profile hot paths and flag regressions"));
+    let summary = dag.add_task(SwarmSubtask::new("review_summary", "Aggregate all reviewer outputs into final verdict"));
+
+    dag.add_dependency(lint, summary)?;
+    dag.add_dependency(security, summary)?;
+    dag.add_dependency(perf, summary)?;
+
+    println!("=== Parallel: Code Review Pipeline ===");
+    println!("DAG: lint_check, security_scan, perf_check (parallel) -> review_summary\n");
+
+    let exec_summary = ParallelScheduler::new()
+        .execute(&mut dag, reviewer_executor())
+        .await?;
+
+    let parallel_tasks: Vec<_> = exec_summary.results.iter()
+        .filter(|r| r.task_id != "review_summary")
+        .collect();
+    let sink = exec_summary.results.iter().find(|r| r.task_id == "review_summary");
+
+    println!("Parallel reviewers (ran concurrently):");
+    for result in &parallel_tasks {
+        let status = if result.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, result.task_id, result.outcome.output().unwrap_or("(no output)"));
+    }
+
+    if let Some(s) = sink {
+        let status = if s.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nAggregation sink:");
+        println!("  [{}] {} -> {}", status, s.task_id, s.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        exec_summary.succeeded, exec_summary.failed, exec_summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/parallel_data_ingestion.rs
+++ b/examples/swarm_coordination_patterns/src/bin/parallel_data_ingestion.rs
@@ -1,0 +1,61 @@
+//! Parallel: Multi-Source Data Ingestion
+//!
+//! Scenario: Pull data from four external APIs simultaneously (Stripe,
+//! Salesforce, Jira, GitHub). All four ingestion agents run in parallel
+//! then the aggregated payload is ready for the ETL layer.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin parallel_data_ingestion
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Parallel: Multi-Source Data Ingestion ===");
+    println!("DAG: ingest_stripe, ingest_salesforce, ingest_jira, ingest_github (all parallel)\n");
+
+    let mut dag = SubtaskDAG::new("data-ingestion");
+
+    dag.add_task(SwarmSubtask::new("ingest_stripe",     "Fetch last 24h of payment events from Stripe API"));
+    dag.add_task(SwarmSubtask::new("ingest_salesforce", "Pull updated opportunity records from Salesforce CRM"));
+    dag.add_task(SwarmSubtask::new("ingest_jira",       "Retrieve all tickets transitioned in the last 24h from Jira"));
+    dag.add_task(SwarmSubtask::new("ingest_github",     "Collect merged PRs and closed issues from the mofa-org GitHub org"));
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "ingest_stripe"     => "stripe_ok: 1,240 events ingested, $48,320 total volume, 3 disputes flagged",
+                    "ingest_salesforce" => "salesforce_ok: 87 opportunities updated, 12 new leads, pipeline delta +$210k",
+                    "ingest_jira"       => "jira_ok: 34 tickets closed, 18 moved to IN_REVIEW, 5 reopened",
+                    "ingest_github"     => "github_ok: 9 PRs merged, 22 issues closed, 4 new contributors",
+                    _                   => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = ParallelScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Ingestion agents (ran concurrently):");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/parallel_test_runner.rs
+++ b/examples/swarm_coordination_patterns/src/bin/parallel_test_runner.rs
@@ -1,0 +1,61 @@
+//! Parallel: Test Suite Runner
+//!
+//! Scenario: Run unit, integration, e2e, and performance test suites
+//! simultaneously. All suites execute in parallel; results are merged
+//! into a single quality gate report.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin parallel_test_runner
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Parallel: Test Suite Runner ===");
+    println!("DAG: unit_tests, integration_tests, e2e_tests, perf_tests (all parallel)\n");
+
+    let mut dag = SubtaskDAG::new("test-runner");
+
+    dag.add_task(SwarmSubtask::new("unit_tests",        "Run all unit tests in mofa-foundation and mofa-kernel"));
+    dag.add_task(SwarmSubtask::new("integration_tests", "Run inter-crate integration tests with in-memory stores"));
+    dag.add_task(SwarmSubtask::new("e2e_tests",         "Run end-to-end swarm orchestration tests against local runtime"));
+    dag.add_task(SwarmSubtask::new("perf_tests",        "Run criterion benchmarks for scheduler hot paths"));
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "unit_tests"        => "unit_ok: 98 passed, 0 failed — 0.26s",
+                    "integration_tests" => "integration_ok: 14 passed, 0 failed — 1.83s",
+                    "e2e_tests"         => "e2e_ok: 6 scenarios passed (sequential, parallel, mapreduce, debate, consensus, routing) — 4.12s",
+                    "perf_tests"        => "perf_ok: parallel_scheduler p99=1.2ms, sequential_scheduler p99=0.4ms — within SLA",
+                    _                   => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = ParallelScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Test suites (ran concurrently):");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/parallel_translation_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/parallel_translation_pipeline.rs
@@ -1,0 +1,61 @@
+//! Parallel: Multi-Language Document Translation
+//!
+//! Scenario: Translate a product release note into EN, ES, FR, and DE
+//! simultaneously. All four translations run in parallel, then results
+//! are collected for publishing.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin parallel_translation_pipeline
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Parallel: Multi-Language Document Translation ===");
+    println!("DAG: translate_en, translate_es, translate_fr, translate_de (all parallel)\n");
+
+    let mut dag = SubtaskDAG::new("translation");
+
+    dag.add_task(SwarmSubtask::new("translate_en", "Translate release note to English (US)"));
+    dag.add_task(SwarmSubtask::new("translate_es", "Translate release note to Spanish (LATAM)"));
+    dag.add_task(SwarmSubtask::new("translate_fr", "Translate release note to French (EU)"));
+    dag.add_task(SwarmSubtask::new("translate_de", "Translate release note to German (DE)"));
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "translate_en" => "en_ok: 'MoFA v2.1 — Swarm coordination patterns now GA. See docs.mofa.dev/swarm.'",
+                    "translate_es" => "es_ok: 'MoFA v2.1 — Patrones de coordinación de enjambre ahora disponibles. Ver docs.mofa.dev/swarm.'",
+                    "translate_fr" => "fr_ok: 'MoFA v2.1 — Les patrons de coordination de swarm sont désormais GA. Voir docs.mofa.dev/swarm.'",
+                    "translate_de" => "de_ok: 'MoFA v2.1 — Swarm-Koordinationsmuster jetzt allgemein verfügbar. Siehe docs.mofa.dev/swarm.'",
+                    _              => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = ParallelScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Translations (ran concurrently):");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/routing_bug_report.rs
+++ b/examples/swarm_coordination_patterns/src/bin/routing_bug_report.rs
@@ -1,0 +1,85 @@
+//! Routing: Bug Report Dispatch
+//!
+//! Scenario: A classifier reads an incoming bug report and identifies
+//! which engineering team owns it (backend, frontend, or infra).
+//! The correct team handles the report; the others are skipped.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin routing_bug_report
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    RoutingScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Routing: Bug Report Dispatch ===");
+    println!("Bug: 'API returns 500 on POST /swarm/execute when DAG has a cycle'");
+    println!("Teams: backend_team [backend], frontend_team [frontend], infra_team [infra]\n");
+
+    let mut dag = SubtaskDAG::new("bug-routing");
+
+    let classifier = dag.add_task(SwarmSubtask::new("bug_classifier", "Analyse the bug report and identify the owning engineering team"));
+
+    let mut backend = SwarmSubtask::new("backend_team", "Triage and assign the bug to a backend engineer");
+    backend.required_capabilities = vec!["backend".into()];
+    let idx_backend = dag.add_task(backend);
+
+    let mut frontend = SwarmSubtask::new("frontend_team", "Triage and assign the bug to a frontend engineer");
+    frontend.required_capabilities = vec!["frontend".into()];
+    let idx_frontend = dag.add_task(frontend);
+
+    let mut infra = SwarmSubtask::new("infra_team", "Triage and assign the bug to an infra engineer");
+    infra.required_capabilities = vec!["infra".into()];
+    let idx_infra = dag.add_task(infra);
+
+    dag.add_dependency(classifier, idx_backend)?;
+    dag.add_dependency(classifier, idx_frontend)?;
+    dag.add_dependency(classifier, idx_infra)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "bug_classifier" => "team: backend — cycle detection in DAG validation layer, 500 response from /swarm/execute endpoint, stack trace points to SubtaskDAG::add_dependency",
+                    "backend_team"   => "bug_triaged: assigned to @nityam (backend-platform), severity=HIGH, milestone=v2.1.1 hotfix, root cause: cycle check only runs at task execution time, not at add_dependency — fix: add petgraph cycle detection on edge insertion",
+                    "frontend_team"  => "not applicable",
+                    "infra_team"     => "not applicable",
+                    _                => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = RoutingScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Classifier output:");
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "bug_classifier") {
+        println!("  [OK] bug_classifier -> {}", r.outcome.output().unwrap_or(""));
+    }
+
+    println!("\nTeam routing:");
+    for r in &summary.results {
+        if r.task_id == "bug_classifier" { continue; }
+        let label = match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Success(s) => format!("[SELECTED] {}", s),
+            mofa_foundation::swarm::TaskOutcome::Skipped(_) => "[SKIPPED]".into(),
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => format!("[FAIL] {}", e),
+        };
+        println!("  {} -> {}", r.task_id, label);
+    }
+
+    println!("\nsucceeded={} skipped={} total_time={:?}",
+        summary.succeeded, summary.skipped, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/routing_loan_application.rs
+++ b/examples/swarm_coordination_patterns/src/bin/routing_loan_application.rs
@@ -1,0 +1,85 @@
+//! Routing: Loan Application Dispatch
+//!
+//! Scenario: A classifier reads the loan application and determines its
+//! type (personal, auto, or mortgage). The correct underwriter handles it;
+//! the other two are skipped.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin routing_loan_application
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    RoutingScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Routing: Loan Application Dispatch ===");
+    println!("Application: $380,000 fixed-rate home purchase, 20% down, 30yr term");
+    println!("Underwriters: personal [personal], auto [auto], mortgage [mortgage]\n");
+
+    let mut dag = SubtaskDAG::new("loan-routing");
+
+    let classifier = dag.add_task(SwarmSubtask::new("loan_classifier", "Read the application and identify the loan type"));
+
+    let mut personal = SwarmSubtask::new("personal_underwriter", "Underwrite the personal loan application");
+    personal.required_capabilities = vec!["personal".into()];
+    let idx_personal = dag.add_task(personal);
+
+    let mut auto = SwarmSubtask::new("auto_underwriter", "Underwrite the auto loan application");
+    auto.required_capabilities = vec!["auto".into()];
+    let idx_auto = dag.add_task(auto);
+
+    let mut mortgage = SwarmSubtask::new("mortgage_underwriter", "Underwrite the mortgage application");
+    mortgage.required_capabilities = vec!["mortgage".into()];
+    let idx_mortgage = dag.add_task(mortgage);
+
+    dag.add_dependency(classifier, idx_personal)?;
+    dag.add_dependency(classifier, idx_auto)?;
+    dag.add_dependency(classifier, idx_mortgage)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "loan_classifier"      => "loan type: mortgage — $380k home purchase, LTV 80%, 30yr fixed, applicant credit score 748",
+                    "mortgage_underwriter" => "mortgage_approved: LTV 80% within guidelines, DTI 28% (below 43% threshold), rate locked at 6.875% 30yr fixed, closing in 21 days",
+                    "personal_underwriter" => "not applicable for this application type",
+                    "auto_underwriter"     => "not applicable for this application type",
+                    _                      => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = RoutingScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Classifier output:");
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "loan_classifier") {
+        println!("  [OK] loan_classifier -> {}", r.outcome.output().unwrap_or(""));
+    }
+
+    println!("\nUnderwriter routing:");
+    for r in &summary.results {
+        if r.task_id == "loan_classifier" { continue; }
+        let label = match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Success(s) => format!("[SELECTED] {}", s),
+            mofa_foundation::swarm::TaskOutcome::Skipped(_) => "[SKIPPED]".into(),
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => format!("[FAIL] {}", e),
+        };
+        println!("  {} -> {}", r.task_id, label);
+    }
+
+    println!("\nsucceeded={} skipped={} total_time={:?}",
+        summary.succeeded, summary.skipped, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/routing_medical_triage.rs
+++ b/examples/swarm_coordination_patterns/src/bin/routing_medical_triage.rs
@@ -1,0 +1,85 @@
+//! Routing: Medical Triage
+//!
+//! Scenario: A triage agent reads patient symptoms and identifies the
+//! required specialty. The correct department agent (cardiology, neurology,
+//! or general) handles the case; the other two are skipped.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin routing_medical_triage
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    RoutingScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Routing: Medical Triage ===");
+    println!("Patient: chest pain, shortness of breath, left arm numbness");
+    println!("Specialists: cardiology [cardiology], neurology [neurology], general [general]\n");
+
+    let mut dag = SubtaskDAG::new("medical-triage");
+
+    let triage = dag.add_task(SwarmSubtask::new("triage_agent", "Assess patient symptoms and identify the required medical specialty"));
+
+    let mut cardio = SwarmSubtask::new("cardiology_dept", "Conduct cardiac assessment and order ECG, troponin panel");
+    cardio.required_capabilities = vec!["cardiology".into()];
+    let idx_cardio = dag.add_task(cardio);
+
+    let mut neuro = SwarmSubtask::new("neurology_dept", "Conduct neurological assessment and order CT head");
+    neuro.required_capabilities = vec!["neurology".into()];
+    let idx_neuro = dag.add_task(neuro);
+
+    let mut general = SwarmSubtask::new("general_dept", "Conduct general assessment and order basic labs");
+    general.required_capabilities = vec!["general".into()];
+    let idx_general = dag.add_task(general);
+
+    dag.add_dependency(triage, idx_cardio)?;
+    dag.add_dependency(triage, idx_neuro)?;
+    dag.add_dependency(triage, idx_general)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "triage_agent"    => "symptoms indicate cardiology referral: chest pain + left arm radiation + dyspnoea — STEMI presentation, escalate immediately",
+                    "cardiology_dept" => "cardiology_assessment: 12-lead ECG ordered, troponin T drawn, patient moved to resus bay, cath lab on standby — suspected STEMI",
+                    "neurology_dept"  => "neurology_assessment: no focal deficits, no indication for CT head at this time",
+                    "general_dept"    => "general_assessment: vital signs stable, no additional general workup required pending cardiac results",
+                    _                 => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = RoutingScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Triage output:");
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "triage_agent") {
+        println!("  [OK] triage_agent -> {}", r.outcome.output().unwrap_or(""));
+    }
+
+    println!("\nDepartment routing:");
+    for r in &summary.results {
+        if r.task_id == "triage_agent" { continue; }
+        let label = match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Success(s) => format!("[SELECTED] {}", s),
+            mofa_foundation::swarm::TaskOutcome::Skipped(_) => "[SKIPPED]".into(),
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => format!("[FAIL] {}", e),
+        };
+        println!("  {} -> {}", r.task_id, label);
+    }
+
+    println!("\nsucceeded={} skipped={} total_time={:?}",
+        summary.succeeded, summary.skipped, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/routing_support_ticket.rs
+++ b/examples/swarm_coordination_patterns/src/bin/routing_support_ticket.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    RoutingScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn ticket_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "ticket_classifier" => {
+                    "billing issue with payment: customer charged twice for subscription renewal".to_string()
+                }
+                "billing_agent" => {
+                    let routed = if desc.contains("Router Output") { "with router context" } else { "no context" };
+                    format!("billing_resolved: duplicate charge identified and refund initiated ({})", routed)
+                }
+                "technical_agent" => {
+                    "technical_resolved: bug triaged and assigned to engineering team".to_string()
+                }
+                "general_agent" => {
+                    "general_resolved: ticket acknowledged, routed to appropriate team".to_string()
+                }
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("support-ticket-routing");
+
+    let classifier = dag.add_task(SwarmSubtask::new(
+        "ticket_classifier",
+        "Classify incoming support ticket by reading subject and body",
+    ));
+
+    let mut billing = SwarmSubtask::new("billing_agent", "Handle billing disputes and payment issues");
+    billing.required_capabilities = vec!["billing".into()];
+    let billing_idx = dag.add_task(billing);
+
+    let mut technical = SwarmSubtask::new("technical_agent", "Handle technical bugs and integration issues");
+    technical.required_capabilities = vec!["technical".into(), "bug".into()];
+    let technical_idx = dag.add_task(technical);
+
+    let mut general = SwarmSubtask::new("general_agent", "Handle general inquiries and account questions");
+    general.required_capabilities = vec!["general".into()];
+    let general_idx = dag.add_task(general);
+
+    dag.add_dependency(classifier, billing_idx)?;
+    dag.add_dependency(classifier, technical_idx)?;
+    dag.add_dependency(classifier, general_idx)?;
+
+    println!("=== Routing: Customer Support Ticket Dispatch ===");
+    println!("Specialists: billing_agent [billing], technical_agent [technical, bug], general_agent [general]");
+    println!("Router output will contain 'billing' -> billing_agent selected\n");
+
+    let summary = RoutingScheduler::new()
+        .execute(&mut dag, ticket_executor())
+        .await?;
+
+    let router_result = summary.results.iter().find(|r| r.task_id == "ticket_classifier");
+    if let Some(r) = router_result {
+        println!("Router output:");
+        println!("  ticket_classifier -> {}", r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSpecialist routing decisions:");
+    for r in &summary.results {
+        if r.task_id == "ticket_classifier" {
+            continue;
+        }
+        use mofa_foundation::swarm::TaskOutcome;
+        let status = match &r.outcome {
+            TaskOutcome::Success(_) => "SELECTED",
+            TaskOutcome::Skipped(_) => "SKIPPED ",
+            TaskOutcome::Failure(_) => "FAILED  ",
+        };
+        let detail = match &r.outcome {
+            TaskOutcome::Success(s) => s.as_str(),
+            TaskOutcome::Skipped(s) => s.as_str(),
+            TaskOutcome::Failure(s) => s.as_str(),
+        };
+        println!("  [{}] {} -> {}", status, r.task_id, detail);
+    }
+
+    println!("\nSummary: succeeded={} skipped={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.skipped, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/sequential_ci_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/sequential_ci_pipeline.rs
@@ -1,0 +1,64 @@
+//! Sequential: CI/CD Pipeline
+//!
+//! Scenario: Four-stage pipeline — build → test → lint → deploy.
+//! Each stage only starts after the previous one passes.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin sequential_ci_pipeline
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SequentialScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Sequential: CI/CD Pipeline ===");
+    println!("DAG: build -> test -> lint -> deploy\n");
+
+    let mut dag = SubtaskDAG::new("ci-pipeline");
+
+    let build  = dag.add_task(SwarmSubtask::new("build",  "Compile the project and produce artefacts"));
+    let test   = dag.add_task(SwarmSubtask::new("test",   "Run the full test suite against build artefacts"));
+    let lint   = dag.add_task(SwarmSubtask::new("lint",   "Run clippy and rustfmt checks on source"));
+    let deploy = dag.add_task(SwarmSubtask::new("deploy", "Push artefacts to production environment"));
+
+    dag.add_dependency(build, test)?;
+    dag.add_dependency(test, lint)?;
+    dag.add_dependency(lint, deploy)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "build"  => "build_ok: 142 files compiled, 0 errors, artefact: mofa-foundation.rlib (2.1 MB)",
+                    "test"   => "tests_ok: 98 passed, 0 failed, 1 ignored — 0.26s",
+                    "lint"   => "lint_ok: 0 clippy warnings, rustfmt diff empty",
+                    "deploy" => "deploy_ok: pushed to prod-us-east-1, health check green, rollout 100%",
+                    _        => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = SequentialScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Pipeline stages (sequential guarantee):");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/sequential_invoice_approval.rs
+++ b/examples/swarm_coordination_patterns/src/bin/sequential_invoice_approval.rs
@@ -1,0 +1,64 @@
+//! Sequential: Invoice Approval Workflow
+//!
+//! Scenario: Finance pipeline — draft invoice → manager review
+//! → finance review → send to client. Strict ordering enforced.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin sequential_invoice_approval
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SequentialScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Sequential: Invoice Approval Workflow ===");
+    println!("DAG: draft_invoice -> manager_review -> finance_review -> send_to_client\n");
+
+    let mut dag = SubtaskDAG::new("invoice-approval");
+
+    let draft   = dag.add_task(SwarmSubtask::new("draft_invoice",   "Generate invoice from time-tracking data for client Acme Corp"));
+    let manager = dag.add_task(SwarmSubtask::new("manager_review",  "Manager verifies hours and line items before escalation"));
+    let finance = dag.add_task(SwarmSubtask::new("finance_review",  "Finance team checks tax codes and payment terms"));
+    let send    = dag.add_task(SwarmSubtask::new("send_to_client",  "Deliver approved invoice via email and mark as outstanding in ERP"));
+
+    dag.add_dependency(draft, manager)?;
+    dag.add_dependency(manager, finance)?;
+    dag.add_dependency(finance, send)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "draft_invoice"  => "draft_ok: INV-2024-0381, total $12,450.00 (160 hrs @ $75 + $450 expenses)",
+                    "manager_review" => "manager_approved: hours confirmed, note added — exclude March 15 public holiday (8 hrs removed, revised $11,850.00)",
+                    "finance_review" => "finance_approved: tax_code=B2B-EXEMPT, net_30 terms, VAT N/A for US client",
+                    "send_to_client" => "sent_ok: delivered to billing@acme.com at 09:14 UTC, ERP ref=INV-2024-0381, status=OUTSTANDING",
+                    _                => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = SequentialScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Approval stages:");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/sequential_onboarding_flow.rs
+++ b/examples/swarm_coordination_patterns/src/bin/sequential_onboarding_flow.rs
@@ -1,0 +1,64 @@
+//! Sequential: User Onboarding Flow
+//!
+//! Scenario: New user sign-up pipeline — verify email → create profile
+//! → send welcome email → assign to team. Each step depends on the previous.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin sequential_onboarding_flow
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SequentialScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Sequential: User Onboarding Flow ===");
+    println!("DAG: verify_email -> create_profile -> send_welcome -> assign_team\n");
+
+    let mut dag = SubtaskDAG::new("onboarding");
+
+    let verify  = dag.add_task(SwarmSubtask::new("verify_email",   "Confirm the user's email address is valid and reachable"));
+    let profile = dag.add_task(SwarmSubtask::new("create_profile", "Create the user account and default workspace settings"));
+    let welcome = dag.add_task(SwarmSubtask::new("send_welcome",   "Send the welcome email with getting-started links"));
+    let assign  = dag.add_task(SwarmSubtask::new("assign_team",    "Add the user to their assigned team and notify the team lead"));
+
+    dag.add_dependency(verify, profile)?;
+    dag.add_dependency(profile, welcome)?;
+    dag.add_dependency(welcome, assign)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                let out = match id.as_str() {
+                    "verify_email"   => "email_verified: nityam@example.com — MX record confirmed, no bounce history",
+                    "create_profile" => "profile_created: user_id=usr_9f2a, workspace=ws_default, tier=free",
+                    "send_welcome"   => "email_sent: message_id=msg_3c81, delivered at 14:02 UTC",
+                    "assign_team"    => "team_assigned: team=backend-platform, lead notified via Slack #team-updates",
+                    _                => "done",
+                };
+                Ok(out.to_string())
+            })
+        });
+
+    let summary = SequentialScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Onboarding steps:");
+    for r in &summary.results {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/sequential_report_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/sequential_report_pipeline.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SequentialScheduler, SubtaskDAG, SubtaskExecutorFn, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+fn stage_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        Box::pin(async move {
+            let output = match id.as_str() {
+                "fetch_data" => "market_data_fetched: S&P 500 -2.3%, NASDAQ +1.1%, DJI -0.8%".to_string(),
+                "analyze_trends" => "trend_analysis: bearish sentiment in tech, bullish in energy".to_string(),
+                "write_draft" => "draft_written: 3-section report covering macro outlook, sector rotation, risk factors".to_string(),
+                "proofread" => "proofread_complete: grammar corrected, citations verified, executive summary added".to_string(),
+                _ => format!("{}: processed", id),
+            };
+            Ok(output)
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("market-report-pipeline");
+
+    let fetch = dag.add_task(SwarmSubtask::new("fetch_data", "Fetch live market data feeds"));
+    let analyze = dag.add_task(SwarmSubtask::new("analyze_trends", "Identify market trends from raw data"));
+    let draft = dag.add_task(SwarmSubtask::new("write_draft", "Write the first draft of the report"));
+    let proof = dag.add_task(SwarmSubtask::new("proofread", "Proofread and finalize the report"));
+
+    dag.add_dependency(fetch, analyze)?;
+    dag.add_dependency(analyze, draft)?;
+    dag.add_dependency(draft, proof)?;
+
+    println!("=== Sequential: Market Report Generation ===");
+    println!("DAG: fetch_data -> analyze_trends -> write_draft -> proofread\n");
+
+    let summary = SequentialScheduler::new()
+        .execute(&mut dag, stage_executor())
+        .await?;
+
+    println!("Execution order (sequential guarantee):");
+    for result in &summary.results {
+        let status = if result.outcome.is_success() { "OK" } else { "FAIL" };
+        let output = result.outcome.output().unwrap_or("(no output)");
+        println!("  [{}] {} -> {}", status, result.task_id, output);
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/supervision_data_migration.rs
+++ b/examples/swarm_coordination_patterns/src/bin/supervision_data_migration.rs
@@ -1,0 +1,84 @@
+//! Supervision: Database Shard Migration with DBA Recovery
+//!
+//! Scenario: Three database shards are migrated in parallel. Shard B
+//! hits a foreign key constraint violation and fails mid-migration.
+//! The DBA supervisor always runs and issues a remediation plan.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin supervision_data_migration
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SubtaskDAG, SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Supervision: Database Shard Migration ===");
+    println!("Workers: migrate_shard_a (OK), migrate_shard_b (FK VIOLATION), migrate_shard_c (OK)");
+    println!("DBA supervisor always runs and issues remediation plan\n");
+
+    let mut dag = SubtaskDAG::new("db-migration");
+
+    let w1 = dag.add_task(SwarmSubtask::new("migrate_shard_a", "Run ALTER TABLE migrations on shard_a (users 0-999k)"));
+    let w2 = dag.add_task(SwarmSubtask::new("migrate_shard_b", "Run ALTER TABLE migrations on shard_b (users 1M-1.99M)"));
+    let w3 = dag.add_task(SwarmSubtask::new("migrate_shard_c", "Run ALTER TABLE migrations on shard_c (users 2M-2.99M)"));
+    let sv = dag.add_task(SwarmSubtask::new("dba_supervisor",  "Review all shard migration outcomes and issue a remediation or sign-off plan"));
+
+    dag.add_dependency(w1, sv)?;
+    dag.add_dependency(w2, sv)?;
+    dag.add_dependency(w3, sv)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                match id.as_str() {
+                    "migrate_shard_a" => Ok("shard_a_ok: 14 migrations applied, 0 errors, 1.02M rows affected, duration=4m12s, checksum_verified".into()),
+                    "migrate_shard_b" => Err(mofa_kernel::agent::types::error::GlobalError::runtime(
+                        "migration_failed: shard_b migration 0012_add_org_fk aborted — ERROR 1452: foreign key constraint violation on user_org_memberships (orphaned org_id=48291), rollback complete",
+                    )),
+                    "migrate_shard_c" => Ok("shard_c_ok: 14 migrations applied, 0 errors, 1.01M rows affected, duration=4m08s, checksum_verified".into()),
+                    "dba_supervisor"  => {
+                        let has_context = desc.contains("Worker Results");
+                        Ok(format!(
+                            "remediation_plan: {} — shard_a and shard_c complete (2/3 shards migrated). shard_b: run data-cleanup script to remove orphaned org_id=48291 row, then re-run migration 0012 in next maintenance window. Production reads on shard_b temporarily routed to replica. ETA resume: 2h.",
+                            if has_context { "all shard outcomes reviewed." } else { "no shard data." }
+                        ))
+                    }
+                    _ => Ok("done".into()),
+                }
+            })
+        });
+
+    let summary = SupervisionScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Shard migrations:");
+    for r in &summary.results {
+        if r.task_id == "dba_supervisor" { continue; }
+        let label = if r.outcome.is_success() { "SUCCESS" } else { "FAILED " };
+        let detail = r.outcome.output().unwrap_or_else(|| match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => e.as_str(),
+            _ => "",
+        });
+        println!("  [{}] {} -> {}", label, r.task_id, detail);
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "dba_supervisor") {
+        println!("\nDBA supervisor (always runs):\n  [OK] {} -> {}",
+            r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/supervision_deployment_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/supervision_deployment_pipeline.rs
@@ -1,0 +1,84 @@
+//! Supervision: Multi-Region Deployment with Failure Recovery
+//!
+//! Scenario: Deploy a new release to three regions simultaneously.
+//! The us-west-2 region fails (health check timeout). The ops supervisor
+//! always runs after all workers and issues a recovery plan.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin supervision_deployment_pipeline
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SubtaskDAG, SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Supervision: Multi-Region Deployment ===");
+    println!("Workers: deploy_us_east (OK), deploy_us_west (FAILS), deploy_eu_west (OK)");
+    println!("Supervisor always runs and issues recovery plan\n");
+
+    let mut dag = SubtaskDAG::new("deployment");
+
+    let w1 = dag.add_task(SwarmSubtask::new("deploy_us_east", "Deploy v2.1 to us-east-1 and validate health checks"));
+    let w2 = dag.add_task(SwarmSubtask::new("deploy_us_west", "Deploy v2.1 to us-west-2 and validate health checks"));
+    let w3 = dag.add_task(SwarmSubtask::new("deploy_eu_west", "Deploy v2.1 to eu-west-1 and validate health checks"));
+    let sv = dag.add_task(SwarmSubtask::new("ops_supervisor", "Review all region outcomes and issue rollback or recovery plan"));
+
+    dag.add_dependency(w1, sv)?;
+    dag.add_dependency(w2, sv)?;
+    dag.add_dependency(w3, sv)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                match id.as_str() {
+                    "deploy_us_east" => Ok("deploy_ok: us-east-1 v2.1 healthy, 3/3 instances passing, latency p99=42ms".into()),
+                    "deploy_us_west" => Err(mofa_kernel::agent::types::error::GlobalError::runtime(
+                        "deploy_failed: us-west-2 health check timeout after 30s — instances stuck in ELB drain state",
+                    )),
+                    "deploy_eu_west" => Ok("deploy_ok: eu-west-1 v2.1 healthy, 3/3 instances passing, latency p99=38ms".into()),
+                    "ops_supervisor" => {
+                        let has_context = desc.contains("Worker Results");
+                        Ok(format!(
+                            "recovery_plan: {} — us-east-1 and eu-west-1 stable (2/3 regions). Action: rollback us-west-2 to v2.0 (in progress), trigger PagerDuty P2, schedule re-deploy post-drain investigation. Global traffic shifted to east+eu.",
+                            if has_context { "all region outcomes reviewed." } else { "no outcome data." }
+                        ))
+                    }
+                    _ => Ok("done".into()),
+                }
+            })
+        });
+
+    let summary = SupervisionScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Region deployments:");
+    for r in &summary.results {
+        if r.task_id == "ops_supervisor" { continue; }
+        let label = if r.outcome.is_success() { "SUCCESS" } else { "FAILED " };
+        let detail = r.outcome.output().unwrap_or_else(|| match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => e.as_str(),
+            _ => "",
+        });
+        println!("  [{}] {} -> {}", label, r.task_id, detail);
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "ops_supervisor") {
+        println!("\nOps supervisor (always runs):\n  [OK] {} -> {}",
+            r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/supervision_ml_training.rs
+++ b/examples/swarm_coordination_patterns/src/bin/supervision_ml_training.rs
@@ -1,0 +1,84 @@
+//! Supervision: ML Training with OOM Recovery
+//!
+//! Scenario: Three model trainers run in parallel with different
+//! hyperparameter configs. The large-batch trainer runs OOM and fails.
+//! The supervisor always runs and selects the best result from survivors.
+//!
+//! Run: RUST_LOG=info cargo run -p swarm_coordination_patterns --bin supervision_ml_training
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SubtaskDAG, SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    println!("=== Supervision: ML Training with OOM Recovery ===");
+    println!("Workers: trainer_small (OK), trainer_large (OOM FAIL), trainer_medium (OK)");
+    println!("Supervisor picks best surviving model\n");
+
+    let mut dag = SubtaskDAG::new("ml-training");
+
+    let w1 = dag.add_task(SwarmSubtask::new("trainer_small",  "Train with batch_size=32, lr=1e-4, epochs=10"));
+    let w2 = dag.add_task(SwarmSubtask::new("trainer_large",  "Train with batch_size=512, lr=5e-4, epochs=10"));
+    let w3 = dag.add_task(SwarmSubtask::new("trainer_medium", "Train with batch_size=128, lr=2e-4, epochs=10"));
+    let sv = dag.add_task(SwarmSubtask::new("model_supervisor", "Review all training outcomes and select the best model for deployment"));
+
+    dag.add_dependency(w1, sv)?;
+    dag.add_dependency(w2, sv)?;
+    dag.add_dependency(w3, sv)?;
+
+    let executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            let desc = task.description.clone();
+            Box::pin(async move {
+                match id.as_str() {
+                    "trainer_small"  => Ok("small_complete: val_loss=0.2341, val_acc=91.2%, checkpoint=ckpt_small_ep10.pt, gpu_mem_peak=4.1GB".into()),
+                    "trainer_large"  => Err(mofa_kernel::agent::types::error::GlobalError::runtime(
+                        "oom_error: CUDA out of memory at epoch 3 — batch_size=512 exceeds 16GB VRAM, checkpoint not saved",
+                    )),
+                    "trainer_medium" => Ok("medium_complete: val_loss=0.1987, val_acc=93.6%, checkpoint=ckpt_medium_ep10.pt, gpu_mem_peak=9.8GB".into()),
+                    "model_supervisor" => {
+                        let has_context = desc.contains("Worker Results");
+                        Ok(format!(
+                            "selection: DEPLOY_MEDIUM — {} trainer_medium wins (val_acc=93.6% vs 91.2%, trainer_large OOM). Promote ckpt_medium_ep10.pt to production. Recommend: retry trainer_large with gradient checkpointing to reduce VRAM.",
+                            if has_context { "all training outcomes reviewed." } else { "no training data." }
+                        ))
+                    }
+                    _ => Ok("done".into()),
+                }
+            })
+        });
+
+    let summary = SupervisionScheduler::new().execute(&mut dag, executor).await?;
+
+    println!("Trainers:");
+    for r in &summary.results {
+        if r.task_id == "model_supervisor" { continue; }
+        let label = if r.outcome.is_success() { "SUCCESS" } else { "FAILED " };
+        let detail = r.outcome.output().unwrap_or_else(|| match &r.outcome {
+            mofa_foundation::swarm::TaskOutcome::Failure(e) => e.as_str(),
+            _ => "",
+        });
+        println!("  [{}] {} -> {}", label, r.task_id, detail);
+    }
+
+    if let Some(r) = summary.results.iter().find(|r| r.task_id == "model_supervisor") {
+        println!("\nModel supervisor (always runs):\n  [OK] {} -> {}",
+            r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nsucceeded={} failed={} total_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/bin/supervision_resilient_pipeline.rs
+++ b/examples/swarm_coordination_patterns/src/bin/supervision_resilient_pipeline.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    SubtaskDAG, SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+
+fn shard_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        let desc = task.description.clone();
+        Box::pin(async move {
+            match id.as_str() {
+                "shard_a_processor" => Ok("shard_a_complete: 1M records indexed, checksum OK".to_string()),
+                "shard_b_processor" => Err(GlobalError::runtime("shard_b_unavailable: disk I/O timeout after 30s")),
+                "shard_c_processor" => Ok("shard_c_complete: 980K records indexed, 20K skipped (invalid schema)".to_string()),
+                "recovery_coordinator" => {
+                    let has_context = desc.contains("Worker Results");
+                    let failed_count = desc.matches("FAILED").count();
+                    let success_count = desc.matches("SUCCESS").count();
+                    Ok(format!(
+                        "recovery_plan: detected {} failed shards, {} successful. \
+                         Action: re-queue shard_b with exponential backoff, alert on-call. \
+                         Context injected: {}",
+                        failed_count,
+                        success_count,
+                        has_context
+                    ))
+                }
+                _ => Ok(format!("{}: processed", id)),
+            }
+        })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let mut dag = SubtaskDAG::new("resilient-data-pipeline");
+
+    let shard_a = dag.add_task(SwarmSubtask::new(
+        "shard_a_processor",
+        "Process partition A of the distributed dataset",
+    ));
+    let shard_b = dag.add_task(SwarmSubtask::new(
+        "shard_b_processor",
+        "Process partition B of the distributed dataset",
+    ));
+    let shard_c = dag.add_task(SwarmSubtask::new(
+        "shard_c_processor",
+        "Process partition C of the distributed dataset",
+    ));
+    let supervisor = dag.add_task(SwarmSubtask::new(
+        "recovery_coordinator",
+        "Review worker outcomes and coordinate failure recovery",
+    ));
+
+    dag.add_dependency(shard_a, supervisor)?;
+    dag.add_dependency(shard_b, supervisor)?;
+    dag.add_dependency(shard_c, supervisor)?;
+
+    println!("=== Supervision: Resilient Distributed Data Pipeline ===");
+    println!("Workers: shard_a (OK), shard_b (FAILS), shard_c (OK)");
+    println!("Supervisor always runs and receives worker outcomes in its context\n");
+
+    let summary = SupervisionScheduler::new()
+        .execute(&mut dag, shard_executor())
+        .await?;
+
+    use mofa_foundation::swarm::TaskOutcome;
+
+    println!("Worker results:");
+    for r in &summary.results {
+        if r.task_id == "recovery_coordinator" {
+            continue;
+        }
+        let status = match &r.outcome {
+            TaskOutcome::Success(_) => "SUCCESS",
+            TaskOutcome::Failure(_) => "FAILED ",
+            TaskOutcome::Skipped(_) => "SKIPPED",
+        };
+        let detail = match &r.outcome {
+            TaskOutcome::Success(s) => s.as_str(),
+            TaskOutcome::Failure(s) => s.as_str(),
+            TaskOutcome::Skipped(s) => s.as_str(),
+        };
+        println!("  [{}] {} -> {}", status, r.task_id, detail);
+    }
+
+    let supervisor_result = summary.results.iter().find(|r| r.task_id == "recovery_coordinator");
+    if let Some(r) = supervisor_result {
+        let status = if r.outcome.is_success() { "OK" } else { "FAIL" };
+        println!("\nSupervisor (receives SUCCESS/FAILED context for each worker):");
+        println!("  [{}] {} -> {}", status, r.task_id, r.outcome.output().unwrap_or("(no output)"));
+    }
+
+    println!("\nSummary: succeeded={} failed={} total_wall_time={:?}",
+        summary.succeeded, summary.failed, summary.total_wall_time);
+
+    Ok(())
+}

--- a/examples/swarm_coordination_patterns/src/main.rs
+++ b/examples/swarm_coordination_patterns/src/main.rs
@@ -56,7 +56,15 @@ async fn run_map_reduce() -> Result<()> {
         failed = summary.failed,
         "MapReduce complete"
     );
-    println!("[MapReduce]   succeeded={} failed={}", summary.succeeded, summary.failed);
+    println!(
+        "[MapReduce]   succeeded={} failed={}  peak_concurrency={}  wall={:?}",
+        summary.succeeded, summary.failed,
+        summary.peak_concurrency(),
+        summary.total_wall_time,
+    );
+    for r in summary.timeline() {
+        println!("  +{:>6}µs  {:>20}  {:?}", r.start_offset_us, r.task_id, r.wall_time);
+    }
     Ok(())
 }
 
@@ -175,8 +183,13 @@ async fn run_supervision() -> Result<()> {
         "Supervision complete"
     );
     println!(
-        "[Supervision] succeeded={} failed={}",
-        summary.succeeded, summary.failed
+        "[Supervision] succeeded={} failed={}  peak_concurrency={}  wall={:?}",
+        summary.succeeded, summary.failed,
+        summary.peak_concurrency(),
+        summary.total_wall_time,
     );
+    for r in summary.timeline() {
+        println!("  +{:>6}µs  {:>20}  {:?}", r.start_offset_us, r.task_id, r.wall_time);
+    }
     Ok(())
 }

--- a/examples/swarm_coordination_patterns/src/main.rs
+++ b/examples/swarm_coordination_patterns/src/main.rs
@@ -1,0 +1,182 @@
+//! Demonstrates all 5 Phase-2 coordination patterns.
+//!
+//! Run with: RUST_LOG=info cargo run -p swarm_coordination_patterns
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ConsensusScheduler, DebateScheduler, MapReduceScheduler, RoutingScheduler, SubtaskDAG,
+    SubtaskExecutorFn, SupervisionScheduler, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+use tracing::info;
+
+fn simple_executor() -> SubtaskExecutorFn {
+    Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+        let id = task.id.clone();
+        Box::pin(async move { Ok(format!("{}: done", id)) })
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    run_map_reduce().await?;
+    run_debate().await?;
+    run_consensus().await?;
+    run_routing().await?;
+    run_supervision().await?;
+
+    Ok(())
+}
+
+async fn run_map_reduce() -> Result<()> {
+    // mappers process chunks in parallel; reducer aggregates all outputs
+    let mut dag = SubtaskDAG::new("map-reduce");
+    let m1 = dag.add_task(SwarmSubtask::new("chunk-1", "Summarize document 1"));
+    let m2 = dag.add_task(SwarmSubtask::new("chunk-2", "Summarize document 2"));
+    let m3 = dag.add_task(SwarmSubtask::new("chunk-3", "Summarize document 3"));
+    let r = dag.add_task(SwarmSubtask::new("reducer", "Merge all summaries"));
+    dag.add_dependency(m1, r)?;
+    dag.add_dependency(m2, r)?;
+    dag.add_dependency(m3, r)?;
+
+    let summary = MapReduceScheduler::new()
+        .execute(&mut dag, simple_executor())
+        .await?;
+
+    info!(
+        pattern = %summary.pattern,
+        succeeded = summary.succeeded,
+        failed = summary.failed,
+        "MapReduce complete"
+    );
+    println!("[MapReduce]   succeeded={} failed={}", summary.succeeded, summary.failed);
+    Ok(())
+}
+
+async fn run_debate() -> Result<()> {
+    // two debaters argue; judge synthesises the verdict
+    let mut dag = SubtaskDAG::new("debate");
+    let pro = dag.add_task(SwarmSubtask::new("pro", "Argue for Postgres"));
+    let con = dag.add_task(SwarmSubtask::new("con", "Argue for MongoDB"));
+    let judge = dag.add_task(SwarmSubtask::new("judge", "Pick the better option"));
+    dag.add_dependency(pro, judge)?;
+    dag.add_dependency(con, judge)?;
+
+    let summary = DebateScheduler::new()
+        .execute(&mut dag, simple_executor())
+        .await?;
+
+    info!(pattern = %summary.pattern, succeeded = summary.succeeded, "Debate complete");
+    println!("[Debate]      succeeded={} failed={}", summary.succeeded, summary.failed);
+    Ok(())
+}
+
+async fn run_consensus() -> Result<()> {
+    // three voters classify independently; aggregator picks majority
+    let mut dag = SubtaskDAG::new("consensus");
+    let v1 = dag.add_task(SwarmSubtask::new("voter-1", "Classify sentiment"));
+    let v2 = dag.add_task(SwarmSubtask::new("voter-2", "Classify sentiment"));
+    let v3 = dag.add_task(SwarmSubtask::new("voter-3", "Classify sentiment"));
+    let agg = dag.add_task(SwarmSubtask::new("aggregator", "Pick majority verdict"));
+    dag.add_dependency(v1, agg)?;
+    dag.add_dependency(v2, agg)?;
+    dag.add_dependency(v3, agg)?;
+
+    let summary = ConsensusScheduler::new()
+        .execute(&mut dag, simple_executor())
+        .await?;
+
+    info!(pattern = %summary.pattern, succeeded = summary.succeeded, "Consensus complete");
+    println!("[Consensus]   succeeded={} failed={}", summary.succeeded, summary.failed);
+    Ok(())
+}
+
+async fn run_routing() -> Result<()> {
+    // router signals "database"; only the db-specialist runs; ml-specialist is skipped
+    let mut dag = SubtaskDAG::new("routing");
+    let router = dag.add_task(SwarmSubtask::new("router", "Identify required capability"));
+
+    let mut db = SwarmSubtask::new("db-specialist", "Handle database queries");
+    db.required_capabilities = vec!["database".into()];
+    let idx_db = dag.add_task(db);
+
+    let mut ml = SwarmSubtask::new("ml-specialist", "Handle ML inference");
+    ml.required_capabilities = vec!["machine_learning".into()];
+    let idx_ml = dag.add_task(ml);
+
+    dag.add_dependency(router, idx_db)?;
+    dag.add_dependency(router, idx_ml)?;
+
+    let routing_executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "router" {
+                    Ok("needs database access".into())
+                } else {
+                    Ok(format!("{}: done", id))
+                }
+            })
+        });
+
+    let summary = RoutingScheduler::new()
+        .execute(&mut dag, routing_executor)
+        .await?;
+
+    info!(
+        pattern = %summary.pattern,
+        succeeded = summary.succeeded,
+        skipped = summary.skipped,
+        "Routing complete"
+    );
+    println!(
+        "[Routing]     succeeded={} skipped={}",
+        summary.succeeded, summary.skipped
+    );
+    Ok(())
+}
+
+async fn run_supervision() -> Result<()> {
+    // worker-b crashes; supervisor always runs and receives failure context
+    let mut dag = SubtaskDAG::new("supervision");
+    let w1 = dag.add_task(SwarmSubtask::new("worker-a", "Process shard A"));
+    let w2 = dag.add_task(SwarmSubtask::new("worker-b", "Process shard B"));
+    let sup = dag.add_task(SwarmSubtask::new("supervisor", "Review worker results"));
+    dag.add_dependency(w1, sup)?;
+    dag.add_dependency(w2, sup)?;
+
+    let supervision_executor: SubtaskExecutorFn =
+        Arc::new(move |_idx, task: SwarmSubtask| -> BoxFuture<'static, GlobalResult<String>> {
+            let id = task.id.clone();
+            Box::pin(async move {
+                if id == "worker-b" {
+                    Err(GlobalError::runtime("shard B unavailable"))
+                } else {
+                    Ok(format!("{}: done", id))
+                }
+            })
+        });
+
+    let summary = SupervisionScheduler::new()
+        .execute(&mut dag, supervision_executor)
+        .await?;
+
+    info!(
+        pattern = %summary.pattern,
+        succeeded = summary.succeeded,
+        failed = summary.failed,
+        "Supervision complete"
+    );
+    println!(
+        "[Supervision] succeeded={} failed={}",
+        summary.succeeded, summary.failed
+    );
+    Ok(())
+}


### PR DESCRIPTION

### Summary

This PR completes the `CoordinationPattern` enum by implementing all five previously unimplemented patterns — **MapReduce, Debate, Consensus, Routing, and Supervision** — as full `SwarmScheduler` implementations. Each pattern is wired into `CoordinationPattern::into_scheduler()`, exported from the public API, and ships with four individual runnable examples covering real-world scenarios, plus two combined examples that chain patterns together. Includes 10 new tests, a pattern decision guide, and updated architecture docs.

Builds directly on the scheduler foundation from #1363 (Sequential & Parallel). No new external dependencies.

---

### Architecture Diagram

#### Swarm Scheduler Flow (all 7 patterns)

<img width="629" height="582" alt="Screenshot 2026-03-21 at 7 57 48 PM" src="https://github.com/user-attachments/assets/b66abf84-dab1-4e15-831b-34ef5429afea" />

> The flow is identical across all 7 patterns. What changes is the algorithm the scheduler follows you always choose the pattern upfront, and the scheduler executes it deterministically.

---

### What Each Pattern Does

| Pattern | Think of it as… | Example |
|---------|----------------|---------|
| **Sequential** | An assembly line — one step at a time | Build → Test → Deploy |
| **Parallel** | A pit crew — everyone works at once | Lint + Tests + Security scan |
| **MapReduce** | Divide and conquer — split work, then merge | 4 log shards → 1 incident report |
| **Debate** | Two lawyers argue → judge decides | Microservices vs Monolith → CTO picks |
| **Consensus** | Majority vote | 3 fraud models → final verdict |
| **Routing** | A switchboard operator | Bug report → correct engineering team |
| **Supervision** | A safety net — manager always reviews | 3 region deploys, one fails → ops supervisor recovers |

---

### Pain Points Addressed

#### Before This PR

1. **5 patterns were `unimplemented!()`** — `CoordinationPattern::MapReduce`, `Debate`, `Consensus`, `Routing`, and `Supervision` all panicked at runtime. They existed in the enum but had no scheduler backing them.

2. **Output context was lost between phases** — There was no mechanism to pass the output of one group of agents (e.g. mappers) into the next agent (the reducer) as structured context.

3. **Supervisor / judge patterns required bespoke code** — Workflows where one agent must always run and review the results of others — including failures — had no first-class support.

---

### What Is Added

#### 5 New Schedulers (`scheduler.rs`)

| Scheduler | DAG contract | Key behaviour |
|-----------|-------------|---------------|
| `MapReduceScheduler` | sources = mappers, sink = reducer | Runs mappers in parallel, injects all outputs into reducer |
| `DebateScheduler` | sources = debaters, sink = judge | Debaters run in parallel, formatted arguments injected into judge |
| `ConsensusScheduler` | sources = voters, sink = aggregator | Voters run in parallel, majority candidate prepended to aggregator |
| `RoutingScheduler` | single source = router, sinks = specialists | Router runs first, specialist matching `required_capabilities` selected, others skipped |
| `SupervisionScheduler` | sources = workers, sink = supervisor | Workers run with `Continue` policy, supervisor always runs with all results (including failures) injected |

#### Private helper: `inject_context`
All patterns that pass data forward share a single helper that prepends upstream outputs into a task's description before handing it to the executor — keeping the executor interface pure and the scheduler as the sole owner of DAG mutation.

#### 10 New Tests (2 per pattern)
- **MapReduce**: output injection into reducer; mappers run in parallel (peak concurrency == mapper count)
- **Debate**: judge receives both arguments; debaters run in parallel
- **Consensus**: aggregator receives all voter outputs; majority candidate prepended
- **Routing**: capability matching selects correct specialist; fallback when no match
- **Supervision**: supervisor always runs after workers; failure context injected into supervisor description

---

### Runnable Examples (30 total)

All examples require zero API keys.

```bash
cd examples
cargo run -p swarm_coordination_patterns --bin <name>
```

#### Sequential (4)
| Binary | Scenario |
|--------|---------|
| `sequential_report_pipeline` | Market report: fetch → analyse → draft → proofread |
| `sequential_ci_pipeline` | CI/CD: build → test → lint → deploy |
| `sequential_onboarding_flow` | User signup: verify → create profile → welcome → assign team |
| `sequential_invoice_approval` | Finance: draft → manager review → finance review → send |

#### Parallel (4)
| Binary | Scenario |
|--------|---------|
| `parallel_code_review` | 3 reviewers (lint, security, perf) → summary |
| `parallel_translation_pipeline` | Translate release note to EN / ES / FR / DE simultaneously |
| `parallel_test_runner` | Unit + integration + e2e + perf suites in parallel |
| `parallel_data_ingestion` | Ingest from Stripe + Salesforce + Jira + GitHub at once |

#### MapReduce (4)
| Binary | Scenario |
|--------|---------|
| `mapreduce_document_summary` | 4 paper sections → final research summary |
| `mapreduce_log_analysis` | 4 server log shards → incident report |
| `mapreduce_sales_report` | 4 regional files → global Q4 revenue summary |
| `mapreduce_codebase_audit` | 4 modules audited → prioritised security report |

#### Debate (4)
| Binary | Scenario |
|--------|---------|
| `debate_architecture` | Microservices vs Monolith → CTO decides |
| `debate_hiring_decision` | Pro / con recruiters → hiring manager decides |
| `debate_product_pricing` | Growth vs Revenue teams → CEO sets price |
| `debate_tech_stack` | React vs Vue advocates → CTO picks framework |

#### Consensus (4)
| Binary | Scenario |
|--------|---------|
| `consensus_sentiment` | 3 sentiment classifiers → majority verdict |
| `consensus_code_approval` | 3 reviewers vote → merge bot applies majority |
| `consensus_fraud_detection` | 3 ML models flag transaction → risk adjudicator |
| `consensus_topic_classification` | 3 classifiers label ticket → routing decision |

#### Routing (4)
| Binary | Scenario |
|--------|---------|
| `routing_support_ticket` | Ticket → billing / technical / general agent |
| `routing_medical_triage` | Symptoms → cardiology / neurology / general |
| `routing_loan_application` | Application → personal / auto / mortgage underwriter |
| `routing_bug_report` | Bug description → backend / frontend / infra team |

#### Supervision (4)
| Binary | Scenario |
|--------|---------|
| `supervision_resilient_pipeline` | 3 data shards, one fails → supervisor recovers |
| `supervision_deployment_pipeline` | 3 region deploys, one fails → ops supervisor |
| `supervision_ml_training` | 3 trainers, one OOM → supervisor picks best model |
| `supervision_data_migration` | 3 DB shard migrations, one fails → DBA supervisor |

#### Combined (2)
| Binary | Patterns chained | Scenario |
|--------|-----------------|---------|
| `combined_research_pipeline` | MapReduce → Debate | Gather research data → debate findings → synthesis |
| `combined_moderation_pipeline` | Routing → Supervision | Classify content → specialist review → compliance officer |

---

### Implementation Details

#### Files Changed

**`crates/mofa-foundation/src/swarm/scheduler.rs`**
- Added `MapReduceScheduler`, `DebateScheduler`, `ConsensusScheduler`, `RoutingScheduler`, `SupervisionScheduler`
- Added private `inject_context` helper shared across all output-passing patterns
- 25 scheduler tests pass (10 new, 15 existing)

**`crates/mofa-foundation/src/swarm/patterns.rs`**
- Updated `CoordinationPattern::into_scheduler()` — all 7 patterns now return real schedulers, zero `unimplemented!()` remaining

**`crates/mofa-foundation/src/swarm/mod.rs`**
- Exported all 5 new scheduler types

**`docs/tutorial/06-multi-agent.md`**
- Added Phase 2 section with Mermaid diagram per pattern and a pattern decision guide table

**`examples/swarm_coordination_patterns/`**
- 30 runnable binaries, all build and run clean

#### Dependencies
Zero new external crates. Built entirely on existing `tokio`, `petgraph`, and `futures` primitives already in the workspace.

---

### Checklist

- [x] All 5 patterns fully implemented — zero `unimplemented!()` remaining
- [x] `CoordinationPattern::into_scheduler()` wired for all 7 patterns
- [x] Executor interface remains pure — scheduler exclusively owns DAG mutation
- [x] Output injection via shared `inject_context` helper (no duplication)
- [x] 25 scheduler tests pass including concurrency and failure edge cases
- [x] 30 runnable examples, zero API key required
- [x] Architecture documentation updated with Mermaid diagrams per pattern
- [x] No new external dependencies