### PR TITLE
feat(plugins): SemVer dependency resolver for Plugin Marketplace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,4 @@ config = { version = "0.14", features = [
     "json5",
 ] }
 regex = "1"
+semver = { version = "1", features = ["serde"] }

--- a/crates/mofa-plugins/Cargo.toml
+++ b/crates/mofa-plugins/Cargo.toml
@@ -28,9 +28,12 @@ notify.workspace = true
 libloading.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
+hex.workspace = true
 tracing.workspace = true
 uuid = { workspace = true, features = ["v7"] }
 rand.workspace = true
+semver = { workspace = true }
+ed25519-dalek = "2.2.0"
 # WASM plugin runtime
 wasmtime = { version = "40", features = ["component-model", "async"] }
 # Local dependencies

--- a/crates/mofa-plugins/examples/semver_resolver.rs
+++ b/crates/mofa-plugins/examples/semver_resolver.rs
@@ -1,0 +1,93 @@
+// Demonstrates resolver behavior:
+// - yanked/deprecated filtering
+// - runtime version gating
+// - trust score filtering
+// - multi-root dependency resolution
+use mofa_plugins::{resolve_with_options, PluginDep, PluginRegistry};
+use mofa_plugins::wasm_runtime::types::PluginManifest;
+use semver::Version;
+
+fn dep(name: &str, req: &str) -> PluginDep {
+    PluginDep::parse(name, req).expect("valid semver requirement")
+}
+
+fn manifest(name: &str, version: &str, deps: &[PluginDep]) -> PluginManifest {
+    let mut manifest = PluginManifest::new_from_str(name, version)
+        .expect("valid semver version")
+        .with_dependency_list(deps);
+    manifest
+}
+
+trait ManifestExt {
+    fn with_dependency_list(self, deps: &[PluginDep]) -> Self;
+}
+
+impl ManifestExt for PluginManifest {
+    fn with_dependency_list(mut self, deps: &[PluginDep]) -> Self {
+        for dep in deps {
+            self = self.with_dependency(dep.clone());
+        }
+        self
+    }
+}
+
+fn main() {
+    // Demo registry showing: yanked/deprecated filtering, runtime gating, and trust filtering.
+    let mut registry = PluginRegistry::new();
+
+    // alpha -> bravo >=1.0
+    let mut alpha = manifest("alpha", "1.0.0", &[dep("bravo", ">=1.0")]);
+    alpha.trust_score = 0.9;
+
+    // bravo v1 is valid for runtime 1.5.0
+    let mut bravo_v1 = manifest("bravo", "1.5.0", &[]);
+    bravo_v1.trust_score = 0.8;
+    bravo_v1.min_runtime_version = Some("1.0.0".to_string());
+
+    // bravo v2 is yanked + requires runtime >=2.0, so it should be skipped.
+    let mut bravo_v2 = manifest("bravo", "2.0.0", &[]).with_yanked(true);
+    bravo_v2.trust_score = 0.95;
+    bravo_v2.min_runtime_version = Some("2.0.0".to_string());
+
+    // charlie -> bravo >=1.0 (meets trust threshold)
+    let mut charlie = manifest("charlie", "1.0.0", &[dep("bravo", ">=1.0")]);
+    charlie.trust_score = 0.6;
+
+    // delta has two versions; trust filter should pick the higher-trust one.
+    let low_trust = manifest("delta", "2.0.0", &[]).with_trust_score(0.2);
+    let high_trust = manifest("delta", "1.0.0", &[]).with_trust_score(0.9);
+
+    registry.publish(alpha);
+    registry.publish(bravo_v1);
+    registry.publish(bravo_v2);
+    registry.publish(charlie);
+    registry.publish(low_trust);
+    registry.publish(high_trust);
+
+    // Resolve with runtime 1.5.0 and min_trust=0.5.
+    let runtime = Version::new(1, 5, 0);
+    let resolved = resolve_with_options(
+        &registry,
+        &[
+            dep("alpha", ">=1.0"),
+            dep("charlie", ">=1.0"),
+            dep("delta", ">=1.0"),
+        ],
+        Some(&runtime),
+        Some(0.5),
+    );
+
+    match resolved {
+        Ok(resolved) => {
+            println!("Resolved dependencies (runtime={}, min_trust=0.5):", runtime);
+            let mut names: Vec<_> = resolved.keys().cloned().collect();
+            names.sort();
+            for name in names {
+                println!("- {}@{}", name, resolved[&name]);
+            }
+        }
+        Err(err) => {
+            eprintln!("Resolution failed: {err}");
+        }
+    }
+}

--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error_conversions;
 
 pub mod asr;
 pub mod hot_reload;
+pub mod resolver;
 pub mod skill;
 pub mod tool;
 pub mod tools;
@@ -21,6 +22,13 @@ pub mod tts;
 pub mod wasm_runtime;
 
 pub use asr::{ASREngine, ASRPlugin, ASRPluginConfig, MockASREngine};
+pub use resolver::{
+    CompositionError, DependencyResolver, InstallError, PluginId, PluginLock, PluginRegistry,
+    PluginResolver, ResolvedVersions, ResolveError, ResolvedDep, VerificationError,
+    compose_capabilities, install_resolved_plugins, resolve, resolve_install_order,
+    resolve_with_options, resolve_with_runtime, verify_plugin_signature,
+};
+pub use wasm_runtime::PluginDep;
 
 pub use mofa_kernel::{
     AgentPlugin, PluginConfig, PluginContext, PluginError, PluginEvent, PluginMetadata,

--- a/crates/mofa-plugins/src/resolver.rs
+++ b/crates/mofa-plugins/src/resolver.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::time::SystemTime;
 use thiserror::Error;
 
-use crate::wasm_runtime::types::{PluginCapability, PluginDep, PluginManifest};
+use crate::wasm_runtime::{PluginCapability, PluginDep, PluginManifest};
 
 pub type PluginId = String;
 pub type ResolvedVersions = HashMap<PluginId, Version>;

--- a/crates/mofa-plugins/src/resolver.rs
+++ b/crates/mofa-plugins/src/resolver.rs
@@ -1,0 +1,986 @@
+//! SemVer aware dependency resolution for marketplace plugins.
+//!
+//! Manifests store dependency requirements, resolution returns a plugin-version
+//! map, capabilities can be composed from the selected set, and install helpers
+//! perform trust gating and Ed25519 verification before writing artifacts to disk.
+//!
+//! The resolver backtracks across candidate versions to avoid false conflicts in
+//! solvable graphs and produces a dependency safe install order.
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+use std::time::SystemTime;
+use thiserror::Error;
+
+use crate::wasm_runtime::types::{PluginCapability, PluginDep, PluginManifest};
+
+pub type PluginId = String;
+pub type ResolvedVersions = HashMap<PluginId, Version>;
+
+/// Registry of available plugin manifests grouped by name.
+#[derive(Debug, Default)]
+pub struct PluginRegistry {
+    plugins: HashMap<String, Vec<PluginManifest>>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn publish(&mut self, manifest: PluginManifest) {
+        let versions = self.plugins.entry(manifest.name.clone()).or_default();
+        versions.push(manifest);
+        versions.sort_by(|a, b| a.version.cmp(&b.version));
+    }
+
+    pub fn resolve_one(&self, name: &str, req: &VersionReq) -> Option<&PluginManifest> {
+        let requirements = vec![req.clone()];
+        self.candidates_for(name, &requirements, None, None)
+            .ok()?
+            .into_iter()
+            .next()
+    }
+
+    fn candidates_for(
+        &self,
+        name: &str,
+        requirements: &[VersionReq],
+        runtime_version: Option<&Version>,
+        min_trust: Option<f32>,
+    ) -> Result<Vec<&PluginManifest>, ResolveError> {
+        let versions = self.plugins.get(name).map(|v| v.as_slice()).unwrap_or(&[]);
+        let mut candidates = Vec::new();
+        for manifest in versions {
+            if manifest.yanked {
+                continue;
+            }
+            if !requirements.iter().all(|req| req.matches(&manifest.version)) {
+                continue;
+            }
+            if let Some(threshold) = min_trust
+                && manifest.trust_score < threshold
+            {
+                continue;
+            }
+            if let Some(runtime) = runtime_version
+                && let Some(req) = manifest.min_runtime_version.as_deref()
+            {
+                let min_version =
+                    Version::parse(req).map_err(|_| ResolveError::InvalidRuntimeVersion {
+                        name: manifest.name.clone(),
+                        value: req.to_string(),
+                    })?;
+                if runtime < &min_version {
+                    continue;
+                }
+            }
+            candidates.push(manifest);
+        }
+
+        candidates.sort_by(|a, b| b.version.cmp(&a.version));
+        Ok(candidates)
+    }
+
+    // Fetch the exact manifest selected by the resolver.
+    fn get_version(&self, name: &str, version: &Version) -> Option<&PluginManifest> {
+        self.plugins
+            .get(name)?
+            .iter()
+            .find(|manifest| &manifest.version == version)
+    }
+
+    // Report installable versions using the same eligibility checks as resolution.
+    fn available_versions_filtered(
+        &self,
+        name: &str,
+        runtime_version: Option<&Version>,
+        min_trust: Option<f32>,
+    ) -> Result<Vec<String>, ResolveError> {
+        let versions = self.plugins.get(name).map(|v| v.as_slice()).unwrap_or(&[]);
+        let mut filtered = Vec::new();
+        for manifest in versions {
+            if manifest.yanked {
+                continue;
+            }
+            if let Some(threshold) = min_trust
+                && manifest.trust_score < threshold
+            {
+                continue;
+            }
+            if let Some(runtime) = runtime_version
+                && let Some(req) = manifest.min_runtime_version.as_deref()
+            {
+                let min_version =
+                    Version::parse(req).map_err(|_| ResolveError::InvalidRuntimeVersion {
+                        name: manifest.name.clone(),
+                        value: req.to_string(),
+                    })?;
+                if runtime < &min_version {
+                    continue;
+                }
+            }
+            filtered.push(manifest.version.to_string());
+        }
+        Ok(filtered)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedDep {
+    pub name: String,
+    pub version: Version,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginLock {
+    pub resolved: Vec<ResolvedDep>,
+    pub generated_at: SystemTime,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResolveError {
+    #[error("Dependency not found: {name}")]
+    NotFound { name: String },
+    #[error("Version conflict for {name}: {required}, available={available:?}")]
+    Conflict {
+        name: String,
+        required: String,
+        available: Vec<String>,
+    },
+    #[error("Invalid runtime version requirement for {name}: {value}")]
+    InvalidRuntimeVersion { name: String, value: String },
+    #[error("Dependency cycle detected: {cycle:?}")]
+    Cycle { cycle: Vec<String> },
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CompositionError {
+    #[error("Selected plugin version not found in registry: {name}@{version}")]
+    MissingSelectedVersion { name: String, version: Version },
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum VerificationError {
+    #[error("Missing public key for plugin {name}")]
+    MissingPublicKey { name: String },
+    #[error("Invalid public key for plugin {name}")]
+    InvalidPublicKey { name: String },
+    #[error("Invalid signature encoding for plugin {name}")]
+    InvalidSignature { name: String },
+    #[error("Signature verification failed for plugin {name}")]
+    VerificationFailed { name: String },
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum InstallError {
+    #[error(transparent)]
+    Resolve(#[from] ResolveError),
+    #[error(transparent)]
+    Verify(#[from] VerificationError),
+    #[error("Missing artifact bytes for plugin {name}")]
+    MissingArtifact { name: String },
+    #[error("Selected plugin version not found in registry: {name}@{version}")]
+    MissingSelectedVersion { name: String, version: Version },
+    #[error("Failed to create install directory {path}: {source}")]
+    CreateDir {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to write plugin artifact {path}: {source}")]
+    WriteArtifact {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Default)]
+pub struct PluginResolver;
+
+impl PluginResolver {
+    // Resolve using default filters only.
+    pub fn resolve(
+        registry: &PluginRegistry,
+        roots: &[PluginDep],
+    ) -> Result<ResolvedVersions, ResolveError> {
+        resolve(registry, roots)
+    }
+
+    // Resolve while enforcing a minimum runtime version.
+    pub fn resolve_with_runtime(
+        registry: &PluginRegistry,
+        roots: &[PluginDep],
+        runtime_version: &Version,
+    ) -> Result<ResolvedVersions, ResolveError> {
+        resolve_with_runtime(registry, roots, runtime_version)
+    }
+
+    pub fn resolve_with_options(
+        registry: &PluginRegistry,
+        roots: &[PluginDep],
+        runtime_version: Option<&Version>,
+        min_trust: Option<f32>,
+    ) -> Result<ResolvedVersions, ResolveError> {
+        resolve_with_options(registry, roots, runtime_version, min_trust)
+    }
+
+    pub fn resolve_install_order(
+        registry: &PluginRegistry,
+        roots: &[PluginDep],
+        runtime_version: Option<&Version>,
+        min_trust: Option<f32>,
+    ) -> Result<Vec<ResolvedDep>, ResolveError> {
+        resolve_install_order(registry, roots, runtime_version, min_trust)
+    }
+
+    pub fn compose_capabilities(
+        selected: &ResolvedVersions,
+        registry: &PluginRegistry,
+    ) -> Result<Vec<PluginCapability>, CompositionError> {
+        compose_capabilities(selected, registry)
+    }
+
+    pub fn verify_plugin_signature(
+        manifest: &PluginManifest,
+        artifact_bytes: &[u8],
+        public_key_hex: &str,
+    ) -> Result<(), VerificationError> {
+        verify_plugin_signature(manifest, artifact_bytes, public_key_hex)
+    }
+
+    pub fn install_resolved_plugins(
+        registry: &PluginRegistry,
+        roots: &[PluginDep],
+        artifacts: &HashMap<String, Vec<u8>>,
+        public_keys: &HashMap<String, String>,
+        install_dir: &Path,
+        runtime_version: Option<&Version>,
+        min_trust: Option<f32>,
+    ) -> Result<PluginLock, InstallError> {
+        install_resolved_plugins(
+            registry,
+            roots,
+            artifacts,
+            public_keys,
+            install_dir,
+            runtime_version,
+            min_trust,
+        )
+    }
+}
+
+pub type DependencyResolver = PluginResolver;
+
+// Resolve with no runtime or trust filtering.
+pub fn resolve(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+) -> Result<ResolvedVersions, ResolveError> {
+    resolve_with_options(registry, roots, None, None)
+}
+
+// Resolve while enforcing a runtime floor.
+pub fn resolve_with_runtime(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+    runtime_version: &Version,
+) -> Result<ResolvedVersions, ResolveError> {
+    resolve_with_options(registry, roots, Some(runtime_version), None)
+}
+
+// Shared entrypoint for all resolver filter combinations.
+pub fn resolve_with_options(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<ResolvedVersions, ResolveError> {
+    let (resolved, selected_manifests) = resolve_internal(registry, roots, runtime_version, min_trust)?;
+    if let Some(cycle) = detect_cycle(&selected_manifests) {
+        return Err(ResolveError::Cycle { cycle });
+    }
+
+    Ok(resolved)
+}
+
+// Return the resolved set in dependency-safe install order.
+pub fn resolve_install_order(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<Vec<ResolvedDep>, ResolveError> {
+    let (resolved, selected_manifests) = resolve_internal(registry, roots, runtime_version, min_trust)?;
+    if let Some(cycle) = detect_cycle(&selected_manifests) {
+        return Err(ResolveError::Cycle { cycle });
+    }
+
+    topological_install_order(&resolved, &selected_manifests)
+}
+
+// Merge unique capabilities from the resolved plugin set.
+pub fn compose_capabilities(
+    selected: &ResolvedVersions,
+    registry: &PluginRegistry,
+) -> Result<Vec<PluginCapability>, CompositionError> {
+    let mut capabilities = Vec::new();
+    let mut names: Vec<_> = selected.keys().cloned().collect();
+    names.sort();
+
+    for name in names {
+        let version = selected.get(&name).expect("name collected from selected");
+        let manifest = registry
+            .get_version(&name, version)
+            .ok_or_else(|| CompositionError::MissingSelectedVersion {
+                name: name.clone(),
+                version: version.clone(),
+            })?;
+        for capability in &manifest.capabilities {
+            if !capabilities.contains(capability) {
+                capabilities.push(capability.clone());
+            }
+        }
+    }
+
+    Ok(capabilities)
+}
+
+// Verify an artifact against the manifest signature using the caller-provided public key.
+pub fn verify_plugin_signature(
+    manifest: &PluginManifest,
+    artifact_bytes: &[u8],
+    public_key_hex: &str,
+) -> Result<(), VerificationError> {
+    let public_key_bytes =
+        hex::decode(public_key_hex).map_err(|_| VerificationError::InvalidPublicKey {
+            name: manifest.name.clone(),
+        })?;
+    let public_key_bytes: [u8; 32] = public_key_bytes
+        .try_into()
+        .map_err(|_| VerificationError::InvalidPublicKey {
+            name: manifest.name.clone(),
+        })?;
+    let public_key = VerifyingKey::from_bytes(&public_key_bytes).map_err(|_| {
+        VerificationError::InvalidPublicKey {
+            name: manifest.name.clone(),
+        }
+    })?;
+
+    let signature_bytes =
+        hex::decode(&manifest.signature).map_err(|_| VerificationError::InvalidSignature {
+            name: manifest.name.clone(),
+        })?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| {
+        VerificationError::InvalidSignature {
+            name: manifest.name.clone(),
+        }
+    })?;
+
+    let artifact_hash = Sha256::digest(artifact_bytes);
+    public_key
+        .verify(&artifact_hash, &signature)
+        .map_err(|_| VerificationError::VerificationFailed {
+            name: manifest.name.clone(),
+        })
+}
+
+// Resolve, verify, and write artifacts in dependency-safe order.
+pub fn install_resolved_plugins(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+    artifacts: &HashMap<String, Vec<u8>>,
+    public_keys: &HashMap<String, String>,
+    install_dir: &Path,
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<PluginLock, InstallError> {
+    let ordered = resolve_install_order(registry, roots, runtime_version, min_trust)?;
+
+    std::fs::create_dir_all(install_dir).map_err(|source| InstallError::CreateDir {
+        path: install_dir.display().to_string(),
+        source,
+    })?;
+
+    for dep in &ordered {
+        let manifest = registry
+            .get_version(&dep.name, &dep.version)
+            .ok_or_else(|| InstallError::MissingSelectedVersion {
+                name: dep.name.clone(),
+                version: dep.version.clone(),
+            })?;
+        let artifact = artifacts
+            .get(&dep.name)
+            .ok_or_else(|| InstallError::MissingArtifact {
+                name: dep.name.clone(),
+            })?;
+        let public_key = public_keys
+            .get(&dep.name)
+            .ok_or_else(|| VerificationError::MissingPublicKey {
+                name: dep.name.clone(),
+            })?;
+
+        verify_plugin_signature(manifest, artifact, public_key)?;
+
+        let artifact_path = install_dir.join(format!("{}-{}.wasm", dep.name, dep.version));
+        std::fs::write(&artifact_path, artifact).map_err(|source| InstallError::WriteArtifact {
+            path: artifact_path.display().to_string(),
+            source,
+        })?;
+    }
+
+    Ok(PluginLock {
+        resolved: ordered,
+        generated_at: SystemTime::now(),
+    })
+}
+
+// Seed the solver with root constraints and defer version choice to backtracking.
+fn resolve_internal(
+    registry: &PluginRegistry,
+    roots: &[PluginDep],
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<(ResolvedVersions, HashMap<String, PluginManifest>), ResolveError> {
+    let mut constraints: HashMap<String, Vec<VersionReq>> = HashMap::new();
+    let mut queue: VecDeque<PluginDep> = VecDeque::from(roots.to_vec());
+
+    while let Some(dep) = queue.pop_front() {
+        constraints
+            .entry(dep.name.clone())
+            .or_default()
+            .push(dep.req.clone());
+    }
+
+    solve_versions(
+        registry,
+        &constraints,
+        &HashMap::new(),
+        runtime_version,
+        min_trust,
+    )
+}
+
+// Explore candidate versions package-by-package until all constraints are satisfied.
+fn solve_versions(
+    registry: &PluginRegistry,
+    constraints: &HashMap<String, Vec<VersionReq>>,
+    selected: &HashMap<String, PluginManifest>,
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<(ResolvedVersions, HashMap<String, PluginManifest>), ResolveError> {
+    if let Some(name) = inconsistent_selected_package(constraints, selected) {
+        let requirements = constraints.get(&name).cloned().unwrap_or_default();
+        return Err(ResolveError::Conflict {
+            name: name.clone(),
+            required: format_requirements(&requirements),
+            available: registry.available_versions_filtered(&name, runtime_version, min_trust)?,
+        });
+    }
+
+    let Some(next_name) = select_next_package(registry, constraints, selected, runtime_version, min_trust)? else {
+        let mut resolved = ResolvedVersions::new();
+        for (name, manifest) in selected {
+            resolved.insert(name.clone(), manifest.version.clone());
+        }
+        return Ok((resolved, selected.clone()));
+    };
+
+    let requirements = constraints.get(&next_name).cloned().unwrap_or_default();
+    let candidates = registry.candidates_for(&next_name, &requirements, runtime_version, min_trust)?;
+    if candidates.is_empty() {
+        if !registry.plugins.contains_key(&next_name) {
+            return Err(ResolveError::NotFound {
+                name: next_name.clone(),
+            });
+        }
+        return Err(ResolveError::Conflict {
+            name: next_name.clone(),
+            required: format_requirements(&requirements),
+            available: registry.available_versions_filtered(&next_name, runtime_version, min_trust)?,
+        });
+    }
+
+    let mut last_err = None;
+    for candidate in candidates {
+        let mut next_selected = selected.clone();
+        next_selected.insert(next_name.clone(), candidate.clone());
+
+        let mut next_constraints = constraints.clone();
+        for dep in candidate.dependency_requirements() {
+            next_constraints.entry(dep.name).or_default().push(dep.req);
+        }
+
+        match solve_versions(
+            registry,
+            &next_constraints,
+            &next_selected,
+            runtime_version,
+            min_trust,
+        ) {
+            Ok(solution) => return Ok(solution),
+            Err(err) => last_err = Some(err),
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| ResolveError::Conflict {
+        name: next_name.clone(),
+        required: format_requirements(&requirements),
+        available: registry
+            .available_versions_filtered(&next_name, runtime_version, min_trust)
+            .unwrap_or_default(),
+    }))
+}
+
+// Pick the unresolved package with the fewest viable candidates first.
+fn select_next_package(
+    registry: &PluginRegistry,
+    constraints: &HashMap<String, Vec<VersionReq>>,
+    selected: &HashMap<String, PluginManifest>,
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<Option<String>, ResolveError> {
+    let mut best: Option<(String, usize)> = None;
+
+    for (name, requirements) in constraints {
+        if selected.contains_key(name) {
+            continue;
+        }
+
+        let candidate_count = registry
+            .candidates_for(name, requirements, runtime_version, min_trust)?
+            .len();
+        match &best {
+            Some((best_name, best_count))
+                if candidate_count > *best_count
+                    || (candidate_count == *best_count && name >= best_name) => {}
+            _ => best = Some((name.clone(), candidate_count)),
+        }
+    }
+
+    Ok(best.map(|(name, _)| name))
+}
+
+fn inconsistent_selected_package(
+    constraints: &HashMap<String, Vec<VersionReq>>,
+    selected: &HashMap<String, PluginManifest>,
+) -> Option<String> {
+    for (name, requirements) in constraints {
+        if let Some(manifest) = selected.get(name)
+            && !requirements.iter().all(|req| req.matches(&manifest.version))
+        {
+            return Some(name.clone());
+        }
+    }
+
+    None
+}
+
+fn format_requirements(requirements: &[VersionReq]) -> String {
+    requirements
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" && ")
+}
+
+// Convert the resolved graph into an install order where dependencies come first.
+fn topological_install_order(
+    resolved: &ResolvedVersions,
+    selected_manifests: &HashMap<String, PluginManifest>,
+) -> Result<Vec<ResolvedDep>, ResolveError> {
+    let mut indegree: HashMap<String, usize> = resolved.keys().cloned().map(|name| (name, 0)).collect();
+    let mut outgoing: HashMap<String, Vec<String>> = HashMap::new();
+
+    for (name, manifest) in selected_manifests {
+        let mut seen = HashSet::new();
+        for dep in manifest.dependency_requirements() {
+            if !resolved.contains_key(&dep.name) || !seen.insert(dep.name.clone()) {
+                continue;
+            }
+            outgoing.entry(dep.name.clone()).or_default().push(name.clone());
+            if let Some(entry) = indegree.get_mut(name) {
+                *entry += 1;
+            }
+        }
+    }
+
+    let mut ready: Vec<String> = indegree
+        .iter()
+        .filter_map(|(name, degree)| (*degree == 0).then_some(name.clone()))
+        .collect();
+    ready.sort();
+
+    let mut queue = VecDeque::from(ready);
+    let mut ordered = Vec::with_capacity(resolved.len());
+
+    while let Some(name) = queue.pop_front() {
+        ordered.push(ResolvedDep {
+            version: resolved.get(&name).expect("resolved entry exists").clone(),
+            name: name.clone(),
+        });
+
+        if let Some(children) = outgoing.get(&name) {
+            for child in children {
+                if let Some(entry) = indegree.get_mut(child) {
+                    *entry -= 1;
+                    if *entry == 0 {
+                        queue.push_back(child.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if ordered.len() != resolved.len() {
+        let cycle: Vec<String> = indegree
+            .into_iter()
+            .filter_map(|(name, degree)| (degree > 0).then_some(name))
+            .collect();
+        return Err(ResolveError::Cycle { cycle });
+    }
+
+    Ok(ordered)
+}
+
+// Detect cycles on the selected graph so cycle errors only reflect chosen versions.
+fn detect_cycle(selected: &HashMap<String, PluginManifest>) -> Option<Vec<String>> {
+    let mut visiting: HashMap<String, usize> = HashMap::new();
+    let mut stack: Vec<String> = Vec::new();
+
+    fn dfs(
+        name: &str,
+        selected: &HashMap<String, PluginManifest>,
+        visiting: &mut HashMap<String, usize>,
+        stack: &mut Vec<String>,
+    ) -> Option<Vec<String>> {
+        if let Some(&idx) = visiting.get(name) {
+            return Some(stack[idx..].to_vec());
+        }
+
+        visiting.insert(name.to_string(), stack.len());
+        stack.push(name.to_string());
+
+        if let Some(manifest) = selected.get(name) {
+            for dep in manifest.dependency_requirements() {
+                if selected.contains_key(&dep.name)
+                    && let Some(cycle) = dfs(&dep.name, selected, visiting, stack)
+                {
+                    return Some(cycle);
+                }
+            }
+        }
+
+        visiting.remove(name);
+        stack.pop();
+        None
+    }
+
+    let names: Vec<String> = selected.keys().cloned().collect();
+    for name in names {
+        if let Some(cycle) = dfs(&name, selected, &mut visiting, &mut stack) {
+            return Some(cycle);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wasm_runtime::types::AuditStatus;
+    use ed25519_dalek::{Signer, SigningKey};
+    use tempfile::TempDir;
+
+    fn manifest(name: &str, version: &str, deps: &[PluginDep]) -> PluginManifest {
+        let mut manifest = PluginManifest::new_from_str(name, version).unwrap();
+        for dep in deps {
+            manifest = manifest.with_dependency(dep.clone());
+        }
+        manifest
+    }
+
+    fn dep(name: &str, req: &str) -> PluginDep {
+        PluginDep::parse(name, req).unwrap()
+    }
+
+    #[test]
+    fn test_resolve_single_dep() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("alpha", ">=1.0")]).unwrap();
+        assert_eq!(resolved.get("alpha"), Some(&Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_resolve_picks_highest_matching() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[]));
+        registry.publish(manifest("alpha", "1.2.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("alpha", ">=1.0")]).unwrap();
+        assert_eq!(resolved.get("alpha"), Some(&Version::new(1, 2, 0)));
+    }
+
+    #[test]
+    fn test_resolve_transitive_deps() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("gamma", "1.0.0", &[]));
+        registry.publish(manifest("beta", "1.0.0", &[dep("gamma", "^1.0")]));
+        registry.publish(manifest("alpha", "1.0.0", &[dep("beta", ">=1.0")]));
+
+        let resolved = resolve(&registry, &[dep("alpha", ">=1.0")]).unwrap();
+        assert_eq!(resolved.len(), 3);
+        assert_eq!(resolved.get("gamma"), Some(&Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_resolve_missing_dep_errors() {
+        let registry = PluginRegistry::new();
+        let err = resolve(&registry, &[dep("missing", ">=1.0")]).unwrap_err();
+        assert!(matches!(err, ResolveError::NotFound { name } if name == "missing"));
+    }
+
+    #[test]
+    fn test_resolve_version_conflict_errors() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("core", "1.0.0", &[]));
+        registry.publish(manifest("core", "2.0.0", &[]));
+
+        let err = resolve(&registry, &[dep("core", "<2.0"), dep("core", ">=2.0")]).unwrap_err();
+        assert!(matches!(err, ResolveError::Conflict { name, .. } if name == "core"));
+    }
+
+    #[test]
+    fn test_resolve_semver_req_respected() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("agent", "1.2.0", &[]));
+        registry.publish(manifest("agent", "2.0.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("agent", ">=1.2.0, <2.0")]).unwrap();
+        assert_eq!(resolved.get("agent"), Some(&Version::new(1, 2, 0)));
+    }
+
+    #[test]
+    fn test_resolve_skips_yanked_versions() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "2.0.0", &[]).with_yanked(true));
+        registry.publish(manifest("alpha", "1.9.0", &[]).with_deprecated(true));
+        registry.publish(manifest("alpha", "1.5.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("alpha", ">=1.0")]).unwrap();
+        assert_eq!(resolved.get("alpha"), Some(&Version::new(1, 9, 0)));
+    }
+
+    #[test]
+    fn test_resolve_with_min_runtime_version() {
+        let mut registry = PluginRegistry::new();
+        let mut v2 = manifest("beta", "2.0.0", &[]);
+        v2.min_runtime_version = Some("2.0.0".to_string());
+        let mut v1 = manifest("beta", "1.0.0", &[]);
+        v1.min_runtime_version = Some("1.0.0".to_string());
+        registry.publish(v2);
+        registry.publish(v1);
+
+        let runtime = Version::new(1, 5, 0);
+        let resolved = resolve_with_options(&registry, &[dep("beta", ">=1.0")], Some(&runtime), None)
+            .unwrap();
+        assert_eq!(resolved.get("beta"), Some(&Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_resolve_with_trust_score_filter() {
+        let mut registry = PluginRegistry::new();
+        let low = manifest("gamma", "2.0.0", &[]).with_trust_score(0.2);
+        let high = manifest("gamma", "1.5.0", &[])
+            .with_community_rating(0.9)
+            .with_download_count(10_000)
+            .with_audit_status(AuditStatus::Passed);
+        registry.publish(low);
+        registry.publish(high);
+
+        let resolved =
+            resolve_with_options(&registry, &[dep("gamma", ">=1.0")], None, Some(0.5)).unwrap();
+        assert_eq!(resolved.get("gamma"), Some(&Version::new(1, 5, 0)));
+    }
+
+    #[test]
+    fn test_large_graph_resolves() {
+        let mut registry = PluginRegistry::new();
+        let node_count = 25;
+        for i in (0..node_count).rev() {
+            let name = format!("node-{i}");
+            let deps = if i + 1 < node_count {
+                vec![dep(&format!("node-{}", i + 1), ">=1.0")]
+            } else {
+                Vec::new()
+            };
+            registry.publish(manifest(&name, "1.0.0", &deps));
+        }
+
+        let resolved = resolve(&registry, &[dep("node-0", ">=1.0")]).unwrap();
+        assert_eq!(resolved.len(), node_count);
+    }
+
+    #[test]
+    fn test_resolve_diamond_solvable() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[dep("bravo", ">=1.0")]));
+        registry.publish(manifest("charlie", "1.0.0", &[dep("bravo", ">=1.1")]));
+        registry.publish(manifest("bravo", "1.2.0", &[]));
+        registry.publish(manifest("bravo", "1.0.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("alpha", ">=1.0"), dep("charlie", ">=1.0")])
+            .unwrap();
+        assert_eq!(resolved.get("bravo"), Some(&Version::new(1, 2, 0)));
+    }
+
+    #[test]
+    fn test_resolve_diamond_unsolvable() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[dep("bravo", ">=2.0")]));
+        registry.publish(manifest("charlie", "1.0.0", &[dep("bravo", "<2.0")]));
+        registry.publish(manifest("bravo", "1.5.0", &[]));
+        registry.publish(manifest("bravo", "2.1.0", &[]));
+
+        let err = resolve(&registry, &[dep("alpha", ">=1.0"), dep("charlie", ">=1.0")])
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Conflict { name, .. } if name == "bravo"));
+    }
+
+    #[test]
+    fn test_publish_cycle_detection() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[dep("bravo", ">=1.0")]));
+        registry.publish(manifest("bravo", "1.0.0", &[dep("alpha", ">=1.0")]));
+
+        let err = resolve(&registry, &[dep("alpha", ">=1.0")]).unwrap_err();
+        assert!(matches!(err, ResolveError::Cycle { .. }));
+    }
+
+    #[test]
+    fn test_resolve_backtracks_to_satisfy_later_constraint() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("app", "1.0.0", &[dep("shared", ">=1.0, <3.0")]));
+        registry.publish(manifest("addon", "1.0.0", &[dep("shared", "<2.0")]));
+        registry.publish(manifest("shared", "2.0.0", &[dep("core", ">=2.0")]));
+        registry.publish(manifest("shared", "1.5.0", &[dep("core", ">=1.0, <2.0")]));
+        registry.publish(manifest("core", "2.0.0", &[]));
+        registry.publish(manifest("core", "1.0.0", &[]));
+
+        let resolved = resolve(&registry, &[dep("app", ">=1.0"), dep("addon", ">=1.0")])
+            .unwrap();
+        assert_eq!(resolved.get("shared"), Some(&Version::new(1, 5, 0)));
+        assert_eq!(resolved.get("core"), Some(&Version::new(1, 0, 0)));
+    }
+
+    #[test]
+    fn test_resolve_install_order_places_dependencies_first() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest("alpha", "1.0.0", &[dep("bravo", ">=1.0")]));
+        registry.publish(manifest("bravo", "1.0.0", &[dep("charlie", ">=1.0")]));
+        registry.publish(manifest("charlie", "1.0.0", &[]));
+
+        let ordered = resolve_install_order(&registry, &[dep("alpha", ">=1.0")], None, None)
+            .unwrap();
+        let names: Vec<_> = ordered.iter().map(|dep| dep.name.as_str()).collect();
+        assert_eq!(names, vec!["charlie", "bravo", "alpha"]);
+    }
+
+    #[test]
+    fn test_manual_trust_score_override_is_stable() {
+        let manifest = manifest("alpha", "1.0.0", &[])
+            .with_trust_score(0.2)
+            .with_community_rating(1.0)
+            .with_download_count(1_000_000)
+            .with_audit_status(AuditStatus::Passed);
+
+        assert_eq!(manifest.trust_score, 0.2);
+    }
+
+    #[test]
+    fn test_compose_capabilities_from_selected_plugins() {
+        let mut registry = PluginRegistry::new();
+        registry.publish(
+            manifest("alpha", "1.0.0", &[])
+                .with_capability(PluginCapability::HttpClient)
+                .with_capability(PluginCapability::Custom("summarise".to_string())),
+        );
+        registry.publish(
+            manifest("bravo", "1.0.0", &[])
+                .with_capability(PluginCapability::HttpClient)
+                .with_capability(PluginCapability::Storage),
+        );
+
+        let mut selected = ResolvedVersions::new();
+        selected.insert("alpha".to_string(), Version::new(1, 0, 0));
+        selected.insert("bravo".to_string(), Version::new(1, 0, 0));
+
+        let capabilities = compose_capabilities(&selected, &registry).unwrap();
+        assert!(capabilities.contains(&PluginCapability::HttpClient));
+        assert!(capabilities.contains(&PluginCapability::Storage));
+        assert!(capabilities.contains(&PluginCapability::Custom("summarise".to_string())));
+    }
+
+    #[test]
+    fn test_verify_plugin_signature() {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let public_key = hex::encode(signing_key.verifying_key().as_bytes());
+        let artifact = b"plugin-bytes";
+        let artifact_hash = Sha256::digest(artifact);
+        let signature = signing_key.sign(&artifact_hash);
+
+        let manifest =
+            manifest("alpha", "1.0.0", &[]).with_signature(hex::encode(signature.to_bytes()));
+        verify_plugin_signature(&manifest, artifact, &public_key).unwrap();
+    }
+
+    #[test]
+    fn test_install_resolved_plugins() {
+        let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+        let public_key = hex::encode(signing_key.verifying_key().as_bytes());
+        let artifact = b"wasm-module".to_vec();
+        let artifact_hash = Sha256::digest(&artifact);
+        let signature = signing_key.sign(&artifact_hash);
+
+        let manifest = manifest("alpha", "1.0.0", &[])
+            .with_signature(hex::encode(signature.to_bytes()))
+            .with_community_rating(0.8)
+            .with_download_count(10_000)
+            .with_audit_status(AuditStatus::Passed);
+
+        let mut registry = PluginRegistry::new();
+        registry.publish(manifest);
+
+        let mut artifacts = HashMap::new();
+        artifacts.insert("alpha".to_string(), artifact);
+        let mut public_keys = HashMap::new();
+        public_keys.insert("alpha".to_string(), public_key);
+
+        let temp = TempDir::new().unwrap();
+        let lock = install_resolved_plugins(
+            &registry,
+            &[dep("alpha", ">=1.0")],
+            &artifacts,
+            &public_keys,
+            temp.path(),
+            None,
+            Some(0.5),
+        )
+        .unwrap();
+
+        assert_eq!(lock.resolved.len(), 1);
+        assert!(temp.path().join("alpha-1.0.0.wasm").exists());
+    }
+}

--- a/crates/mofa-plugins/src/wasm_runtime/manager.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/manager.rs
@@ -548,7 +548,7 @@ mod tests {
     async fn test_plugin_registry() {
         let registry = PluginRegistry::new();
 
-        let manifest = PluginManifest::new("test", "1.0.0")
+        let manifest = PluginManifest::new_from_str("test", "1.0.0").unwrap()
             .with_capability(PluginCapability::ReadConfig)
             .with_capability(PluginCapability::SendMessage);
 

--- a/crates/mofa-plugins/src/wasm_runtime/mod.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/mod.rs
@@ -44,7 +44,7 @@ mod manager;
 mod memory;
 mod plugin;
 pub mod runtime;
-mod types;
+pub mod types;
 
 pub use host::{HostCallback, HostContext, HostFunctions, LogLevel, MessageDirection};
 pub use manager::{LoadedPlugin, PluginEvent, PluginHandle, PluginRegistry, WasmPluginManager};
@@ -54,6 +54,6 @@ pub use memory::{
 pub use plugin::{PluginInstance, PluginMetrics, WasmPlugin, WasmPluginConfig, WasmPluginState};
 pub use runtime::{CompiledModule, ModuleCache, RuntimeConfig, RuntimeStats, WasmRuntime};
 pub use types::{
-    ExecutionConfig, IntoWasmReport, MemoryConfig, PluginCapability, PluginExport, PluginManifest,
-    ResourceLimits, WasmError, WasmReport, WasmResult, WasmType, WasmValue,
+    ExecutionConfig, IntoWasmReport, MemoryConfig, PluginCapability, PluginDep, PluginExport,
+    PluginManifest, ResourceLimits, WasmError, WasmReport, WasmResult, WasmType, WasmValue,
 };

--- a/crates/mofa-plugins/src/wasm_runtime/plugin.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/plugin.rs
@@ -296,7 +296,7 @@ impl WasmPlugin {
 
     fn extract_manifest(module: &Module, config: &WasmPluginConfig) -> PluginManifest {
         // Try to extract from custom section or use defaults
-        let mut manifest = PluginManifest::new(&config.id, "1.0.0");
+        let mut manifest = PluginManifest::new_from_str(&config.id, "1.0.0").unwrap();
 
         // List exports from module
         for export in module.exports() {

--- a/crates/mofa-plugins/src/wasm_runtime/runtime.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/runtime.rs
@@ -514,7 +514,7 @@ fn create_plugin_from_module(
     use super::plugin::*;
 
     let manifest = {
-        let mut manifest = super::types::PluginManifest::new(&config.id, "1.0.0");
+        let mut manifest = super::types::PluginManifest::new_from_str(&config.id, "1.0.0").unwrap();
         for export in module.exports() {
             if let ExternType::Func(_) = export.ty() {
                 manifest.exports.push(super::types::PluginExport::function(

--- a/crates/mofa-plugins/src/wasm_runtime/types.rs
+++ b/crates/mofa-plugins/src/wasm_runtime/types.rs
@@ -2,6 +2,7 @@
 //!
 //! Core types for the WASM plugin runtime
 
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -289,13 +290,89 @@ impl fmt::Display for PluginCapability {
     }
 }
 
+/// Declared dependency requirement for a plugin
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginDep {
+    pub name: String,
+    pub req: VersionReq,
+}
+
+impl PluginDep {
+    /// Create a new dependency with the provided semver requirement
+    pub fn new(name: &str, req: VersionReq) -> Self {
+        Self {
+            name: name.to_string(),
+            req,
+        }
+    }
+
+    /// Helper that parses a textual requirement
+    pub fn parse(name: &str, requirement: &str) -> Result<Self, semver::Error> {
+        let req = VersionReq::parse(requirement)?;
+        Ok(Self {
+            name: name.to_string(),
+            req,
+        })
+    }
+}
+
+/// Audit status captured by the marketplace trust pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AuditStatus {
+    Unknown,
+    Passed,
+    Failed,
+    Pending,
+}
+
+impl Default for AuditStatus {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+impl AuditStatus {
+    pub fn trust_bonus(&self) -> f32 {
+        match self {
+            Self::Passed => 1.0,
+            Self::Pending => 0.5,
+            Self::Unknown => 0.25,
+            Self::Failed => 0.0,
+        }
+    }
+}
+
 /// Plugin manifest describing the plugin
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginManifest {
     /// Plugin name
     pub name: String,
     /// Plugin version
-    pub version: String,
+    pub version: Version,
+    /// Yanked versions should not be selected by default
+    #[serde(default)]
+    pub yanked: bool,
+    /// Deprecated marker kept for registry policy and install-time warnings
+    #[serde(default)]
+    pub deprecated: bool,
+    /// Trust score (0.0 - 1.0)
+    #[serde(default)]
+    pub trust_score: f32,
+    /// Community rating in the range 0.0 - 1.0
+    #[serde(default)]
+    pub community_rating: f32,
+    /// Aggregate download count used by the trust model
+    #[serde(default)]
+    pub download_count: u64,
+    /// Ed25519 signature stored with the published plugin artifact
+    #[serde(default)]
+    pub signature: String,
+    /// Audit state used by marketplace trust policies
+    #[serde(default)]
+    pub audit_status: AuditStatus,
+    /// Internal flag to preserve explicit trust overrides across builder calls.
+    #[serde(skip)]
+    trust_score_locked: bool,
     /// Plugin description
     pub description: Option<String>,
     /// Plugin author
@@ -312,13 +389,24 @@ pub struct PluginManifest {
     pub config_schema: Option<serde_json::Value>,
     /// Plugin metadata
     pub metadata: HashMap<String, String>,
+    /// Declared dependencies
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dependencies: HashMap<String, VersionReq>,
 }
 
 impl Default for PluginManifest {
     fn default() -> Self {
         Self {
             name: "unknown".to_string(),
-            version: "0.0.0".to_string(),
+            version: Version::new(0, 0, 0),
+            yanked: false,
+            deprecated: false,
+            trust_score: 1.0,
+            community_rating: 0.0,
+            download_count: 0,
+            signature: String::new(),
+            audit_status: AuditStatus::Unknown,
+            trust_score_locked: false,
             description: None,
             author: None,
             license: None,
@@ -327,17 +415,22 @@ impl Default for PluginManifest {
             min_runtime_version: None,
             config_schema: None,
             metadata: HashMap::new(),
+            dependencies: HashMap::new(),
         }
     }
 }
 
 impl PluginManifest {
-    pub fn new(name: &str, version: &str) -> Self {
+    pub fn new(name: &str, version: Version) -> Self {
         Self {
             name: name.to_string(),
-            version: version.to_string(),
+            version,
             ..Default::default()
         }
+    }
+
+    pub fn new_from_str(name: &str, version: &str) -> Result<Self, semver::Error> {
+        Ok(Self::new(name, Version::parse(version)?))
     }
 
     pub fn with_description(mut self, description: &str) -> Self {
@@ -355,6 +448,70 @@ impl PluginManifest {
     pub fn with_export(mut self, export: PluginExport) -> Self {
         self.exports.push(export);
         self
+    }
+
+    pub fn with_dependency(mut self, dependency: PluginDep) -> Self {
+        self.dependencies.insert(dependency.name, dependency.req);
+        self
+    }
+
+    pub fn with_trust_score(mut self, trust_score: f32) -> Self {
+        self.trust_score = trust_score.clamp(0.0, 1.0);
+        self.trust_score_locked = true;
+        self
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.signature = signature.into();
+        self
+    }
+
+    pub fn with_community_rating(mut self, community_rating: f32) -> Self {
+        self.community_rating = community_rating.clamp(0.0, 1.0);
+        self.recompute_trust_score();
+        self
+    }
+
+    pub fn with_download_count(mut self, download_count: u64) -> Self {
+        self.download_count = download_count;
+        self.recompute_trust_score();
+        self
+    }
+
+    pub fn with_audit_status(mut self, audit_status: AuditStatus) -> Self {
+        self.audit_status = audit_status;
+        self.recompute_trust_score();
+        self
+    }
+
+    pub fn with_yanked(mut self, yanked: bool) -> Self {
+        self.yanked = yanked;
+        self
+    }
+
+    pub fn with_deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = deprecated;
+        self
+    }
+
+    pub fn dependency_requirements(&self) -> impl Iterator<Item = PluginDep> + '_ {
+        self.dependencies.iter().map(|(name, req)| PluginDep {
+            name: name.clone(),
+            req: req.clone(),
+        })
+    }
+
+    pub fn recompute_trust_score(&mut self) {
+        if self.trust_score_locked {
+            return;
+        }
+        let downloads_component = ((self.download_count as f32 + 1.0).ln() / 10.0).clamp(0.0, 1.0);
+        self.trust_score = (
+            0.4 * self.community_rating.clamp(0.0, 1.0)
+                + 0.3 * self.audit_status.trust_bonus()
+                + 0.3 * downloads_component
+        )
+        .clamp(0.0, 1.0);
     }
 
     pub fn has_capability(&self, capability: &PluginCapability) -> bool {
@@ -556,13 +713,14 @@ mod tests {
 
     #[test]
     fn test_plugin_manifest() {
-        let manifest = PluginManifest::new("test-plugin", "1.0.0")
+        let manifest = PluginManifest::new_from_str("test-plugin", "1.0.0")
+            .unwrap()
             .with_description("A test plugin")
             .with_capability(PluginCapability::ReadConfig)
             .with_capability(PluginCapability::SendMessage);
 
         assert_eq!(manifest.name, "test-plugin");
-        assert_eq!(manifest.version, "1.0.0");
+        assert_eq!(manifest.version, Version::new(1, 0, 0));
         assert!(manifest.has_capability(&PluginCapability::ReadConfig));
         assert!(!manifest.has_capability(&PluginCapability::Storage));
     }

--- a/crates/mofa-runtime/Cargo.toml
+++ b/crates/mofa-runtime/Cargo.toml
@@ -31,6 +31,7 @@ eyre.workspace = true
 mofa-kernel = { path = "../mofa-kernel", version = "0.1", features = ["config"] }
 mofa-foundation = { path = "../mofa-foundation", version = "0.1" }
 mofa-plugins = { path = "../mofa-plugins", version = "0.1" }
+semver = { workspace = true }
 mofa-monitoring = { path = "../mofa-monitoring", version = "0.1", optional = true }
 # Dora-rs dependencies
 dora-node-api = { version = "0", default-features = false, optional = true }

--- a/crates/mofa-runtime/src/lib.rs
+++ b/crates/mofa-runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod rag;
 pub mod retry;
 pub mod runner;
 pub mod security;
+pub mod swarm;
 
 // Dora adapter module (only compiled when dora feature is enabled)
 #[cfg(feature = "dora")]

--- a/crates/mofa-runtime/src/swarm/mod.rs
+++ b/crates/mofa-runtime/src/swarm/mod.rs
@@ -1,0 +1,57 @@
+//! Swarm integration helpers for plugin dependency resolution.
+
+use mofa_plugins::{PluginLock, PluginRegistry, ResolveError, resolve_install_order};
+use mofa_plugins::wasm_runtime::types::{PluginDep, PluginManifest};
+use std::time::SystemTime;
+use semver::Version;
+
+/// Resolve plugin dependencies for a swarm run using the plugin registry.
+///
+/// This is a thin integration wrapper that constructs a registry from the
+/// available manifests and applies the resolver with runtime and trust filters.
+pub fn resolve_swarm_plugins(
+    manifests: &[PluginManifest],
+    roots: &[PluginDep],
+    runtime_version: Option<&Version>,
+    min_trust: Option<f32>,
+) -> Result<PluginLock, ResolveError> {
+    let mut registry = PluginRegistry::new();
+    for manifest in manifests {
+        registry.publish(manifest.clone());
+    }
+
+    let resolved = resolve_install_order(&registry, roots, runtime_version, min_trust)?;
+    Ok(PluginLock {
+        resolved,
+        generated_at: SystemTime::now(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dep(name: &str, req: &str) -> PluginDep {
+        PluginDep::parse(name, req).unwrap()
+    }
+
+    fn manifest(name: &str, version: &str, deps: &[PluginDep]) -> PluginManifest {
+        let mut manifest = PluginManifest::new_from_str(name, version).unwrap();
+        for dep in deps {
+            manifest = manifest.with_dependency(dep.clone());
+        }
+        manifest
+    }
+
+    #[test]
+    fn test_resolve_swarm_plugins_success() {
+        let manifests = vec![
+            manifest("alpha", "1.0.0", &[dep("bravo", ">=1.0")]),
+            manifest("bravo", "1.2.0", &[]),
+        ];
+
+        let lock = resolve_swarm_plugins(&manifests, &[dep("alpha", ">=1.0")], None, None)
+            .expect("resolution should succeed");
+        assert_eq!(lock.resolved.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a SemVer aware dependency resolver to `mofa-plugins`, delivering the requirement for basic dependency resolution with conflict detection. Plugins can now declare versioned dependencies, carry trust and signature metadata, and participate in a resolver-driven install flow before plugin loading.

Resolves: #1416

## Problem

Prior to this PR:
- Plugins had no SemVer aware resolver to select compatible versions.
- Conflicts between required versions were silently ignored until runtime failure.
- The swarm orchestrator had no way to build a consistent plugin set before composing a team.

## SemVer Dependency Resolution Flow

```mermaid
flowchart TD
    A[Root plugin requirements] --> B[Build PluginRegistry]
    B --> C[Resolve dependency queue]
    C --> D{Matching version exists?}
    D -- No --> E[ResolveError::NotFound]
    D -- Yes --> F[Try highest compatible version]
    F --> G{Allowed by runtime, trust and yanked filters?}
    G -- No --> H[Skip candidate and continue search]
    H --> D
    G -- Yes --> I[Select candidate version]
    I --> J{Already resolved with incompatible version?}
    J -- Yes --> K[Backtrack to next candidate]
    J -- No --> L[Push transitive dependencies]
    L --> M{Queue empty?}
    M -- No --> C
    M -- Yes --> N[Detect cycle in resolved graph]
    N --> O{Cycle found?}
    O -- Yes --> P[ResolveError::Cycle]
    O -- No --> Q[Resolve HashMap plugin_id -> version]
    Q --> R[Verify Ed25519 signatures]
    R --> S[Trust-gated install writes artifacts]
```

## Changes
#### `crates/mofa-plugins/src/wasm_runtime/types.rs`
- Added `PluginManifest.signature: String` and `PluginManifest.audit_status: AuditStatus`.
- Changed `PluginManifest.dependencies` to `HashMap<String, semver::VersionReq>` for direct dependency lookup.
- Added trust inputs on the manifest: `community_rating`, `download_count`, `trust_score`.
- Added builder helpers for trust, audit status, signature, deprecation and yanked state.
- Added trust score recomputation from marketplace metadata.

#### `crates/mofa-plugins/src/resolver.rs`
- `PluginRegistry`: sorted `HashMap<name, Vec<PluginManifest>>`.
- `PluginResolver`: public facade over the resolver API.
- `resolve()` / `resolve_with_runtime()` / `resolve_with_options()`, return `HashMap<PluginId, semver::Version>`.
- Backtracking resolver core: retries lower compatible versions when the first choice causes a later conflict.
- `resolve_install_order()`: produces dependency-safe `ResolvedDep` entries for install/runtime wiring.
- `PluginLock`: serializable snapshot of a resolved dep set with generation timestamp.
- `compose_capabilities()`: aggregates capabilities from the selected plugin set.
- `verify_plugin_signature()`: verifies SHA-256 artifact hashes against Ed25519 signatures stored on manifests.
- `install_resolved_plugins()`: performs `resolve -> verify -> install` for pre-fetched plugin artifacts.
- `ResolveError`, `CompositionError`, `VerificationError`, `InstallError` cover the resolver and install path.
- **19 tests** covering resolution, conflict detection, backtracking, dependency-safe install ordering, trust/runtime filtering, cycle detection, capability composition, signature verification and install flow.

#### `crates/mofa-plugins/src/lib.rs`
- `pub mod resolver` exposed.
- Re-exports the resolver API, capability composition, verification and install helpers.
- Re-exports `PluginDep` from `wasm_runtime` so callers use `mofa_plugins::PluginDep` directly.

#### `crates/mofa-plugins/examples/semver_resolver.rs`
- End-to-end runnable demo: builds a multi-plugin graph with trust scores, runtime requirements and multi-root dependencies, resolves it, and prints the selected version map.

#### `crates/mofa-runtime/src/swarm/mod.rs`
- `resolve_swarm_plugins(manifests, roots, runtime_version, min_trust) -> Result<PluginLock, ResolveError>`
- Thin integration wrapper: builds `PluginRegistry` from available manifests, calls `resolve_install_order`, returns `PluginLock`.
- Integration test: alpha to bravo chain, asserts lock has 2 resolved entries.


## Design decisions
**Integrated resolver surface**: this PR aligns the manifest model, resolver surface, trust metadata, capability composition, signature verification, and install flow into one consistent API.

**Backtracking resolution**: the resolver backtracks across candidate versions to avoid false conflicts in solvable dependency graphs.

**Cycle detection after selection**: cycles are detected on the resolved dependency graph, avoiding false positives from version-agnostic registry checks.

**Dependency-safe install order**: install order is topologically sorted so transitive dependencies are written before their dependents.

**Install path split from fetch path**: `install_resolved_plugins()` assumes plugin artifacts have already been fetched. This keeps resolver logic independent from transport while preserving a clean `resolve, verify, install` sequence.

---

## Testing

```
cargo test -p mofa-plugins resolver --offline          # 19 unit tests
cargo test -p mofa-runtime swarm --offline             # runtime wrapper test
cargo run --example semver_resolver -p mofa-plugins  # runnable example
```
Example output:

```text
Resolved dependencies (runtime=1.5.0, min_trust=0.5):
- alpha@1.0.0
- bravo@1.5.0
- charlie@1.0.0
- delta@1.0.0
```