### PR TITLE
 feat(testing): add memory drift testing support for episodic and semantic memory

### DIFF
--- a/examples/memory_drift_testing/Cargo.toml
+++ b/examples/memory_drift_testing/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "memory_drift_testing"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mofa-testing = { path = "../../tests" }
+tokio = { workspace = true }

--- a/examples/memory_drift_testing/src/main.rs
+++ b/examples/memory_drift_testing/src/main.rs
@@ -1,0 +1,111 @@
+//! Memory drift testing example
+//!
+//! Demonstrates:
+//! - episodic cross-session retention
+//! - session isolation after clearing one session
+//! - semantic search and reset behavior
+//!
+//! Run:
+//! `cargo run --manifest-path examples/Cargo.toml -p memory_drift_testing`
+
+use mofa_testing::MemoryDriftHarness;
+
+async fn run_episodic_flow() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "remember I prefer Rust", "Saved your Rust preference")
+        .await
+        .expect("record session-a");
+    harness
+        .record_turn("session-b", "what do you remember?", "You prefer Rust")
+        .await
+        .expect("record session-b");
+
+    let session_a = harness.history("session-a").await.expect("history session-a");
+    let recent = harness
+        .recent_episode_texts(4)
+        .await
+        .expect("recent episodes");
+    let stats = harness.stats().await.expect("episodic stats");
+
+    println!("== Episodic Memory ==");
+    println!("session_ids: {:?}", harness.session_ids());
+    println!("session-a messages: {}", session_a.len());
+    println!("recent episodes: {:?}", recent);
+    println!(
+        "stats: sessions={} messages={}",
+        stats.total_sessions, stats.total_messages
+    );
+    println!();
+}
+
+async fn run_clear_flow() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "alpha", "ack alpha")
+        .await
+        .expect("record session-a");
+    harness
+        .record_turn("session-b", "beta", "ack beta")
+        .await
+        .expect("record session-b");
+
+    harness
+        .clear_session("session-a")
+        .await
+        .expect("clear session-a");
+
+    println!("== Isolation After Clear ==");
+    println!("session_ids: {:?}", harness.session_ids());
+    println!(
+        "session-a history: {:?}",
+        harness.history("session-a").await.expect("history session-a")
+    );
+    println!(
+        "session-b history len: {}",
+        harness.history("session-b")
+            .await
+            .expect("history session-b")
+            .len()
+    );
+    println!();
+}
+
+async fn run_semantic_flow() {
+    let mut harness = MemoryDriftHarness::with_semantic_memory();
+
+    harness
+        .store_text("rust-note", "Rust is a systems programming language")
+        .await
+        .expect("store rust note");
+    harness
+        .store_text("python-note", "Python is common in machine learning")
+        .await
+        .expect("store python note");
+
+    let search_results = harness
+        .search_texts("systems language", 2)
+        .await
+        .expect("semantic search");
+
+    println!("== Semantic Memory ==");
+    println!("memory_type: {}", harness.memory_type());
+    println!("search results: {:?}", search_results);
+
+    harness.clear_all().await.expect("clear semantic memory");
+    let after_clear = harness
+        .search_texts("systems language", 2)
+        .await
+        .expect("semantic search after clear");
+    println!("after clear: {:?}", after_clear);
+    println!();
+}
+
+#[tokio::main]
+async fn main() {
+    run_episodic_flow().await;
+    run_clear_flow().await;
+    run_semantic_flow().await;
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,12 +8,14 @@ pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod memory;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use memory::{MemoryDriftHarness, SessionMemorySnapshot};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/memory.rs
+++ b/tests/src/memory.rs
@@ -158,6 +158,16 @@ impl MemoryDriftHarness {
         Ok(())
     }
 
+    // Exact KV lookup helper for testing direct retrieval separately from search based recall
+    pub async fn retrieve_text(&self, key: &str) -> Result<Option<String>> {
+        let value = match &self.backend {
+            MemoryBackend::Episodic(memory) => memory.retrieve(key).await?,
+            MemoryBackend::Semantic(memory) => memory.retrieve(key).await?,
+        };
+
+        Ok(value.and_then(|value| value.as_text().map(str::to_string)))
+    }
+
     pub async fn search_texts(&self, query: &str, limit: usize) -> Result<Vec<String>> {
         let results: Vec<MemoryItem> = match &self.backend {
             MemoryBackend::Episodic(memory) => memory.search(query, limit).await?,

--- a/tests/src/memory.rs
+++ b/tests/src/memory.rs
@@ -1,0 +1,178 @@
+//! Memory drift testing harness built on top of real MoFA memory components.
+
+use anyhow::Result;
+use mofa_foundation::agent::components::{
+    EpisodicMemory, HashEmbedder, Memory, MemoryItem, MemoryStats, Message, SemanticMemory,
+};
+use mofa_kernel::agent::components::memory::MemoryValue;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+/// Snapshot of a single session's history for drift/isolation assertions.
+#[derive(Debug, Clone)]
+pub struct SessionMemorySnapshot {
+    pub session_id: String,
+    pub messages: Vec<Message>,
+}
+
+/// Small harness for testing cross-session memory retention and isolation.
+pub struct MemoryDriftHarness {
+    backend: MemoryBackend,
+    known_sessions: BTreeSet<String>,
+}
+
+enum MemoryBackend {
+    Episodic(EpisodicMemory),
+    Semantic(SemanticMemory),
+}
+
+impl Default for MemoryDriftHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryDriftHarness {
+    pub fn new() -> Self {
+        Self {
+            backend: MemoryBackend::Episodic(EpisodicMemory::new()),
+            known_sessions: BTreeSet::new(),
+        }
+    }
+
+    pub fn with_semantic_memory() -> Self {
+        Self {
+            // Use the built-in hash embedder so semantic-memory tests stay fully local and deterministic.
+            backend: MemoryBackend::Semantic(SemanticMemory::new(Arc::new(
+                HashEmbedder::with_128_dims(),
+            ))),
+            known_sessions: BTreeSet::new(),
+        }
+    }
+
+    pub async fn record_message(&mut self, session_id: &str, message: Message) -> Result<()> {
+        self.known_sessions.insert(session_id.to_string());
+        match &mut self.backend {
+            MemoryBackend::Episodic(memory) => memory.add_to_history(session_id, message).await?,
+            MemoryBackend::Semantic(memory) => memory.add_to_history(session_id, message).await?,
+        }
+        Ok(())
+    }
+
+    pub async fn record_turn(
+        &mut self,
+        session_id: &str,
+        user_text: &str,
+        assistant_text: &str,
+    ) -> Result<()> {
+        self.record_message(session_id, Message::user(user_text))
+            .await?;
+        self.record_message(session_id, Message::assistant(assistant_text))
+            .await?;
+        Ok(())
+    }
+
+    pub async fn history(&self, session_id: &str) -> Result<Vec<Message>> {
+        Ok(match &self.backend {
+            MemoryBackend::Episodic(memory) => memory.get_history(session_id).await?,
+            MemoryBackend::Semantic(memory) => memory.get_history(session_id).await?,
+        })
+    }
+
+    pub async fn session_snapshot(&self, session_id: &str) -> Result<SessionMemorySnapshot> {
+        Ok(SessionMemorySnapshot {
+            session_id: session_id.to_string(),
+            messages: self.history(session_id).await?,
+        })
+    }
+
+    pub async fn all_session_snapshots(&self) -> Result<Vec<SessionMemorySnapshot>> {
+        let mut snapshots = Vec::new();
+        for session_id in self.session_ids() {
+            snapshots.push(self.session_snapshot(&session_id).await?);
+        }
+        Ok(snapshots)
+    }
+
+    pub async fn recent_episode_texts(&self, limit: usize) -> Result<Vec<String>> {
+        match &self.backend {
+            MemoryBackend::Episodic(memory) => Ok(memory
+                .get_recent_episodes(limit)
+                .into_iter()
+                .map(|episode| episode.message.content.clone())
+                .collect()),
+            MemoryBackend::Semantic(memory) => {
+                // Semantic memory does not expose cross-session episodes directly, so rebuild
+                // a recent view from known session histories.
+                let mut messages: Vec<Message> = Vec::new();
+                for session_id in &self.known_sessions {
+                    messages.extend(memory.get_history(session_id).await?);
+                }
+                messages.sort_by_key(|message| message.timestamp);
+                let total = messages.len();
+                let start = total.saturating_sub(limit);
+                Ok(messages[start..]
+                    .iter()
+                    .map(|message| message.content.clone())
+                    .collect())
+            }
+        }
+    }
+
+    pub fn session_ids(&self) -> Vec<String> {
+        self.known_sessions.iter().cloned().collect()
+    }
+
+    pub async fn clear_session(&mut self, session_id: &str) -> Result<()> {
+        self.known_sessions.remove(session_id);
+        match &mut self.backend {
+            MemoryBackend::Episodic(memory) => memory.clear_history(session_id).await?,
+            MemoryBackend::Semantic(memory) => memory.clear_history(session_id).await?,
+        }
+        Ok(())
+    }
+
+    pub async fn clear_all(&mut self) -> Result<()> {
+        self.known_sessions.clear();
+        match &mut self.backend {
+            MemoryBackend::Episodic(memory) => memory.clear().await?,
+            MemoryBackend::Semantic(memory) => memory.clear().await?,
+        }
+        Ok(())
+    }
+
+    pub async fn stats(&self) -> Result<MemoryStats> {
+        Ok(match &self.backend {
+            MemoryBackend::Episodic(memory) => memory.stats().await?,
+            MemoryBackend::Semantic(memory) => memory.stats().await?,
+        })
+    }
+
+    pub async fn store_text(&mut self, key: &str, value: &str) -> Result<()> {
+        match &mut self.backend {
+            // Store text through the real memory trait so retrieval/search semantics stay aligned
+            // with the underlying backend implementation.
+            MemoryBackend::Episodic(memory) => memory.store(key, MemoryValue::text(value)).await?,
+            MemoryBackend::Semantic(memory) => memory.store(key, MemoryValue::text(value)).await?,
+        }
+        Ok(())
+    }
+
+    pub async fn search_texts(&self, query: &str, limit: usize) -> Result<Vec<String>> {
+        let results: Vec<MemoryItem> = match &self.backend {
+            MemoryBackend::Episodic(memory) => memory.search(query, limit).await?,
+            MemoryBackend::Semantic(memory) => memory.search(query, limit).await?,
+        };
+        Ok(results
+            .into_iter()
+            .filter_map(|item| item.value.as_text().map(str::to_string))
+            .collect())
+    }
+
+    pub fn memory_type(&self) -> &'static str {
+        match self.backend {
+            MemoryBackend::Episodic(_) => "episodic",
+            MemoryBackend::Semantic(_) => "semantic",
+        }
+    }
+}

--- a/tests/tests/memory_drift_tests.rs
+++ b/tests/tests/memory_drift_tests.rs
@@ -1,0 +1,243 @@
+use mofa_testing::MemoryDriftHarness;
+
+#[tokio::test]
+async fn memory_persists_across_sessions() {
+    let mut harness = MemoryDriftHarness::new();
+
+    // Session B should still be able to observe content that originated in session A
+    // through the shared episodic memory timeline.
+    harness
+        .record_turn("session-a", "remember I prefer Rust", "Noted: Rust preference saved")
+        .await
+        .unwrap();
+    harness
+        .record_turn("session-b", "what do you remember?", "You prefer Rust")
+        .await
+        .unwrap();
+
+    let session_a = harness.history("session-a").await.unwrap();
+    let session_b = harness.history("session-b").await.unwrap();
+
+    assert_eq!(session_a.len(), 2);
+    assert_eq!(session_b.len(), 2);
+
+    let recent = harness.recent_episode_texts(4).await.unwrap();
+    assert!(recent.iter().any(|text| text.contains("prefer Rust")));
+    assert!(recent.iter().any(|text| text.contains("You prefer Rust")));
+}
+
+#[tokio::test]
+async fn clearing_one_session_does_not_affect_others() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "alpha", "ack alpha")
+        .await
+        .unwrap();
+    harness
+        .record_turn("session-b", "beta", "ack beta")
+        .await
+        .unwrap();
+
+    harness.clear_session("session-a").await.unwrap();
+
+    let session_a = harness.history("session-a").await.unwrap();
+    let session_b = harness.history("session-b").await.unwrap();
+
+    assert!(session_a.is_empty());
+    assert_eq!(session_b.len(), 2);
+    assert_eq!(
+        harness.session_ids(),
+        vec!["session-b".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn recent_episodes_include_multiple_sessions() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_message("session-a", mofa_foundation::agent::components::Message::user("one"))
+        .await
+        .unwrap();
+    harness
+        .record_message("session-b", mofa_foundation::agent::components::Message::user("two"))
+        .await
+        .unwrap();
+    harness
+        .record_message(
+            "session-c",
+            mofa_foundation::agent::components::Message::assistant("three"),
+        )
+        .await
+        .unwrap();
+
+    let recent = harness.recent_episode_texts(3).await.unwrap();
+    assert_eq!(recent, vec!["one", "two", "three"]);
+}
+
+#[tokio::test]
+async fn clear_all_removes_all_memory() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "persist this", "saved")
+        .await
+        .unwrap();
+    harness
+        .record_turn("session-b", "persist that", "saved too")
+        .await
+        .unwrap();
+
+    harness.clear_all().await.unwrap();
+
+    assert!(harness.history("session-a").await.unwrap().is_empty());
+    assert!(harness.history("session-b").await.unwrap().is_empty());
+    assert!(harness.session_ids().is_empty());
+    assert!(harness.recent_episode_texts(10).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn session_snapshot_captures_ordered_session_history() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-snap", "first question", "first answer")
+        .await
+        .unwrap();
+
+    let snapshot = harness.session_snapshot("session-snap").await.unwrap();
+    assert_eq!(snapshot.session_id, "session-snap");
+    assert_eq!(snapshot.messages.len(), 2);
+    assert_eq!(snapshot.messages[0].content, "first question");
+    assert_eq!(snapshot.messages[1].content, "first answer");
+}
+
+#[tokio::test]
+async fn stats_reflect_sessions_and_messages() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "alpha", "ack alpha")
+        .await
+        .unwrap();
+    harness
+        .record_message(
+            "session-b",
+            mofa_foundation::agent::components::Message::user("beta"),
+        )
+        .await
+        .unwrap();
+
+    let stats = harness.stats().await.unwrap();
+    assert_eq!(stats.total_sessions, 2);
+    assert_eq!(stats.total_messages, 3);
+}
+
+#[tokio::test]
+async fn all_session_snapshots_include_each_session_history() {
+    let mut harness = MemoryDriftHarness::new();
+
+    // Snapshots are useful for drift assertions because they preserve the full
+    // ordered per-session history instead of just aggregate stats.
+    harness
+        .record_turn("session-a", "alpha question", "alpha answer")
+        .await
+        .unwrap();
+    harness
+        .record_message(
+            "session-b",
+            mofa_foundation::agent::components::Message::user("beta only"),
+        )
+        .await
+        .unwrap();
+
+    let snapshots = harness.all_session_snapshots().await.unwrap();
+    assert_eq!(snapshots.len(), 2);
+
+    let session_a = snapshots
+        .iter()
+        .find(|snapshot| snapshot.session_id == "session-a")
+        .unwrap();
+    let session_b = snapshots
+        .iter()
+        .find(|snapshot| snapshot.session_id == "session-b")
+        .unwrap();
+
+    assert_eq!(session_a.messages.len(), 2);
+    assert_eq!(session_a.messages[0].content, "alpha question");
+    assert_eq!(session_a.messages[1].content, "alpha answer");
+    assert_eq!(session_b.messages.len(), 1);
+    assert_eq!(session_b.messages[0].content, "beta only");
+}
+
+#[tokio::test]
+async fn clearing_session_updates_recent_recall_without_affecting_others() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .record_turn("session-a", "alpha question", "alpha answer")
+        .await
+        .unwrap();
+    harness
+        .record_turn("session-b", "beta question", "beta answer")
+        .await
+        .unwrap();
+
+    let before_clear = harness.recent_episode_texts(4).await.unwrap();
+    assert!(before_clear.iter().any(|text| text == "alpha question"));
+    assert!(before_clear.iter().any(|text| text == "beta answer"));
+
+    harness.clear_session("session-a").await.unwrap();
+
+    let after_clear = harness.recent_episode_texts(4).await.unwrap();
+    assert!(!after_clear.iter().any(|text| text == "alpha question"));
+    assert!(!after_clear.iter().any(|text| text == "alpha answer"));
+    assert!(after_clear.iter().any(|text| text == "beta question"));
+    assert!(after_clear.iter().any(|text| text == "beta answer"));
+}
+
+#[tokio::test]
+async fn semantic_memory_mode_supports_search() {
+    let mut harness = MemoryDriftHarness::with_semantic_memory();
+
+    // This verifies semantic retrieval through the same harness API rather than
+    // only direct SemanticMemory unit tests in foundation.
+    harness
+        .store_text("rust-note", "Rust is a systems programming language")
+        .await
+        .unwrap();
+    harness
+        .store_text("python-note", "Python is often used for machine learning")
+        .await
+        .unwrap();
+
+    let results = harness.search_texts("systems language", 2).await.unwrap();
+    assert!(!results.is_empty());
+    assert!(results
+        .iter()
+        .any(|text| text.contains("Rust is a systems programming language")));
+    assert_eq!(harness.memory_type(), "semantic");
+}
+
+#[tokio::test]
+async fn semantic_memory_mode_keeps_session_history_and_reset_behavior() {
+    let mut harness = MemoryDriftHarness::with_semantic_memory();
+
+    harness
+        .record_turn("semantic-session", "remember this", "saved in semantic mode")
+        .await
+        .unwrap();
+
+    let history = harness.history("semantic-session").await.unwrap();
+    assert_eq!(history.len(), 2);
+
+    harness.clear_all().await.unwrap();
+
+    assert!(harness
+        .history("semantic-session")
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(harness.session_ids().is_empty());
+}

--- a/tests/tests/memory_drift_tests.rs
+++ b/tests/tests/memory_drift_tests.rs
@@ -241,3 +241,19 @@ async fn semantic_memory_mode_keeps_session_history_and_reset_behavior() {
         .is_empty());
     assert!(harness.session_ids().is_empty());
 }
+
+#[tokio::test]
+async fn store_text_and_retrieve_text_roundtrip() {
+    let mut harness = MemoryDriftHarness::new();
+
+    harness
+        .store_text("preference", "User prefers concise Rust examples")
+        .await
+        .unwrap();
+
+    let retrieved = harness.retrieve_text("preference").await.unwrap();
+    assert_eq!(
+        retrieved.as_deref(),
+        Some("User prefers concise Rust examples")
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds memory drift testing support to `mofa-testing` using MoFA's real episodic and semantic memory implementations.

It introduces a `MemoryDriftHarness` for recording session history, inspecting recent recall, capturing snapshots, checking stats, retrieving exact stored text, and verifying that memory persists or resets as expected across sessions.

Fixes: #1439

## Context

MoFA agents support persistent memory, so the testing platform should be able to verify:

- cross session retention
- isolation between sessions
- session specific clearing behavior
- full reset behavior
- recent recall behavior
- semantic retrieval behavior

This makes the testing work more MoFA-specific and moves beyond generic mock-based testing.

## Memory Harness Flow
<img width="590" height="1027" alt="image" src="https://github.com/user-attachments/assets/4bf683c1-2b76-42da-a680-df5cfe72e20a" />

## Changed

### `tests/src/memory.rs`

Adds `MemoryDriftHarness`, built on top of real `mofa-foundation` memory implementations.

The harness supports:

- recording individual messages
- recording user/assistant turns
- semantic memory mode
- reading session history
- capturing all and per session snapshots
- reading recent episode text across sessions
- listing session IDs
- storing searchable memory text
- retrieving exact stored text by key
- running search queries
- reading memory stats
- clearing one or all single session

### `tests/src/lib.rs`

Exports the new memory testing module and `MemoryDriftHarness`.

### `tests/tests/memory_drift_tests.rs`

Adds focused tests for:

- memory persistence across sessions
- session isolation after clearing one session
- recent recall after clearing one session
- recent episode recall across multiple sessions
- session snapshot correctness
- all session snapshot coverage
- memory stats correctness
- direct text retrieval roundtrip
- semantic memory search behavior
- semantic memory reset behavior
- full memory reset

### `examples/memory_drift_testing/Cargo.toml`

Adds a runnable example crate for manual validation of memory drift behavior.

### `examples/memory_drift_testing/src/main.rs`

Adds a manual example that demonstrates:

- episodic cross session retention
- isolation after clearing one session
- semantic memory search and full reset

## Testing

1. Ran:
   `cargo test -p mofa-testing --test memory_drift_tests`

2. Ran:
   `CARGO_TARGET_DIR=/home/aditya/projc/mvpissues/mofa/target cargo run --manifest-path /home/aditya/projc/mvpissues/mofa/examples/Cargo.toml -p memory_drift_testing`

3. Verified:
   - memory persists across sessions
   - clearing one session does not affect others
   - recent recall updates correctly after clearing one session
   - recent recall spans multiple sessions
   - session snapshots preserve ordered history
   - all session snapshots include each session history
   - memory stats reflect session/message counts
   - direct text retrieval roundtrips correctly
   - semantic memory search returns relevant stored text
   - semantic memory reset clears stored history
   - the manual example runs successfully

## Example Output

```text
== Episodic Memory ==
session_ids: ["session-a", "session-b"]
session-a messages: 2
recent episodes: ["remember I prefer Rust", "Saved your Rust preference", "what do you remember?", "You prefer Rust"]
stats: sessions=2 messages=4

== Isolation After Clear ==
session_ids: ["session-b"]
session-a history: []
session-b history len: 2

== Semantic Memory ==
memory_type: semantic
search results: ["Rust is a systems programming language", "Python is common in machine learning"]
after clear: []
```

4. Verified:
   - clearing all memory resets the harness completely
