### PR TITLE
feat(testing):  Add visual swarm and orchestrator testing artifacts

### DIFF
--- a/crates/mofa-foundation/src/swarm/mod.rs
+++ b/crates/mofa-foundation/src/swarm/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyzer;
 pub mod config;
 pub mod dag;
+pub mod orchestrator;
 pub mod patterns;
 pub mod telemetry;
 
@@ -10,6 +11,7 @@ pub use config::{
     SwarmResult, SwarmStatus,
 };
 pub use dag::{DependencyEdge, DependencyKind, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmSubtask};
+pub use orchestrator::SwarmOrchestrator;
 pub use patterns::CoordinationPattern;
 pub mod scheduler;
 pub use scheduler::{

--- a/crates/mofa-foundation/src/swarm/orchestrator.rs
+++ b/crates/mofa-foundation/src/swarm/orchestrator.rs
@@ -1,0 +1,396 @@
+//! High-level swarm orchestration entrypoint built on top of the swarm primitives.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::json;
+
+use mofa_kernel::agent::types::error::{GlobalError, GlobalResult};
+
+use crate::swarm::{
+    AuditEvent, AuditEventKind, CoordinationPattern, HITLMode, SchedulerSummary, SwarmConfig,
+    SwarmMetrics, SwarmResult, SwarmScheduler, SwarmSchedulerConfig, SwarmStatus, TaskAnalyzer,
+};
+use crate::swarm::{SubtaskDAG, SubtaskExecutorFn, SwarmSubtask};
+
+/// Coordinate DAG construction, agent assignment, scheduler execution, and result synthesis.
+pub struct SwarmOrchestrator {
+    scheduler_config: SwarmSchedulerConfig,
+}
+
+impl SwarmOrchestrator {
+    /// Create an orchestrator with default scheduler behavior.
+    pub fn new() -> Self {
+        Self {
+            scheduler_config: SwarmSchedulerConfig::default(),
+        }
+    }
+
+    /// Create an orchestrator with explicit scheduler configuration.
+    pub fn with_scheduler_config(scheduler_config: SwarmSchedulerConfig) -> Self {
+        Self { scheduler_config }
+    }
+
+    /// Build a runnable DAG from the task text using the deterministic offline analyzer.
+    pub fn build_dag(&self, config: &SwarmConfig) -> GlobalResult<SubtaskDAG> {
+        if config.task.trim().is_empty() {
+            return Err(GlobalError::Other(
+                "swarm task must not be empty".to_string(),
+            ));
+        }
+
+        let analysis = TaskAnalyzer::analyze_offline_with_risk(&config.task);
+        let mut dag = analysis.dag;
+        dag.name = config.name.clone();
+        self.apply_hitl_mode(config, &mut dag);
+        self.assign_agents(config, &mut dag)?;
+        Ok(dag)
+    }
+
+    /// Execute an already-constructed DAG and return a full `SwarmResult`.
+    pub async fn run_dag(
+        &self,
+        config: &SwarmConfig,
+        mut dag: SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SwarmResult> {
+        self.apply_hitl_mode(config, &mut dag);
+        self.assign_agents(config, &mut dag)?;
+
+        let started_at = Utc::now();
+        let mut audit_events = vec![
+            AuditEvent::new(AuditEventKind::SwarmStarted, "Swarm orchestration started")
+                .with_data(json!({"config_id": config.id, "name": config.name})),
+            AuditEvent::new(AuditEventKind::TaskDecomposed, "Swarm DAG prepared").with_data(json!({
+                "task_count": dag.task_count(),
+                "hitl_required": dag.hitl_required_tasks(),
+            })),
+            AuditEvent::new(
+                AuditEventKind::PatternSelected,
+                format!("Coordination pattern selected: {}", config.pattern),
+            )
+            .with_data(json!({"pattern": config.pattern})),
+        ];
+        self.record_agent_assignments(&dag, &mut audit_events);
+        self.record_hitl_requests(&dag, &mut audit_events);
+
+        let summary = self.execute_pattern(config.pattern.clone(), &mut dag, executor).await?;
+        let metrics = self.metrics_from_summary(&dag, &summary);
+        let status = self.status_from_summary(&summary);
+        let output = self.aggregate_output(&summary);
+
+        audit_events.push(
+            AuditEvent::new(
+                AuditEventKind::SwarmCompleted,
+                "Swarm orchestration finished",
+            )
+            .with_data(json!({
+                "status": status,
+                "succeeded": summary.succeeded,
+                "failed": summary.failed,
+                "skipped": summary.skipped,
+            })),
+        );
+
+        Ok(SwarmResult {
+            config_id: config.id.clone(),
+            status,
+            dag,
+            output,
+            metrics,
+            audit_events,
+            started_at,
+            completed_at: Some(Utc::now()),
+        })
+    }
+
+    /// Build a DAG from config and execute it end to end.
+    pub async fn run(
+        &self,
+        config: &SwarmConfig,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SwarmResult> {
+        let dag = self.build_dag(config)?;
+        self.run_dag(config, dag, executor).await
+    }
+
+    /// Dispatch execution to the scheduler that matches the requested coordination pattern.
+    async fn execute_pattern(
+        &self,
+        pattern: CoordinationPattern,
+        dag: &mut SubtaskDAG,
+        executor: SubtaskExecutorFn,
+    ) -> GlobalResult<SchedulerSummary> {
+        match pattern {
+            CoordinationPattern::Sequential => {
+                let scheduler = crate::swarm::SequentialScheduler::with_config(
+                    self.scheduler_config.clone(),
+                );
+                scheduler.execute(dag, executor).await
+            }
+            CoordinationPattern::Parallel => {
+                let scheduler =
+                    crate::swarm::ParallelScheduler::with_config(self.scheduler_config.clone());
+                scheduler.execute(dag, executor).await
+            }
+            other => Err(GlobalError::Other(format!(
+                "coordination pattern `{other}` is not yet implemented for SwarmOrchestrator"
+            ))),
+        }
+    }
+
+    /// Normalize per-task HITL flags against the top-level swarm HITL mode.
+    fn apply_hitl_mode(&self, config: &SwarmConfig, dag: &mut SubtaskDAG) {
+        let updates: Vec<_> = dag
+            .all_tasks()
+            .into_iter()
+            .map(|(idx, task)| {
+                let required = match config.hitl {
+                    HITLMode::None => false,
+                    HITLMode::Required => true,
+                    HITLMode::Optional => task.hitl_required,
+                };
+                (idx, required)
+            })
+            .collect();
+
+        for (idx, required) in updates {
+            if let Some(task_mut) = dag.get_task_mut(idx) {
+                task_mut.hitl_required = required;
+            }
+        }
+    }
+
+    /// Assign each task to the best matching configured agent before execution starts.
+    fn assign_agents(&self, config: &SwarmConfig, dag: &mut SubtaskDAG) -> GlobalResult<()> {
+        if config.agents.is_empty() {
+            return Ok(());
+        }
+
+        let assignments: Vec<(petgraph::graph::NodeIndex, String)> = dag
+            .all_tasks()
+            .into_iter()
+            .map(|(idx, task)| self.select_agent_for_task(config, task).map(|agent| (idx, agent)))
+            .collect::<GlobalResult<_>>()?;
+
+        for (idx, agent_id) in assignments {
+            dag.assign_agent(idx, agent_id);
+        }
+
+        Ok(())
+    }
+
+    /// Choose an agent whose capabilities satisfy the task, falling back to the first agent.
+    fn select_agent_for_task(
+        &self,
+        config: &SwarmConfig,
+        task: &SwarmSubtask,
+    ) -> GlobalResult<String> {
+        let required: HashSet<&str> = task
+            .required_capabilities
+            .iter()
+            .map(String::as_str)
+            .collect();
+
+        if required.is_empty() {
+            return config
+                .agents
+                .first()
+                .map(|agent| agent.id.clone())
+                .ok_or_else(|| GlobalError::Other("no agents configured for swarm".to_string()));
+        }
+
+        config
+            .agents
+            .iter()
+            .find(|agent| {
+                required
+                    .iter()
+                    .all(|cap| agent.capabilities.iter().any(|agent_cap| agent_cap == cap))
+            })
+            .or_else(|| config.agents.first())
+            .map(|agent| agent.id.clone())
+            .ok_or_else(|| GlobalError::Other("no agents configured for swarm".to_string()))
+    }
+
+    /// Emit audit events for the final task-to-agent assignment plan.
+    fn record_agent_assignments(&self, dag: &SubtaskDAG, audit_events: &mut Vec<AuditEvent>) {
+        for (_, task) in dag.all_tasks() {
+            if let Some(agent) = &task.assigned_agent {
+                audit_events.push(
+                    AuditEvent::new(
+                        AuditEventKind::AgentAssigned,
+                        format!("Assigned task `{}` to `{agent}`", task.id),
+                    )
+                    .with_data(json!({"task_id": task.id, "agent_id": agent})),
+                );
+            }
+        }
+    }
+
+    /// Emit audit events for tasks that require human review before execution.
+    fn record_hitl_requests(&self, dag: &SubtaskDAG, audit_events: &mut Vec<AuditEvent>) {
+        for task_id in dag.hitl_required_tasks() {
+            audit_events.push(
+                AuditEvent::new(
+                    AuditEventKind::HITLRequested,
+                    format!("Task `{task_id}` requires human approval"),
+                )
+                .with_data(json!({"task_id": task_id})),
+            );
+        }
+    }
+
+    /// Translate scheduler-level execution counts into the stable swarm metrics snapshot.
+    fn metrics_from_summary(&self, dag: &SubtaskDAG, summary: &SchedulerSummary) -> SwarmMetrics {
+        let mut metrics = SwarmMetrics::default();
+        for _ in 0..summary.succeeded {
+            metrics.record_task_completed();
+        }
+        for _ in 0..summary.failed {
+            metrics.record_task_failed();
+        }
+        metrics.hitl_interventions = dag.hitl_required_tasks().len();
+        metrics.set_duration_ms(summary.total_wall_time.as_millis() as u64);
+
+        for (_, task) in dag.all_tasks() {
+            if let Some(agent) = &task.assigned_agent {
+                metrics.record_agent_tokens(agent.clone(), 0);
+            }
+        }
+
+        metrics
+    }
+
+    /// Collapse scheduler outcome counts into one top-level swarm status.
+    fn status_from_summary(&self, summary: &SchedulerSummary) -> SwarmStatus {
+        if summary.failed > 0 {
+            SwarmStatus::Failed(format!(
+                "{} task(s) failed during swarm execution",
+                summary.failed
+            ))
+        } else {
+            SwarmStatus::Completed
+        }
+    }
+
+    /// Join successful task outputs into one top-level swarm output payload.
+    fn aggregate_output(&self, summary: &SchedulerSummary) -> Option<String> {
+        let outputs = summary.successful_outputs();
+        if outputs.is_empty() {
+            None
+        } else {
+            Some(outputs.join("\n"))
+        }
+    }
+}
+
+impl Default for SwarmOrchestrator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use futures::future::BoxFuture;
+
+    use crate::swarm::{AgentSpec, RiskLevel};
+
+    fn test_config(pattern: CoordinationPattern) -> SwarmConfig {
+        SwarmConfig {
+            id: "cfg-test".into(),
+            name: "incident-response".into(),
+            description: String::new(),
+            task: "fetch logs then summarize findings".into(),
+            agents: vec![
+                AgentSpec {
+                    id: "researcher".into(),
+                    capabilities: vec!["fetch".into(), "search".into(), "list".into()],
+                    model: None,
+                    cost_per_token: None,
+                    max_concurrency: 1,
+                },
+                AgentSpec {
+                    id: "analyst".into(),
+                    capabilities: vec!["summarize".into(), "analyze".into(), "reporting".into()],
+                    model: None,
+                    cost_per_token: None,
+                    max_concurrency: 1,
+                },
+            ],
+            pattern,
+            sla: Default::default(),
+            hitl: HITLMode::Optional,
+            metadata: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrator_runs_a_config_end_to_end() {
+        let orchestrator = SwarmOrchestrator::new();
+        let config = test_config(CoordinationPattern::Sequential);
+        let executor = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+            Box::pin(async move { Ok(format!("{} handled", task.id)) })
+        });
+
+        let result = orchestrator.run(&config, executor).await.unwrap();
+
+        assert_eq!(result.status, SwarmStatus::Completed);
+        assert_eq!(result.metrics.tasks_completed, result.dag.completed_count());
+        assert!(result.output.as_deref().unwrap_or_default().contains("handled"));
+        assert!(result
+            .audit_events
+            .iter()
+            .any(|event| event.kind == AuditEventKind::PatternSelected));
+    }
+
+    #[tokio::test]
+    async fn orchestrator_assigns_agents_and_respects_required_hitl() {
+        let orchestrator = SwarmOrchestrator::new();
+        let mut config = test_config(CoordinationPattern::Sequential);
+        config.hitl = HITLMode::Required;
+
+        let dag = orchestrator.build_dag(&config).unwrap();
+
+        assert!(dag.all_tasks().iter().all(|(_, task)| task.hitl_required));
+        assert!(dag
+            .all_tasks()
+            .iter()
+            .all(|(_, task)| task.assigned_agent.is_some()));
+    }
+
+    #[tokio::test]
+    async fn orchestrator_reports_unsupported_patterns() {
+        let orchestrator = SwarmOrchestrator::new();
+        let config = test_config(CoordinationPattern::Debate);
+        let executor = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                Ok(task.id)
+            })
+        });
+
+        let err = orchestrator.run(&config, executor).await.unwrap_err();
+        assert!(err.to_string().contains("not yet implemented"));
+    }
+
+    #[test]
+    fn orchestrator_build_dag_uses_offline_swarm_analysis() {
+        let orchestrator = SwarmOrchestrator::new();
+        let config = test_config(CoordinationPattern::Sequential);
+
+        let dag = orchestrator.build_dag(&config).unwrap();
+
+        assert_eq!(dag.name, "incident-response");
+        assert!(dag.task_count() >= 2);
+        assert!(dag
+            .all_tasks()
+            .iter()
+            .any(|(_, task)| matches!(&task.risk_level, RiskLevel::Low | RiskLevel::Medium | RiskLevel::High | RiskLevel::Critical)));
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "resume_from_checkpoint",
     "claw_demo",
     "swarm_orchestrator",
+    "swarm_testing_demo",
 ]
 
 [workspace.package]

--- a/examples/swarm_testing_demo/Cargo.toml
+++ b/examples/swarm_testing_demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "swarm_testing_demo"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+futures = { workspace = true }
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+mofa-testing = { path = "../../tests" }
+tokio = { workspace = true }

--- a/examples/swarm_testing_demo/src/main.rs
+++ b/examples/swarm_testing_demo/src/main.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, RiskLevel, SubtaskDAG, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+use mofa_testing::SwarmRunArtifact;
+
+#[tokio::main]
+async fn main() -> GlobalResult<()> {
+    let mut dag = SubtaskDAG::new("incident-response");
+
+    let triage = dag.add_task(
+        SwarmSubtask::new("triage", "Triage incoming incident")
+            .with_capabilities(vec!["triage".into()]),
+    );
+    let investigate = dag.add_task(
+        SwarmSubtask::new("investigate", "Investigate impact")
+            .with_capabilities(vec!["analysis".into()]),
+    );
+    let remediate = dag.add_task(
+        SwarmSubtask::new("remediate", "Apply remediation")
+            .with_capabilities(vec!["ops".into()])
+            .with_risk_level(RiskLevel::High),
+    );
+    let report = dag.add_task(
+        SwarmSubtask::new("report", "Publish summary")
+            .with_capabilities(vec!["reporting".into()]),
+    );
+
+    dag.add_dependency(triage, investigate)?;
+    dag.add_dependency(investigate, remediate)?;
+    dag.add_dependency(remediate, report)?;
+
+    dag.assign_agent(triage, "router");
+    dag.assign_agent(investigate, "analyst");
+    dag.assign_agent(remediate, "operator");
+    dag.assign_agent(report, "communicator");
+
+    let executor = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(15)).await;
+            Ok(format!(
+                "{} handled by {}",
+                task.id,
+                task.assigned_agent.unwrap_or_else(|| "unassigned".into())
+            ))
+        })
+    });
+
+    let scheduler = ParallelScheduler::new();
+    let summary = scheduler.execute(&mut dag, executor).await?;
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    println!("{}", artifact.to_markdown());
+    println!("{}", artifact.to_json());
+
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,3 +15,4 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+futures = { workspace = true }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod report;
+pub mod swarm;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
@@ -18,4 +19,5 @@ pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
 };
+pub use swarm::{SwarmRunArtifact, SwarmTaskRecord};
 pub use tools::MockTool;

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -3,7 +3,8 @@
 use std::collections::HashMap;
 
 use mofa_foundation::swarm::{
-    CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG, SubtaskStatus, TaskOutcome,
+    AuditEvent, AuditEventKind, CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG,
+    SubtaskStatus, SwarmMetrics, SwarmResult, SwarmStatus, TaskOutcome,
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,12 +28,16 @@ pub struct SwarmTaskRecord {
 pub struct SwarmRunArtifact {
     pub name: String,
     pub pattern: CoordinationPattern,
+    pub swarm_status: Option<SwarmStatus>,
     pub total_tasks: usize,
     pub succeeded: usize,
     pub failed: usize,
     pub skipped: usize,
     pub total_wall_time_ms: u64,
     pub success_rate: f64,
+    pub output: Option<String>,
+    pub metrics: Option<SwarmMetricsRecord>,
+    pub audit_events: Vec<SwarmAuditRecord>,
     pub tasks: Vec<SwarmTaskRecord>,
     pub execution: Vec<SwarmExecutionRecord>,
 }
@@ -48,73 +53,99 @@ pub struct SwarmExecutionRecord {
     pub attempt: u32,
 }
 
+/// Normalized metrics snapshot for swarm testing artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmMetricsRecord {
+    pub total_tokens: u64,
+    pub duration_ms: u64,
+    pub tasks_completed: usize,
+    pub tasks_failed: usize,
+    pub hitl_interventions: usize,
+    pub reassignments: usize,
+    pub agent_tokens: HashMap<String, u64>,
+}
+
+/// Normalized audit event for assertion and visual review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmAuditRecord {
+    pub kind: AuditEventKind,
+    pub description: String,
+    pub timestamp_ms: i64,
+    pub data: serde_json::Value,
+}
+
 impl SwarmRunArtifact {
     /// Build an artifact from a scheduler summary and the final DAG state.
     pub fn from_scheduler_run(dag: &SubtaskDAG, summary: &SchedulerSummary) -> Self {
-        let mut tasks = Vec::new();
-
-        let ordered = dag
-            .topological_order()
-            .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
-
-        for idx in ordered {
-            if let Some(task) = dag.get_task(idx) {
-                let dependencies = dag
-                    .dependencies_of(idx)
-                    .into_iter()
-                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
-                    .collect();
-                let dependents = dag
-                    .dependents_of(idx)
-                    .into_iter()
-                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
-                    .collect();
-
-                tasks.push(SwarmTaskRecord {
-                    id: task.id.clone(),
-                    description: task.description.clone(),
-                    status: task.status.clone(),
-                    assigned_agent: task.assigned_agent.clone(),
-                    output: task.output.clone(),
-                    dependencies,
-                    dependents,
-                    required_capabilities: task.required_capabilities.clone(),
-                    risk_level: task.risk_level.clone(),
-                    hitl_required: task.hitl_required,
-                });
-            }
-        }
-
-        let execution = summary
-            .results
-            .iter()
-            .map(|result| {
-                let (outcome, detail) = match &result.outcome {
-                    TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
-                    TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
-                    TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
-                };
-
-                SwarmExecutionRecord {
-                    task_id: result.task_id.clone(),
-                    node_index: result.node_index,
-                    outcome,
-                    detail,
-                    wall_time_ms: result.wall_time.as_millis() as u64,
-                    attempt: result.attempt,
-                }
-            })
-            .collect();
+        let tasks = snapshot_tasks(dag);
+        let execution = snapshot_execution(summary);
 
         Self {
             name: dag.name.clone(),
             pattern: summary.pattern.clone(),
+            swarm_status: None,
             total_tasks: summary.total_tasks,
             succeeded: summary.succeeded,
             failed: summary.failed,
             skipped: summary.skipped,
             total_wall_time_ms: summary.total_wall_time.as_millis() as u64,
             success_rate: summary.success_rate(),
+            output: None,
+            metrics: None,
+            audit_events: Vec::new(),
+            tasks,
+            execution,
+        }
+    }
+
+    /// Build an artifact from a full swarm result, including metrics and audit events.
+    pub fn from_swarm_result(
+        result: &SwarmResult,
+        pattern: CoordinationPattern,
+        summary: Option<&SchedulerSummary>,
+    ) -> Self {
+        let tasks = snapshot_tasks(&result.dag);
+        let execution = summary.map(snapshot_execution).unwrap_or_default();
+        let total_tasks = result.dag.task_count();
+        let succeeded = summary.map(|it| it.succeeded).unwrap_or_else(|| {
+            result
+                .dag
+                .all_tasks()
+                .iter()
+                .filter(|(_, task)| task.status == SubtaskStatus::Completed)
+                .count()
+        });
+        let failed = summary.map(|it| it.failed).unwrap_or(result.metrics.tasks_failed);
+        let skipped = summary.map(|it| it.skipped).unwrap_or_else(|| {
+            result
+                .dag
+                .all_tasks()
+                .iter()
+                .filter(|(_, task)| task.status == SubtaskStatus::Skipped)
+                .count()
+        });
+        let total_wall_time_ms = summary
+            .map(|it| it.total_wall_time.as_millis() as u64)
+            .unwrap_or(result.metrics.duration_ms);
+        let success_rate = if total_tasks == 0 {
+            1.0
+        } else {
+            succeeded as f64 / total_tasks as f64
+        };
+
+        Self {
+            name: result.dag.name.clone(),
+            pattern,
+            swarm_status: Some(result.status.clone()),
+            total_tasks,
+            succeeded,
+            failed,
+            skipped,
+            total_wall_time_ms,
+            success_rate,
+            output: result.output.clone(),
+            metrics: Some(SwarmMetricsRecord::from(&result.metrics)),
+            audit_events: result.audit_events.iter().map(SwarmAuditRecord::from).collect(),
             tasks,
             execution,
         }
@@ -137,10 +168,16 @@ impl SwarmRunArtifact {
         out.push_str(&format!("- Failed: `{}`\n", self.failed));
         out.push_str(&format!("- Skipped: `{}`\n", self.skipped));
         out.push_str(&format!("- Success rate: `{:.1}%`\n", self.success_rate * 100.0));
+        if let Some(status) = &self.swarm_status {
+            out.push_str(&format!("- Swarm status: `{}`\n", swarm_status_label(status)));
+        }
         out.push_str(&format!(
             "- Total wall time: `{} ms`\n\n",
             self.total_wall_time_ms
         ));
+        if let Some(output) = &self.output {
+            out.push_str(&format!("- Final output: `{}`\n\n", compact(output)));
+        }
 
         out.push_str("## Dependency Graph\n\n```mermaid\ngraph TD\n");
         for task in &self.tasks {
@@ -218,6 +255,47 @@ impl SwarmRunArtifact {
                         join_or_dash(&statuses)
                     ));
                 }
+            }
+        }
+
+        if let Some(metrics) = &self.metrics {
+            let mut agents: Vec<_> = metrics.agent_tokens.iter().collect();
+            agents.sort_by(|a, b| a.0.cmp(b.0));
+
+            out.push_str("\n## Metrics\n\n");
+            out.push_str("| Total Tokens | Duration | Tasks Completed | Tasks Failed | HITL | Reassignments |\n");
+            out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+            out.push_str(&format!(
+                "| {} | {} ms | {} | {} | {} | {} |\n",
+                metrics.total_tokens,
+                metrics.duration_ms,
+                metrics.tasks_completed,
+                metrics.tasks_failed,
+                metrics.hitl_interventions,
+                metrics.reassignments
+            ));
+
+            if !agents.is_empty() {
+                out.push_str("\n| Agent | Tokens |\n");
+                out.push_str("| --- | --- |\n");
+                for (agent, tokens) in agents {
+                    out.push_str(&format!("| {} | {} |\n", agent, tokens));
+                }
+            }
+        }
+
+        if !self.audit_events.is_empty() {
+            out.push_str("\n## Audit Trail\n\n");
+            out.push_str("| Event | Description | Data |\n");
+            out.push_str("| --- | --- | --- |\n");
+            for event in &self.audit_events {
+                // Keep event payloads compact so the markdown stays PR-comment friendly.
+                out.push_str(&format!(
+                    "| {} | {} | `{}` |\n",
+                    audit_kind_label(&event.kind),
+                    compact(&event.description),
+                    compact(&event.data.to_string())
+                ));
             }
         }
 
@@ -363,6 +441,44 @@ impl SwarmRunArtifact {
         }
     }
 
+    /// Assert swarm-level metrics match expected HITL and reassignment counts.
+    pub fn assert_metrics(
+        &self,
+        hitl_interventions: usize,
+        reassignments: usize,
+    ) -> Result<(), String> {
+        let metrics = self
+            .metrics
+            .as_ref()
+            .ok_or_else(|| "artifact has no metrics snapshot".to_string())?;
+
+        if metrics.hitl_interventions == hitl_interventions
+            && metrics.reassignments == reassignments
+        {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected metrics hitl/reassignments = {}/{}, got {}/{}",
+                hitl_interventions,
+                reassignments,
+                metrics.hitl_interventions,
+                metrics.reassignments
+            ))
+        }
+    }
+
+    /// Assert at least one audit event of the given kind exists.
+    pub fn assert_audit_event_kind(&self, kind: AuditEventKind) -> Result<(), String> {
+        if self.audit_events.iter().any(|event| event.kind == kind) {
+            Ok(())
+        } else {
+            Err(format!(
+                "artifact does not contain audit event `{}`",
+                audit_kind_label(&kind)
+            ))
+        }
+    }
+
     fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {
         self.tasks.iter().find(|task| task.id == task_id)
     }
@@ -378,6 +494,93 @@ impl SwarmRunArtifact {
             CoordinationPattern::Routing => "routing",
         }
     }
+}
+
+impl From<&SwarmMetrics> for SwarmMetricsRecord {
+    fn from(value: &SwarmMetrics) -> Self {
+        Self {
+            total_tokens: value.total_tokens,
+            duration_ms: value.duration_ms,
+            tasks_completed: value.tasks_completed,
+            tasks_failed: value.tasks_failed,
+            hitl_interventions: value.hitl_interventions,
+            reassignments: value.reassignments,
+            agent_tokens: value.agent_tokens.clone(),
+        }
+    }
+}
+
+impl From<&AuditEvent> for SwarmAuditRecord {
+    fn from(value: &AuditEvent) -> Self {
+        Self {
+            kind: value.kind.clone(),
+            description: value.description.clone(),
+            timestamp_ms: value.timestamp.timestamp_millis(),
+            data: value.data.clone(),
+        }
+    }
+}
+
+fn snapshot_tasks(dag: &SubtaskDAG) -> Vec<SwarmTaskRecord> {
+    // Prefer topological order so the rendered artifact reads like the intended
+    // orchestration plan rather than raw graph insertion order.
+    let ordered = dag
+        .topological_order()
+        .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
+
+    let mut tasks = Vec::new();
+    for idx in ordered {
+        if let Some(task) = dag.get_task(idx) {
+            let dependencies = dag
+                .dependencies_of(idx)
+                .into_iter()
+                .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                .collect();
+            let dependents = dag
+                .dependents_of(idx)
+                .into_iter()
+                .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                .collect();
+
+            tasks.push(SwarmTaskRecord {
+                id: task.id.clone(),
+                description: task.description.clone(),
+                status: task.status.clone(),
+                assigned_agent: task.assigned_agent.clone(),
+                output: task.output.clone(),
+                dependencies,
+                dependents,
+                required_capabilities: task.required_capabilities.clone(),
+                risk_level: task.risk_level.clone(),
+                hitl_required: task.hitl_required,
+            });
+        }
+    }
+    tasks
+}
+
+fn snapshot_execution(summary: &SchedulerSummary) -> Vec<SwarmExecutionRecord> {
+    summary
+        .results
+        .iter()
+        .map(|result| {
+            // Normalize scheduler outcomes to stable strings
+            let (outcome, detail) = match &result.outcome {
+                TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
+                TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
+                TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
+            };
+
+            SwarmExecutionRecord {
+                task_id: result.task_id.clone(),
+                node_index: result.node_index,
+                outcome,
+                detail,
+                wall_time_ms: result.wall_time.as_millis() as u64,
+                attempt: result.attempt,
+            }
+        })
+        .collect()
 }
 
 fn join_or_dash(values: &[String]) -> String {
@@ -411,5 +614,35 @@ fn status_label(status: &SubtaskStatus) -> String {
         SubtaskStatus::Completed => "completed".to_string(),
         SubtaskStatus::Failed(reason) => format!("failed ({reason})"),
         SubtaskStatus::Skipped => "skipped".to_string(),
+    }
+}
+
+fn swarm_status_label(status: &SwarmStatus) -> String {
+    match status {
+        SwarmStatus::Running => "running".to_string(),
+        SwarmStatus::Completed => "completed".to_string(),
+        SwarmStatus::Failed(reason) => format!("failed ({reason})"),
+        SwarmStatus::Cancelled => "cancelled".to_string(),
+        SwarmStatus::Escalated => "escalated".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn audit_kind_label(kind: &AuditEventKind) -> &'static str {
+    match kind {
+        AuditEventKind::SwarmStarted => "swarm_started",
+        AuditEventKind::TaskDecomposed => "task_decomposed",
+        AuditEventKind::AgentAssigned => "agent_assigned",
+        AuditEventKind::PatternSelected => "pattern_selected",
+        AuditEventKind::SubtaskStarted => "subtask_started",
+        AuditEventKind::SubtaskCompleted => "subtask_completed",
+        AuditEventKind::SubtaskFailed => "subtask_failed",
+        AuditEventKind::HITLRequested => "hitl_requested",
+        AuditEventKind::HITLDecision => "hitl_decision",
+        AuditEventKind::SLAWarning => "sla_warning",
+        AuditEventKind::SLABreach => "sla_breach",
+        AuditEventKind::AgentReassigned => "agent_reassigned",
+        AuditEventKind::SwarmCompleted => "swarm_completed",
+        _ => "unknown_event",
     }
 }

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -1,0 +1,373 @@
+//! Swarm/orchestrator testing helpers with visual artifact rendering.
+
+use std::collections::HashMap;
+
+use mofa_foundation::swarm::{
+    CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG, SubtaskStatus, TaskOutcome,
+};
+use serde::{Deserialize, Serialize};
+
+/// Canonical snapshot of one swarm task for testing and review output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmTaskRecord {
+    pub id: String,
+    pub description: String,
+    pub status: SubtaskStatus,
+    pub assigned_agent: Option<String>,
+    pub output: Option<String>,
+    pub dependencies: Vec<String>,
+    pub dependents: Vec<String>,
+    pub required_capabilities: Vec<String>,
+    pub risk_level: RiskLevel,
+    pub hitl_required: bool,
+}
+
+/// Visualizable artifact for one orchestrated swarm run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmRunArtifact {
+    pub name: String,
+    pub pattern: CoordinationPattern,
+    pub total_tasks: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub total_wall_time_ms: u64,
+    pub success_rate: f64,
+    pub tasks: Vec<SwarmTaskRecord>,
+    pub execution: Vec<SwarmExecutionRecord>,
+}
+
+/// One scheduler result entry normalized for rendering/assertion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmExecutionRecord {
+    pub task_id: String,
+    pub node_index: usize,
+    pub outcome: String,
+    pub detail: Option<String>,
+    pub wall_time_ms: u64,
+    pub attempt: u32,
+}
+
+impl SwarmRunArtifact {
+    /// Build an artifact from a scheduler summary and the final DAG state.
+    pub fn from_scheduler_run(dag: &SubtaskDAG, summary: &SchedulerSummary) -> Self {
+        let mut tasks = Vec::new();
+
+        let ordered = dag
+            .topological_order()
+            .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
+
+        for idx in ordered {
+            if let Some(task) = dag.get_task(idx) {
+                let dependencies = dag
+                    .dependencies_of(idx)
+                    .into_iter()
+                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                    .collect();
+                let dependents = dag
+                    .dependents_of(idx)
+                    .into_iter()
+                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                    .collect();
+
+                tasks.push(SwarmTaskRecord {
+                    id: task.id.clone(),
+                    description: task.description.clone(),
+                    status: task.status.clone(),
+                    assigned_agent: task.assigned_agent.clone(),
+                    output: task.output.clone(),
+                    dependencies,
+                    dependents,
+                    required_capabilities: task.required_capabilities.clone(),
+                    risk_level: task.risk_level.clone(),
+                    hitl_required: task.hitl_required,
+                });
+            }
+        }
+
+        let execution = summary
+            .results
+            .iter()
+            .map(|result| {
+                let (outcome, detail) = match &result.outcome {
+                    TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
+                    TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
+                    TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
+                };
+
+                SwarmExecutionRecord {
+                    task_id: result.task_id.clone(),
+                    node_index: result.node_index,
+                    outcome,
+                    detail,
+                    wall_time_ms: result.wall_time.as_millis() as u64,
+                    attempt: result.attempt,
+                }
+            })
+            .collect();
+
+        Self {
+            name: dag.name.clone(),
+            pattern: summary.pattern.clone(),
+            total_tasks: summary.total_tasks,
+            succeeded: summary.succeeded,
+            failed: summary.failed,
+            skipped: summary.skipped,
+            total_wall_time_ms: summary.total_wall_time.as_millis() as u64,
+            success_rate: summary.success_rate(),
+            tasks,
+            execution,
+        }
+    }
+
+    /// Render the artifact as pretty JSON for CI/artifacts.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("swarm artifact serialization should not fail")
+    }
+
+    /// Render the artifact as markdown with a Mermaid dependency graph.
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+
+        out.push_str(&format!("# Swarm Test Artifact: {}\n\n", self.name));
+        out.push_str(&format!("- Pattern: `{}`\n", self.pattern_label()));
+        out.push_str(&format!("- Total tasks: `{}`\n", self.total_tasks));
+        out.push_str(&format!("- Succeeded: `{}`\n", self.succeeded));
+        out.push_str(&format!("- Failed: `{}`\n", self.failed));
+        out.push_str(&format!("- Skipped: `{}`\n", self.skipped));
+        out.push_str(&format!("- Success rate: `{:.1}%`\n", self.success_rate * 100.0));
+        out.push_str(&format!(
+            "- Total wall time: `{} ms`\n\n",
+            self.total_wall_time_ms
+        ));
+
+        out.push_str("## Dependency Graph\n\n```mermaid\ngraph TD\n");
+        for task in &self.tasks {
+            if task.dependencies.is_empty() {
+                out.push_str(&format!("    {}[\"{}\"]\n", sanitize_node_id(&task.id), task.id));
+            } else {
+                for dep in &task.dependencies {
+                    out.push_str(&format!(
+                        "    {}[\"{}\"] --> {}[\"{}\"]\n",
+                        sanitize_node_id(dep),
+                        dep,
+                        sanitize_node_id(&task.id),
+                        task.id
+                    ));
+                }
+            }
+        }
+        out.push_str("```\n\n");
+
+        out.push_str("## Tasks\n\n");
+        out.push_str("| Task | Status | Agent | Depends On | Capabilities | HITL |\n");
+        out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+        for task in &self.tasks {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} | {} |\n",
+                task.id,
+                status_label(&task.status),
+                task.assigned_agent.as_deref().unwrap_or("-"),
+                join_or_dash(&task.dependencies),
+                join_or_dash(&task.required_capabilities),
+                if task.hitl_required { "required" } else { "no" }
+            ));
+            if let Some(output) = &task.output {
+                out.push_str(&format!("| output | `{}` |  |  |  |  |\n", compact(output)));
+            }
+        }
+
+        out.push_str("\n## Execution Trace\n\n");
+        out.push_str("| Order | Task | Outcome | Detail | Duration |\n");
+        out.push_str("| --- | --- | --- | --- | --- |\n");
+        for (order, record) in self.execution.iter().enumerate() {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} ms |\n",
+                order + 1,
+                record.task_id,
+                record.outcome,
+                record
+                    .detail
+                    .as_deref()
+                    .map(compact)
+                    .unwrap_or_else(|| "-".to_string()),
+                record.wall_time_ms
+            ));
+        }
+
+        out
+    }
+
+    /// Assert a specific task exists and has the expected status.
+    pub fn assert_task_status(
+        &self,
+        task_id: &str,
+        expected: SubtaskStatus,
+    ) -> Result<(), String> {
+        let actual = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        if actual.status == expected {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` expected status `{}` but was `{}`",
+                status_label(&expected),
+                status_label(&actual.status)
+            ))
+        }
+    }
+
+    /// Assert that all tasks completed successfully.
+    pub fn assert_all_completed(&self) -> Result<(), String> {
+        let incomplete: Vec<String> = self
+            .tasks
+            .iter()
+            .filter(|task| task.status != SubtaskStatus::Completed)
+            .map(|task| format!("{}:{}", task.id, status_label(&task.status)))
+            .collect();
+
+        if incomplete.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected all tasks completed, found non-completed tasks: {}",
+                incomplete.join(", ")
+            ))
+        }
+    }
+
+    /// Assert aggregate scheduler counts.
+    pub fn assert_counts(
+        &self,
+        succeeded: usize,
+        failed: usize,
+        skipped: usize,
+    ) -> Result<(), String> {
+        if self.succeeded == succeeded && self.failed == failed && self.skipped == skipped {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected counts success/fail/skip = {}/{}/{}, got {}/{}/{}",
+                succeeded, failed, skipped, self.succeeded, self.failed, self.skipped
+            ))
+        }
+    }
+
+    /// Assert a dependency edge exists in the decomposed task graph.
+    pub fn assert_dependency(&self, task_id: &str, dependency_id: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        if task.dependencies.iter().any(|dep| dep == dependency_id) {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` does not depend on `{dependency_id}`"
+            ))
+        }
+    }
+
+    /// Assert a task output contains the provided substring.
+    pub fn assert_output_contains(&self, task_id: &str, needle: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+        let output = task
+            .output
+            .as_deref()
+            .ok_or_else(|| format!("task `{task_id}` has no output"))?;
+
+        if output.contains(needle) {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` output did not contain `{needle}`"
+            ))
+        }
+    }
+
+    /// Assert a task failed and its failure message contains the provided substring.
+    pub fn assert_task_failed_contains(&self, task_id: &str, needle: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        match &task.status {
+            SubtaskStatus::Failed(reason) if reason.contains(needle) => Ok(()),
+            SubtaskStatus::Failed(reason) => Err(format!(
+                "task `{task_id}` failed, but `{reason}` did not contain `{needle}`"
+            )),
+            status => Err(format!(
+                "task `{task_id}` expected failed status but was `{}`",
+                status_label(status)
+            )),
+        }
+    }
+
+    /// Group tasks by assigned agent for multi-agent collaboration assertions.
+    pub fn tasks_by_agent(&self) -> HashMap<String, Vec<&SwarmTaskRecord>> {
+        let mut by_agent = HashMap::new();
+        for task in &self.tasks {
+            if let Some(agent) = &task.assigned_agent {
+                by_agent
+                    .entry(agent.clone())
+                    .or_insert_with(Vec::new)
+                    .push(task);
+            }
+        }
+        by_agent
+    }
+
+    fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {
+        self.tasks.iter().find(|task| task.id == task_id)
+    }
+
+    fn pattern_label(&self) -> &'static str {
+        match self.pattern {
+            CoordinationPattern::Sequential => "sequential",
+            CoordinationPattern::Parallel => "parallel",
+            CoordinationPattern::Debate => "debate",
+            CoordinationPattern::Consensus => "consensus",
+            CoordinationPattern::MapReduce => "map_reduce",
+            CoordinationPattern::Supervision => "supervision",
+            CoordinationPattern::Routing => "routing",
+        }
+    }
+}
+
+fn join_or_dash(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn sanitize_node_id(id: &str) -> String {
+    id.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn compact(value: &str) -> String {
+    let trimmed = value.replace('\n', " ");
+    if trimmed.len() > 60 {
+        format!("{}...", &trimmed[..57])
+    } else {
+        trimmed
+    }
+}
+
+fn status_label(status: &SubtaskStatus) -> String {
+    match status {
+        SubtaskStatus::Pending => "pending".to_string(),
+        SubtaskStatus::Ready => "ready".to_string(),
+        SubtaskStatus::Running => "running".to_string(),
+        SubtaskStatus::Completed => "completed".to_string(),
+        SubtaskStatus::Failed(reason) => format!("failed ({reason})"),
+        SubtaskStatus::Skipped => "skipped".to_string(),
+    }
+}

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -128,6 +128,7 @@ impl SwarmRunArtifact {
     /// Render the artifact as markdown with a Mermaid dependency graph.
     pub fn to_markdown(&self) -> String {
         let mut out = String::new();
+        let tasks_by_agent = self.tasks_by_agent();
 
         out.push_str(&format!("# Swarm Test Artifact: {}\n\n", self.name));
         out.push_str(&format!("- Pattern: `{}`\n", self.pattern_label()));
@@ -193,6 +194,31 @@ impl SwarmRunArtifact {
                     .unwrap_or_else(|| "-".to_string()),
                 record.wall_time_ms
             ));
+        }
+
+        if !tasks_by_agent.is_empty() {
+            let mut agent_names: Vec<_> = tasks_by_agent.keys().cloned().collect();
+            agent_names.sort();
+
+            out.push_str("\n## Agent Collaboration View\n\n");
+            out.push_str("| Agent | Tasks | Terminal States |\n");
+            out.push_str("| --- | --- | --- |\n");
+
+            for agent in agent_names {
+                if let Some(tasks) = tasks_by_agent.get(&agent) {
+                    let task_ids: Vec<String> = tasks.iter().map(|task| task.id.clone()).collect();
+                    let statuses: Vec<String> = tasks
+                        .iter()
+                        .map(|task| format!("{}:{}", task.id, status_label(&task.status)))
+                        .collect();
+                    out.push_str(&format!(
+                        "| {} | {} | {} |\n",
+                        agent,
+                        join_or_dash(&task_ids),
+                        join_or_dash(&statuses)
+                    ));
+                }
+            }
         }
 
         out
@@ -319,6 +345,22 @@ impl SwarmRunArtifact {
             }
         }
         by_agent
+    }
+
+    /// Assert that a given agent was assigned the expected task.
+    pub fn assert_agent_has_task(&self, agent_id: &str, task_id: &str) -> Result<(), String> {
+        let by_agent = self.tasks_by_agent();
+        let tasks = by_agent
+            .get(agent_id)
+            .ok_or_else(|| format!("agent `{agent_id}` not found in artifact"))?;
+
+        if tasks.iter().any(|task| task.id == task_id) {
+            Ok(())
+        } else {
+            Err(format!(
+                "agent `{agent_id}` was not assigned task `{task_id}`"
+            ))
+        }
     }
 
     fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -7,10 +7,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use futures::future::BoxFuture;
 use mofa_foundation::swarm::{
-    FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmScheduler,
-    SwarmSchedulerConfig, SwarmSubtask,
+    AuditEvent, AuditEventKind, FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG,
+    SubtaskStatus, SwarmMetrics, SwarmResult, SwarmScheduler, SwarmSchedulerConfig, SwarmStatus,
+    SwarmSubtask, CoordinationPattern,
 };
 use mofa_kernel::agent::types::error::GlobalError;
 use mofa_testing::SwarmRunArtifact;
@@ -127,7 +129,7 @@ async fn swarm_artifact_surfaces_failed_orchestration_state() {
 
     let err = artifact.assert_all_completed().unwrap_err();
     assert!(err.contains("approve"));
-    assert!(artifact.to_markdown().contains("failed (approval rejected)"));
+    assert!(artifact.to_markdown().contains("approval rejected"));
     assert!(artifact.to_json().contains("\"outcome\": \"failure\""));
     let approve = dag.find_by_id("approve").unwrap();
     let notify = dag.find_by_id("notify").unwrap();
@@ -136,4 +138,54 @@ async fn swarm_artifact_surfaces_failed_orchestration_state() {
         SubtaskStatus::Failed(_)
     ));
     assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Skipped);
+}
+
+#[tokio::test]
+async fn swarm_artifact_from_swarm_result_captures_metrics_and_audit() {
+    let dag = workflow_dag();
+
+    let mut metrics = SwarmMetrics::default();
+    metrics.record_task_completed();
+    metrics.record_task_completed();
+    metrics.record_task_failed();
+    metrics.record_hitl_intervention();
+    metrics.record_reassignment();
+    metrics.record_agent_tokens("reviewer", 120);
+    metrics.record_agent_tokens("analyst", 60);
+    metrics.set_duration_ms(321);
+
+    let audit_events = vec![
+        AuditEvent::new(AuditEventKind::SwarmStarted, "Swarm started")
+            .with_data(serde_json::json!({"swarm_id":"support-escalation"})),
+        AuditEvent::new(AuditEventKind::AgentReassigned, "Reviewer took over approve")
+            .with_data(serde_json::json!({"subtask_id":"approve","new_agent":"reviewer"})),
+        AuditEvent::new(AuditEventKind::SwarmCompleted, "Swarm completed")
+            .with_data(serde_json::json!({"swarm_id":"support-escalation"})),
+    ];
+
+    let result = SwarmResult {
+        config_id: "cfg-1".into(),
+        status: SwarmStatus::Completed,
+        dag,
+        output: Some("customer notified".into()),
+        metrics,
+        audit_events,
+        started_at: Utc::now(),
+        completed_at: Some(Utc::now()),
+    };
+
+    let artifact =
+        SwarmRunArtifact::from_swarm_result(&result, CoordinationPattern::Parallel, None);
+
+    artifact.assert_metrics(1, 1).unwrap();
+    artifact
+        .assert_audit_event_kind(AuditEventKind::AgentReassigned)
+        .unwrap();
+    assert_eq!(artifact.swarm_status, Some(SwarmStatus::Completed));
+    assert_eq!(artifact.output.as_deref(), Some("customer notified"));
+    assert_eq!(artifact.metrics.as_ref().unwrap().agent_tokens["reviewer"], 120);
+    assert!(artifact.to_markdown().contains("## Metrics"));
+    assert!(artifact.to_markdown().contains("## Audit Trail"));
+    assert!(artifact.to_markdown().contains("agent_reassigned"));
+    assert!(artifact.to_json().contains("\"hitl_interventions\": 1"));
 }

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -1,0 +1,136 @@
+//! Integration tests for swarm/orchestrator testing artifacts and assertions.
+//!
+//! Covers multi-agent task decomposition, orchestration state assertions,
+//! fail-fast cascade behavior, and the visual markdown/JSON artifacts exposed
+//! by `mofa-testing` for maintainers and CI review.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmScheduler,
+    SwarmSchedulerConfig, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalError;
+use mofa_testing::SwarmRunArtifact;
+
+fn workflow_dag() -> SubtaskDAG {
+    let mut dag = SubtaskDAG::new("support-escalation");
+    let classify = dag.add_task(
+        SwarmSubtask::new("classify", "Classify inbound request")
+            .with_capabilities(vec!["triage".into()]),
+    );
+    let investigate = dag.add_task(
+        SwarmSubtask::new("investigate", "Investigate account state")
+            .with_capabilities(vec!["lookup".into()])
+            .with_risk_level(RiskLevel::Medium),
+    );
+    let approve = dag.add_task(
+        SwarmSubtask::new("approve", "Approve account change")
+            .with_capabilities(vec!["approval".into()])
+            .with_risk_level(RiskLevel::High),
+    );
+    let notify = dag.add_task(
+        SwarmSubtask::new("notify", "Notify customer")
+            .with_capabilities(vec!["email".into()]),
+    );
+
+    dag.add_dependency(classify, investigate).unwrap();
+    dag.add_dependency(investigate, approve).unwrap();
+    dag.add_dependency(approve, notify).unwrap();
+
+    dag.assign_agent(classify, "router");
+    dag.assign_agent(investigate, "analyst");
+    dag.assign_agent(approve, "reviewer");
+    dag.assign_agent(notify, "notifier");
+
+    dag
+}
+
+#[tokio::test]
+async fn swarm_artifact_captures_decomposition_and_collaboration() {
+    let mut dag = workflow_dag();
+
+    let exec = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            Ok(format!("{} completed by {}", task.id, task.assigned_agent.unwrap()))
+        })
+    });
+
+    let scheduler = ParallelScheduler::new();
+    let summary = scheduler.execute(&mut dag, exec).await.unwrap();
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    artifact.assert_all_completed().unwrap();
+    artifact.assert_counts(4, 0, 0).unwrap();
+    artifact.assert_dependency("approve", "investigate").unwrap();
+    artifact
+        .assert_task_status("approve", SubtaskStatus::Completed)
+        .unwrap();
+    artifact
+        .assert_output_contains("notify", "notifier")
+        .unwrap();
+
+    let by_agent = artifact.tasks_by_agent();
+    assert_eq!(by_agent["reviewer"][0].id, "approve");
+    assert!(artifact.tasks.iter().any(|task| task.id == "approve" && task.hitl_required));
+    assert!(artifact
+        .to_markdown()
+        .contains("graph TD"));
+    assert!(artifact.to_markdown().contains("approve"));
+    assert!(artifact.to_json().contains("\"assigned_agent\": \"reviewer\""));
+
+    let approve_task = artifact
+        .tasks
+        .iter()
+        .find(|task| task.id == "approve")
+        .unwrap();
+    assert_eq!(approve_task.risk_level, RiskLevel::High);
+    let notify_task = artifact.tasks.iter().find(|task| task.id == "notify").unwrap();
+    assert_eq!(notify_task.dependencies, vec!["approve".to_string()]);
+    let approve = dag.find_by_id("approve").unwrap();
+    let notify = dag.find_by_id("notify").unwrap();
+    assert_eq!(dag.get_task(approve).unwrap().status, SubtaskStatus::Completed);
+    assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Completed);
+}
+
+#[tokio::test]
+async fn swarm_artifact_surfaces_failed_orchestration_state() {
+    let mut dag = workflow_dag();
+
+    let exec = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            if task.id == "approve" {
+                Err(GlobalError::runtime("approval rejected"))
+            } else {
+                Ok(format!("{} ok", task.id))
+            }
+        })
+    });
+
+    let mut config = SwarmSchedulerConfig::default();
+    config.failure_policy = FailurePolicy::FailFastCascade;
+    let scheduler = ParallelScheduler::with_config(config);
+    let summary = scheduler.execute(&mut dag, exec).await.unwrap();
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    artifact.assert_counts(2, 1, 1).unwrap();
+    artifact.assert_task_failed_contains("approve", "approval rejected").unwrap();
+    artifact
+        .assert_task_status("notify", SubtaskStatus::Skipped)
+        .unwrap();
+
+    let err = artifact.assert_all_completed().unwrap_err();
+    assert!(err.contains("approve"));
+    assert!(artifact.to_markdown().contains("failed (approval rejected)"));
+    assert!(artifact.to_json().contains("\"outcome\": \"failure\""));
+    let approve = dag.find_by_id("approve").unwrap();
+    let notify = dag.find_by_id("notify").unwrap();
+    assert!(matches!(
+        dag.get_task(approve).unwrap().status,
+        SubtaskStatus::Failed(_)
+    ));
+    assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Skipped);
+}

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -75,11 +75,14 @@ async fn swarm_artifact_captures_decomposition_and_collaboration() {
 
     let by_agent = artifact.tasks_by_agent();
     assert_eq!(by_agent["reviewer"][0].id, "approve");
+    artifact.assert_agent_has_task("reviewer", "approve").unwrap();
     assert!(artifact.tasks.iter().any(|task| task.id == "approve" && task.hitl_required));
     assert!(artifact
         .to_markdown()
         .contains("graph TD"));
     assert!(artifact.to_markdown().contains("approve"));
+    assert!(artifact.to_markdown().contains("Agent Collaboration View"));
+    assert!(artifact.to_markdown().contains("| reviewer | approve |"));
     assert!(artifact.to_json().contains("\"assigned_agent\": \"reviewer\""));
 
     let approve_task = artifact


### PR DESCRIPTION
## Summary

Add swarm/orchestrator testing artifacts to `mofa-testing`.

This PR introduces a `SwarmRunArtifact` that captures multi-agent task state, execution results, metrics, and audit events, then renders that data as:

- markdown for PR review
- JSON for CI/artifacts

It also adds swarm-specific assertions, integration tests, and a runnable demo.
##  Swarm Testing Artifact Flow
<img width="1600" height="850" alt="image" src="https://github.com/user-attachments/assets/1ab48244-99f3-4d28-bfe5-726928e03c7e" />

## What Changed

### Artifact support

Added `tests/src/swarm.rs` with:

- `SwarmRunArtifact`: top-level snapshot for one orchestrated swarm run
- `SwarmTaskRecord`: canonical task-level state including dependencies, assignment, output, and risk/HITL flags
- `SwarmExecutionRecord`: normalized execution trace entries derived from scheduler results
- `SwarmMetricsRecord`: stable testing-facing view of swarm metrics
- `SwarmAuditRecord`: stable testing-facing view of audit events

The artifact can be built from:

- `from_scheduler_run(dag, summary)`: for scheduler-focused tests that only have DAG state plus `SchedulerSummary`
- `from_swarm_result(result, pattern, summary)`: for fuller orchestration tests that also want swarm status, final output, metrics, and audit trail

### Assertions

Added assertions for:

- task completion and task status: verify terminal orchestration state for specific subtasks or the full run
- dependency relationships: verify task decomposition and ordering constraints
- output and failure message matching: check behavior evidence without relying on exact full-string formatting
- agent-to-task assignment: verify which agent owned which subtask
- swarm metrics: validate HITL/reassignment counters from `SwarmResult`
- audit event presence: verify orchestration emitted expected audit trail events

### Rendering

`SwarmRunArtifact::to_markdown()` renders:

- swarm summary: top-level status, counts, success rate, duration, and optional final output
- Mermaid dependency graph: visual decomposition of the task DAG
- task table: per-task state, owner, dependencies, capabilities, and HITL requirements
- execution trace: ordered scheduler results with outcome and timing
- agent collaboration view: grouped ownership of subtasks by assigned agent
- metrics table: aggregate run metrics plus optional per-agent token breakdown
- audit trail: normalized swarm events for review and CI artifacts

`SwarmRunArtifact::to_json()` provides the machine-readable artifact form.

### Tests

Added/updated:

- `tests/tests/swarm_testing_tests.rs`: integration coverage for successful orchestration, fail-fast cascade behavior, artifact rendering, and `SwarmResult` metrics/audit capture
- `examples/swarm_testing_demo/Cargo.toml`: example package manifest for the runnable swarm testing demo
- `examples/swarm_testing_demo/src/main.rs`: a small incident-response workflow that executes a DAG and prints both markdown and JSON artifacts
- `examples/Cargo.toml`: registers the new demo in the examples workspace
- `tests/src/lib.rs`: exports the swarm testing surface from `mofa-testing`
- `tests/Cargo.toml`: dependency wiring for the new swarm testing module and target

The test coverage includes:

- successful orchestration
- fail-fast cascade behavior
- artifact rendering
- metrics and audit capture from `SwarmResult`

The demo runs a small incident-response DAG and prints both markdown and JSON artifacts.

## Test Commands

```bash
cargo test -p mofa-testing --test swarm_testing_tests
cargo run --manifest-path examples/Cargo.toml -p swarm_testing_demo
```
## Example Output

```text
Compiling swarm_testing_demo v0.1.0 (/home/aditya/projc/mvpissues/mofa/examples/swarm_testing_demo)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.38s
Running `examples/target/debug/swarm_testing_demo`
# Swarm Test Artifact: incident-response

- Pattern: `parallel`
- Total tasks: `4`
- Succeeded: `4`
- Failed: `0`
- Skipped: `0`
- Success rate: `100.0%`
- Total wall time: `65 ms`

## Dependency Graph

graph TD
    triage["triage"]
    triage["triage"] --> investigate["investigate"]
    investigate["investigate"] --> remediate["remediate"]
    remediate["remediate"] --> report["report"]

## Agent Collaboration View

| Agent | Tasks | Terminal States |
| --- | --- | --- |
| analyst | investigate | investigate:completed |
| communicator | report | report:completed |
| operator | remediate | remediate:completed |
| router | triage | triage:completed |

{
  "name": "incident-response",
  "pattern": "parallel",
  "swarm_status": null,
  "total_tasks": 4,
  "succeeded": 4,
  "failed": 0,
  "skipped": 0,
  "total_wall_time_ms": 65,
  "success_rate": 1.0,
  "output": null,
  "metrics": null,
  "audit_events": [],
  "tasks": [
    {
      "id": "triage",
      "description": "Triage incoming incident",
      "status": "completed",
      "assigned_agent": "router",
      "output": "triage handled by router",
      "dependencies": [],
      "dependents": [
        "investigate"
      ],
      "required_capabilities": [
        "triage"
      ],
      "risk_level": "low",
      "hitl_required": false
    },...
}
```
## Outcome

After this PR, `mofa-testing` can produce a reviewable swarm/orchestrator artifact that shows:

- task decomposition
- agent ownership
- failure/skip behavior
- execution trace
- metrics and audit signals
