### PR TITLE
 feat(testing): add artifact-backed assertions for agent runs

### DIFF
--- a/crates/mofa-foundation/src/agent/context/prompt.rs
+++ b/crates/mofa-foundation/src/agent/context/prompt.rs
@@ -142,6 +142,17 @@ impl PromptContext {
         self
     }
 
+    /// Replace the agent identity.
+    pub fn set_identity(&mut self, identity: AgentIdentity) {
+        self.agent_name = identity.name.clone();
+        self.identity = identity;
+    }
+
+    /// Replace the bootstrap file list.
+    pub fn set_bootstrap_files(&mut self, files: Vec<String>) {
+        self.bootstrap_files = files;
+    }
+
     /// Set skills that should always be loaded
     pub fn with_always_load(mut self, skills: Vec<String>) -> Self {
         self.always_load = skills;

--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -595,7 +595,9 @@ impl MoFAAgent for AgentExecutor {
         self.base.initialize(ctx).await?;
 
         // Additional executor-specific initialization
-        self.base.transition_to(AgentState::Ready)?;
+        if self.base.state() != AgentState::Ready {
+            self.base.transition_to(AgentState::Ready)?;
+        }
 
         Ok(())
     }

--- a/crates/mofa-foundation/src/agent/executor.rs
+++ b/crates/mofa-foundation/src/agent/executor.rs
@@ -548,6 +548,15 @@ impl AgentExecutor {
         &self.config
     }
 
+    /// Update the prompt context (system prompt builder).
+    pub async fn update_prompt_context<F>(&self, updater: F)
+    where
+        F: FnOnce(&mut PromptContext),
+    {
+        let mut ctx = self.context.write().await;
+        updater(&mut ctx);
+    }
+
     /// Get mutable reference to base agent
     pub fn base_mut(&mut self) -> &mut BaseAgent {
         &mut self.base
@@ -643,7 +652,10 @@ mod tests {
             "mock"
         }
 
-        async fn chat(&self, _request: ChatCompletionRequest) -> AgentResult<ChatCompletionResponse> {
+        async fn chat(
+            &self,
+            _request: ChatCompletionRequest,
+        ) -> AgentResult<ChatCompletionResponse> {
             Ok(ChatCompletionResponse {
                 content: Some("ok".to_string()),
                 tool_calls: Some(Vec::<ToolCall>::new()),

--- a/crates/mofa-runtime/src/runner.rs
+++ b/crates/mofa-runtime/src/runner.rs
@@ -349,6 +349,11 @@ impl<T: MoFAAgent> AgentRunner<T> {
         &self.context
     }
 
+    /// Update session ID in the execution context.
+    pub fn set_session_id(&mut self, session_id: Option<String>) {
+        self.context.session_id = session_id;
+    }
+
     /// 获取运行器状态
     /// Get runner state
     pub async fn state(&self) -> RunnerState {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 resolver = "3"
 members = [
+    "agent_runner_basic",
+    "agent_runner_custom_session",
+    "agent_runner_tools",
     "cli_production_smoke",
     "cli_agent_logs_demo",
     "cli_plugin_lifecycle",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "3"
 members = [
+    "agent_runner_assertions_basic",
+    "agent_runner_assertions_tools",
     "agent_runner_basic",
     "agent_runner_custom_session",
     "agent_runner_tools",

--- a/examples/agent_runner_assertions_basic/Cargo.toml
+++ b/examples/agent_runner_assertions_basic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_assertions_basic"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-runtime = { path = "../../crates/mofa-runtime" }
+mofa-testing = { path = "../../tests" }
+tokio.workspace = true

--- a/examples/agent_runner_assertions_basic/src/main.rs
+++ b/examples/agent_runner_assertions_basic/src/main.rs
@@ -1,0 +1,46 @@
+//! Basic example showing assertion-driven validation over a successful agent run.
+//!
+//! Demonstrates output, session, LLM-capture, runner-state, and stats assertions.
+
+use anyhow::Result;
+use mofa_runtime::runner::RunnerState;
+use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::assertions::{
+    assert_duration_under, assert_execution_id_present, assert_llm_request_has_system_message,
+    assert_llm_request_message_count, assert_llm_response_equals, assert_output_contains,
+    assert_run_success, assert_runner_state_after, assert_runner_state_before,
+    assert_session_contains_in_order, assert_session_id_equals, assert_session_len_at_least,
+    assert_successful_executions_delta, assert_total_executions_delta,
+};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+    runner.mock_llm().add_response("Hello from assertions").await;
+
+    let result = runner.run_text("hello").await?;
+
+    assert_run_success(&result);
+    assert_execution_id_present(&result);
+    assert_session_id_equals(&result, runner.session_id());
+    assert_runner_state_before(&result, RunnerState::Created);
+    assert_runner_state_after(&result, RunnerState::Running);
+    assert_total_executions_delta(&result, 1);
+    assert_successful_executions_delta(&result, 1);
+    assert_output_contains(&result, "assertions");
+    assert_duration_under(&result, Duration::from_secs(2));
+    assert_llm_request_message_count(&result, 2);
+    assert_llm_request_has_system_message(&result);
+    assert_llm_response_equals(&result, "Hello from assertions");
+    assert_session_len_at_least(&result, 2);
+    assert_session_contains_in_order(
+        &result,
+        &[("user", "hello"), ("assistant", "Hello from assertions")],
+    );
+
+    println!("basic assertions example passed");
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_assertions_tools/Cargo.toml
+++ b/examples/agent_runner_assertions_tools/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_assertions_tools"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+serde_json.workspace = true
+tokio.workspace = true

--- a/examples/agent_runner_assertions_tools/src/main.rs
+++ b/examples/agent_runner_assertions_tools/src/main.rs
@@ -1,0 +1,59 @@
+//! Tool-focused example showing assertion-driven validation over a tool-calling agent run.
+//!
+//! Demonstrates tool-call, LLM-capture, and workspace-side-effect assertions.
+
+use anyhow::Result;
+use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::assertions::{
+    assert_llm_request_has_system_message, assert_llm_request_message_count,
+    assert_llm_response_equals, assert_run_tool_called, assert_run_tool_call_count,
+    assert_run_tool_duration_recorded, assert_run_tool_input, assert_run_tool_output_contains,
+    assert_run_tool_succeeded, assert_workspace_file_count_delta,
+    assert_workspace_file_exists_after,
+};
+use mofa_testing::tools::MockTool;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo the provided input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+
+    runner.register_mock_tool(tool).await?;
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), Some("calling tool".into()))
+        .await;
+    runner.mock_llm().add_response("Tool response completed").await;
+
+    let result = runner.run_text("use the tool").await?;
+    let session_file = format!("sessions/{}.jsonl", runner.session_id());
+
+    assert_llm_request_message_count(&result, 4);
+    assert_llm_request_has_system_message(&result);
+    assert_llm_response_equals(&result, "Tool response completed");
+    assert_run_tool_called(&result, "echo_tool");
+    assert_run_tool_call_count(&result, "echo_tool", 1);
+    assert_run_tool_input(&result, "echo_tool", &json!({ "input": "ping" }));
+    assert_run_tool_succeeded(&result, "echo_tool");
+    assert_run_tool_output_contains(&result, "echo_tool", "Mock execution default");
+    assert_run_tool_duration_recorded(&result, "echo_tool");
+    assert_workspace_file_count_delta(&result, 1);
+    assert_workspace_file_exists_after(&result, &session_file);
+
+    println!("tool assertions example passed");
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_basic/Cargo.toml
+++ b/examples/agent_runner_basic/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agent_runner_basic"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+tokio.workspace = true

--- a/examples/agent_runner_basic/src/main.rs
+++ b/examples/agent_runner_basic/src/main.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use mofa_testing::AgentTestRunner;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+    runner.mock_llm().add_response("Hello from the runner").await;
+
+    let result = runner.run_text("hi").await?;
+    println!("Output: {}", result.output_text().unwrap_or_default());
+    println!(
+        "Session: {}",
+        result
+            .metadata
+            .session_id
+            .as_deref()
+            .unwrap_or("<none>")
+    );
+    println!("Workspace: {}", result.metadata.workspace_root.display());
+    println!(
+        "Runner stats: total={} success={} failed={}",
+        result.metadata.runner_stats_after.total_executions,
+        result.metadata.runner_stats_after.successful_executions,
+        result.metadata.runner_stats_after.failed_executions
+    );
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_custom_session/Cargo.toml
+++ b/examples/agent_runner_custom_session/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_custom_session"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+tokio.workspace = true

--- a/examples/agent_runner_custom_session/src/main.rs
+++ b/examples/agent_runner_custom_session/src/main.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use mofa_foundation::agent::context::prompt::AgentIdentity;
+use mofa_testing::AgentTestRunner;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+
+    runner.write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")?;
+    runner
+        .configure_prompt(
+            Some(AgentIdentity {
+                name: "RunnerDemo".to_string(),
+                description: "Custom identity for example runs".to_string(),
+                icon: None,
+            }),
+            Some(vec!["CUSTOM.md".to_string()]),
+        )
+        .await;
+
+    runner
+        .mock_llm()
+        .add_response("Custom session response")
+        .await;
+
+    let result = runner
+        .run_text_with_session("demo-session", "hello session")
+        .await?;
+
+    println!(
+        "Session id: {}",
+        result
+            .metadata
+            .session_id
+            .as_deref()
+            .unwrap_or("<none>")
+    );
+    println!("Output: {}", result.output_text().unwrap_or_default());
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/examples/agent_runner_tools/Cargo.toml
+++ b/examples/agent_runner_tools/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "agent_runner_tools"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+mofa-testing = { path = "../../tests" }
+serde_json.workspace = true
+tokio.workspace = true

--- a/examples/agent_runner_tools/src/main.rs
+++ b/examples/agent_runner_tools/src/main.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use mofa_testing::{AgentTestRunner, MockTool};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut runner = AgentTestRunner::new().await?;
+
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo the provided input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+
+    runner.register_mock_tool(tool).await?;
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner
+        .mock_llm()
+        .add_response("Tool response completed")
+        .await;
+
+    let result = runner.run_text("use the tool").await?;
+    println!("Output: {}", result.output_text().unwrap_or_default());
+
+    for record in &result.metadata.tool_calls {
+        println!(
+            "Tool call: name={} input={} output={} duration_ms={:?}",
+            record.tool_name,
+            record.input,
+            record.output.as_ref().unwrap_or(&serde_json::Value::Null),
+            record.duration_ms
+        );
+    }
+
+    runner.shutdown().await?;
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+regex = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,9 +9,12 @@ description = "Testing utilities for the MoFA agent framework"
 [dependencies]
 mofa-kernel = { path = "../crates/mofa-kernel" }
 mofa-foundation = { path = "../crates/mofa-foundation" }
+mofa-runtime = { path = "../crates/mofa-runtime" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,9 +16,6 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-<<<<<<< feat/testing-artifact-assertions
 thiserror = { workspace = true }
 uuid = { workspace = true }
-=======
->>>>>>> main
 regex = { workspace = true }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -5,12 +5,14 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use mofa_foundation::agent::context::prompt::AgentIdentity;
 use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
 use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_foundation::agent::components::tool::as_tool;
 use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
+use crate::tools::MockTool;
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
 use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
 use mofa_kernel::agent::AgentCapabilities;
@@ -52,6 +54,9 @@ pub struct AgentRunMetadata {
     pub agent_state_after: AgentState,
     pub started_at: DateTime<Utc>,
     pub session_snapshot: Option<Session>,
+    pub tool_calls: Vec<ToolCallRecord>,
+    pub llm_last_request: Option<ChatCompletionRequest>,
+    pub llm_last_response: Option<ChatCompletionResponse>,
 }
 
 /// Result of a single agent run.
@@ -62,6 +67,15 @@ pub struct AgentRunResult {
     pub error: Option<AgentError>,
     pub duration: Duration,
     pub metadata: AgentRunMetadata,
+}
+
+/// Captures a tool call with its input and output.
+#[derive(Debug, Clone)]
+pub struct ToolCallRecord {
+    pub tool_name: String,
+    pub input: serde_json::Value,
+    pub output: Option<serde_json::Value>,
+    pub success: bool,
 }
 
 impl AgentRunResult {
@@ -81,6 +95,7 @@ pub struct MockAgentLLMProvider {
     responses: RwLock<VecDeque<MockLlmResponse>>,
     default_response: RwLock<String>,
     last_request: RwLock<Option<ChatCompletionRequest>>,
+    last_response: RwLock<Option<ChatCompletionResponse>>,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +115,7 @@ impl MockAgentLLMProvider {
             responses: RwLock::new(VecDeque::new()),
             default_response: RwLock::new("This is a mock response.".to_string()),
             last_request: RwLock::new(None),
+            last_response: RwLock::new(None),
         }
     }
 
@@ -145,6 +161,10 @@ impl MockAgentLLMProvider {
     pub async fn last_request(&self) -> Option<ChatCompletionRequest> {
         self.last_request.read().await.clone()
     }
+
+    pub async fn last_response(&self) -> Option<ChatCompletionResponse> {
+        self.last_response.read().await.clone()
+    }
 }
 
 #[async_trait]
@@ -167,7 +187,7 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
             }
         };
 
-        match response {
+        let response = match response {
             MockLlmResponse::Text(content) => Ok(ChatCompletionResponse {
                 content: Some(content),
                 tool_calls: Some(Vec::<ToolCall>::new()),
@@ -179,7 +199,10 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
                 usage: None,
             }),
             MockLlmResponse::Error(message) => Err(AgentError::ExecutionFailed(message)),
-        }
+        }?;
+
+        *self.last_response.write().await = Some(response.clone());
+        Ok(response)
     }
 }
 
@@ -197,6 +220,13 @@ impl SessionAwareExecutor {
         tool: Arc<dyn mofa_kernel::agent::components::tool::DynTool>,
     ) -> AgentResult<()> {
         self.executor.register_tool(tool).await
+    }
+
+    async fn update_prompt_context<F>(&self, updater: F)
+    where
+        F: FnOnce(&mut mofa_foundation::agent::context::prompt::PromptContext),
+    {
+        self.executor.update_prompt_context(updater).await;
     }
 }
 
@@ -276,6 +306,7 @@ pub struct AgentTestRunner {
     execution_id: String,
     llm: Arc<MockAgentLLMProvider>,
     runner: AgentRunner<SessionAwareExecutor>,
+    mock_tools: Vec<MockTool>,
 }
 
 impl AgentTestRunner {
@@ -301,6 +332,7 @@ impl AgentTestRunner {
             execution_id,
             llm,
             runner,
+            mock_tools: Vec::new(),
         })
     }
 
@@ -348,8 +380,43 @@ impl AgentTestRunner {
             .map_err(AgentRunnerError::from)
     }
 
+    pub async fn register_mock_tool(&mut self, tool: MockTool) -> Result<(), AgentRunnerError> {
+        self.register_simple_tool(tool.clone()).await?;
+        self.mock_tools.push(tool);
+        Ok(())
+    }
+
+    pub async fn configure_prompt(
+        &self,
+        identity: Option<AgentIdentity>,
+        bootstrap_files: Option<Vec<String>>,
+    ) {
+        self.runner
+            .agent()
+            .update_prompt_context(|ctx| {
+                if let Some(identity) = identity {
+                    ctx.set_identity(identity);
+                }
+                if let Some(files) = bootstrap_files {
+                    ctx.set_bootstrap_files(files);
+                }
+            })
+            .await;
+    }
+
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_texts(
+        &mut self,
+        inputs: &[&str],
+    ) -> Result<Vec<AgentRunResult>, AgentRunnerError> {
+        let mut results = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            results.push(self.run_text(input).await?);
+        }
+        Ok(results)
     }
 
     pub async fn run_input(
@@ -367,6 +434,9 @@ impl AgentTestRunner {
         let runner_stats_after = self.runner.stats().await;
         let agent_state_after = self.runner.agent_state();
         let session_snapshot = self.load_session_snapshot().await;
+        let tool_calls = self.collect_tool_calls().await;
+        let llm_last_request = self.llm.last_request().await;
+        let llm_last_response = self.llm.last_response().await;
 
         let (output, error) = match result {
             Ok(output) => (Some(output), None),
@@ -387,6 +457,9 @@ impl AgentTestRunner {
             agent_state_after,
             started_at,
             session_snapshot,
+            tool_calls,
+            llm_last_request,
+            llm_last_response,
         };
 
         Ok(AgentRunResult {
@@ -406,5 +479,27 @@ impl AgentTestRunner {
         let session_id = self.runner.context().session_id.as_deref()?;
         let storage = JsonlSessionStorage::new(self.workspace.path()).await.ok()?;
         storage.load(session_id).await.ok()?
+    }
+
+    async fn collect_tool_calls(&self) -> Vec<ToolCallRecord> {
+        let mut records = Vec::new();
+        for tool in &self.mock_tools {
+            let calls = tool.history().await;
+            let results = tool.results().await;
+            for (idx, call) in calls.into_iter().enumerate() {
+                let result = results.get(idx).cloned();
+                let (output, success) = match result {
+                    Some(result) => (Some(result.output.clone()), result.success),
+                    None => (None, false),
+                };
+                records.push(ToolCallRecord {
+                    tool_name: tool.name().to_string(),
+                    input: call.arguments,
+                    output,
+                    success,
+                });
+            }
+        }
+        records
     }
 }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -9,9 +9,12 @@ use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
 use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_foundation::agent::components::tool::as_tool;
+use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
 use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
 use mofa_kernel::agent::AgentCapabilities;
+use mofa_kernel::agent::AgentState;
 use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
@@ -34,19 +37,26 @@ pub enum AgentRunnerError {
 
 /// Metadata captured for each run.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct AgentRunMetadata {
     pub agent_id: String,
     pub agent_name: String,
     pub execution_id: String,
     pub session_id: Option<String>,
     pub workspace_root: PathBuf,
-    pub runner_state: RunnerState,
-    pub runner_stats: RunnerStats,
+    pub runner_state_before: RunnerState,
+    pub runner_state_after: RunnerState,
+    pub runner_stats_before: RunnerStats,
+    pub runner_stats_after: RunnerStats,
+    pub agent_state_before: AgentState,
+    pub agent_state_after: AgentState,
     pub started_at: DateTime<Utc>,
+    pub session_snapshot: Option<Session>,
 }
 
 /// Result of a single agent run.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct AgentRunResult {
     pub output: Option<AgentOutput>,
     pub error: Option<AgentError>,
@@ -68,8 +78,19 @@ impl AgentRunResult {
 #[derive(Debug)]
 pub struct MockAgentLLMProvider {
     name: String,
-    responses: RwLock<VecDeque<String>>,
+    responses: RwLock<VecDeque<MockLlmResponse>>,
     default_response: RwLock<String>,
+    last_request: RwLock<Option<ChatCompletionRequest>>,
+}
+
+#[derive(Debug, Clone)]
+enum MockLlmResponse {
+    Text(String),
+    ToolCall {
+        content: Option<String>,
+        tool_calls: Vec<ToolCall>,
+    },
+    Error(String),
 }
 
 impl MockAgentLLMProvider {
@@ -78,11 +99,39 @@ impl MockAgentLLMProvider {
             name: name.into(),
             responses: RwLock::new(VecDeque::new()),
             default_response: RwLock::new("This is a mock response.".to_string()),
+            last_request: RwLock::new(None),
         }
     }
 
     pub async fn add_response(&self, response: impl Into<String>) {
-        self.responses.write().await.push_back(response.into());
+        self.responses
+            .write()
+            .await
+            .push_back(MockLlmResponse::Text(response.into()));
+    }
+
+    pub async fn add_tool_call_response(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        content: Option<String>,
+    ) {
+        let tool_call = ToolCall {
+            id: Uuid::now_v7().to_string(),
+            name: tool_name.to_string(),
+            arguments,
+        };
+        self.responses.write().await.push_back(MockLlmResponse::ToolCall {
+            content,
+            tool_calls: vec![tool_call],
+        });
+    }
+
+    pub async fn add_error_response(&self, message: impl Into<String>) {
+        self.responses
+            .write()
+            .await
+            .push_back(MockLlmResponse::Error(message.into()));
     }
 
     pub async fn set_default_response(&self, response: impl Into<String>) {
@@ -91,6 +140,10 @@ impl MockAgentLLMProvider {
 
     pub async fn pending_responses(&self) -> usize {
         self.responses.read().await.len()
+    }
+
+    pub async fn last_request(&self) -> Option<ChatCompletionRequest> {
+        self.last_request.read().await.clone()
     }
 }
 
@@ -102,22 +155,31 @@ impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
 
     async fn chat(
         &self,
-        _request: ChatCompletionRequest,
+        request: ChatCompletionRequest,
     ) -> AgentResult<ChatCompletionResponse> {
+        *self.last_request.write().await = Some(request);
         let response = {
             let mut responses = self.responses.write().await;
             if let Some(next) = responses.pop_front() {
                 next
             } else {
-                self.default_response.read().await.clone()
+                MockLlmResponse::Text(self.default_response.read().await.clone())
             }
         };
 
-        Ok(ChatCompletionResponse {
-            content: Some(response),
-            tool_calls: Some(Vec::<ToolCall>::new()),
-            usage: None,
-        })
+        match response {
+            MockLlmResponse::Text(content) => Ok(ChatCompletionResponse {
+                content: Some(content),
+                tool_calls: Some(Vec::<ToolCall>::new()),
+                usage: None,
+            }),
+            MockLlmResponse::ToolCall { content, tool_calls } => Ok(ChatCompletionResponse {
+                content,
+                tool_calls: Some(tool_calls),
+                usage: None,
+            }),
+            MockLlmResponse::Error(message) => Err(AgentError::ExecutionFailed(message)),
+        }
     }
 }
 
@@ -128,6 +190,13 @@ struct SessionAwareExecutor {
 impl SessionAwareExecutor {
     fn new(executor: AgentExecutor) -> Self {
         Self { executor }
+    }
+
+    async fn register_tool(
+        &self,
+        tool: Arc<dyn mofa_kernel::agent::components::tool::DynTool>,
+    ) -> AgentResult<()> {
+        self.executor.register_tool(tool).await
     }
 }
 
@@ -182,6 +251,15 @@ impl TempWorkspace {
 
     fn path(&self) -> &Path {
         &self.root
+    }
+
+    fn write_file(&self, relative_path: &Path, content: &str) -> Result<PathBuf, AgentRunnerError> {
+        let path = self.root.join(relative_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, content)?;
+        Ok(path)
     }
 }
 
@@ -242,6 +320,34 @@ impl AgentTestRunner {
         Arc::clone(&self.llm)
     }
 
+    pub fn write_bootstrap_file(
+        &self,
+        filename: &str,
+        content: &str,
+    ) -> Result<PathBuf, AgentRunnerError> {
+        self.workspace.write_file(Path::new(filename), content)
+    }
+
+    pub fn write_workspace_file(
+        &self,
+        relative_path: impl AsRef<Path>,
+        content: &str,
+    ) -> Result<PathBuf, AgentRunnerError> {
+        self.workspace.write_file(relative_path.as_ref(), content)
+    }
+
+    pub async fn register_simple_tool<T>(&self, tool: T) -> Result<(), AgentRunnerError>
+    where
+        T: mofa_foundation::agent::components::tool::SimpleTool + Send + Sync + 'static,
+    {
+        let tool_ref = as_tool(tool);
+        self.runner
+            .agent()
+            .register_tool(tool_ref)
+            .await
+            .map_err(AgentRunnerError::from)
+    }
+
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
     }
@@ -251,9 +357,16 @@ impl AgentTestRunner {
         input: AgentInput,
     ) -> Result<AgentRunResult, AgentRunnerError> {
         let started_at = Utc::now();
+        let runner_state_before = self.runner.state().await;
+        let runner_stats_before = self.runner.stats().await;
+        let agent_state_before = self.runner.agent_state();
         let timer = Instant::now();
         let result = self.runner.execute(input).await;
         let duration = timer.elapsed();
+        let runner_state_after = self.runner.state().await;
+        let runner_stats_after = self.runner.stats().await;
+        let agent_state_after = self.runner.agent_state();
+        let session_snapshot = self.load_session_snapshot().await;
 
         let (output, error) = match result {
             Ok(output) => (Some(output), None),
@@ -266,9 +379,14 @@ impl AgentTestRunner {
             execution_id: self.runner.context().execution_id.clone(),
             session_id: self.runner.context().session_id.clone(),
             workspace_root: self.workspace.path().to_path_buf(),
-            runner_state: self.runner.state().await,
-            runner_stats: self.runner.stats().await,
+            runner_state_before,
+            runner_state_after,
+            runner_stats_before,
+            runner_stats_after,
+            agent_state_before,
+            agent_state_after,
             started_at,
+            session_snapshot,
         };
 
         Ok(AgentRunResult {
@@ -282,5 +400,11 @@ impl AgentTestRunner {
     pub async fn shutdown(self) -> Result<(), AgentRunnerError> {
         self.runner.shutdown().await?;
         Ok(())
+    }
+
+    async fn load_session_snapshot(&self) -> Option<Session> {
+        let session_id = self.runner.context().session_id.as_deref()?;
+        let storage = JsonlSessionStorage::new(self.workspace.path()).await.ok()?;
+        storage.load(session_id).await.ok()?
     }
 }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -19,6 +19,8 @@ use mofa_kernel::agent::AgentCapabilities;
 use mofa_kernel::agent::AgentState;
 use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
 use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -57,6 +59,8 @@ pub struct AgentRunMetadata {
     pub tool_calls: Vec<ToolCallRecord>,
     pub llm_last_request: Option<ChatCompletionRequest>,
     pub llm_last_response: Option<ChatCompletionResponse>,
+    pub workspace_snapshot_before: WorkspaceSnapshot,
+    pub workspace_snapshot_after: WorkspaceSnapshot,
 }
 
 /// Result of a single agent run.
@@ -76,6 +80,22 @@ pub struct ToolCallRecord {
     pub input: serde_json::Value,
     pub output: Option<serde_json::Value>,
     pub success: bool,
+    pub duration_ms: Option<u64>,
+    pub timed_out: bool,
+}
+
+/// Snapshot of files in the test workspace.
+#[derive(Debug, Clone)]
+pub struct WorkspaceSnapshot {
+    pub files: Vec<WorkspaceFileSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceFileSnapshot {
+    pub relative_path: String,
+    pub size_bytes: u64,
+    pub modified_ms: Option<u64>,
+    pub checksum: u64,
 }
 
 impl AgentRunResult {
@@ -291,12 +311,70 @@ impl TempWorkspace {
         std::fs::write(&path, content)?;
         Ok(path)
     }
+
+    fn snapshot(&self) -> WorkspaceSnapshot {
+        let mut files = Vec::new();
+        collect_workspace_files(&self.root, &self.root, &mut files);
+        files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+        WorkspaceSnapshot { files }
+    }
 }
 
 impl Drop for TempWorkspace {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.root);
     }
+}
+
+fn collect_workspace_files(root: &Path, current: &Path, files: &mut Vec<WorkspaceFileSnapshot>) {
+    let entries = match std::fs::read_dir(current) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_workspace_files(root, &path, files);
+            continue;
+        }
+
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+
+        let size_bytes = metadata.len();
+        let modified_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as u64);
+
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(_) => Vec::new(),
+        };
+        let checksum = hash_bytes(&bytes);
+        let relative_path = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .to_string();
+
+        files.push(WorkspaceFileSnapshot {
+            relative_path,
+            size_bytes,
+            modified_ms,
+            checksum,
+        });
+    }
+}
+
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Test harness for running real agent execution paths.
@@ -427,6 +505,7 @@ impl AgentTestRunner {
         let runner_state_before = self.runner.state().await;
         let runner_stats_before = self.runner.stats().await;
         let agent_state_before = self.runner.agent_state();
+        let workspace_snapshot_before = self.workspace.snapshot();
         let timer = Instant::now();
         let result = self.runner.execute(input).await;
         let duration = timer.elapsed();
@@ -434,6 +513,7 @@ impl AgentTestRunner {
         let runner_stats_after = self.runner.stats().await;
         let agent_state_after = self.runner.agent_state();
         let session_snapshot = self.load_session_snapshot().await;
+        let workspace_snapshot_after = self.workspace.snapshot();
         let tool_calls = self.collect_tool_calls().await;
         let llm_last_request = self.llm.last_request().await;
         let llm_last_response = self.llm.last_response().await;
@@ -460,6 +540,8 @@ impl AgentTestRunner {
             tool_calls,
             llm_last_request,
             llm_last_response,
+            workspace_snapshot_before,
+            workspace_snapshot_after,
         };
 
         Ok(AgentRunResult {
@@ -488,15 +570,33 @@ impl AgentTestRunner {
             let results = tool.results().await;
             for (idx, call) in calls.into_iter().enumerate() {
                 let result = results.get(idx).cloned();
-                let (output, success) = match result {
-                    Some(result) => (Some(result.output.clone()), result.success),
-                    None => (None, false),
+                let (output, success, duration_ms, timed_out) = match result {
+                    Some(result) => {
+                        let duration_ms = result
+                            .metadata
+                            .get("duration_ms")
+                            .and_then(|value| value.parse::<u64>().ok());
+                        let timed_out = result
+                            .error
+                            .as_ref()
+                            .map(|err| err.contains("timed out"))
+                            .unwrap_or(false);
+                        (
+                            Some(result.output.clone()),
+                            result.success,
+                            duration_ms,
+                            timed_out,
+                        )
+                    }
+                    None => (None, false, None, false),
                 };
                 records.push(ToolCallRecord {
                     tool_name: tool.name().to_string(),
                     input: call.arguments,
                     output,
                     success,
+                    duration_ms,
+                    timed_out,
                 });
             }
         }

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -361,7 +361,7 @@ fn collect_workspace_files(root: &Path, current: &Path, files: &mut Vec<Workspac
             .strip_prefix(root)
             .unwrap_or(&path)
             .to_string_lossy()
-            .to_string();
+            .replace('\\', "/");
 
         files.push(WorkspaceFileSnapshot {
             relative_path,

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -11,6 +11,7 @@ use mofa_kernel::agent::context::AgentContext;
 use mofa_kernel::agent::core::MoFAAgent;
 use mofa_kernel::agent::error::{AgentError, AgentResult};
 use mofa_foundation::agent::components::tool::as_tool;
+use mofa_foundation::agent::components::tool::SimpleTool;
 use mofa_foundation::agent::session::{JsonlSessionStorage, Session, SessionStorage};
 use crate::tools::MockTool;
 use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
@@ -484,6 +485,19 @@ impl AgentTestRunner {
 
     pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
         self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_text_with_session(
+        &mut self,
+        session_id: &str,
+        input: &str,
+    ) -> Result<AgentRunResult, AgentRunnerError> {
+        let original_session = self.runner.context().session_id.clone();
+        self.runner
+            .set_session_id(Some(session_id.to_string()));
+        let result = self.run_text(input).await;
+        self.runner.set_session_id(original_session);
+        result
     }
 
     pub async fn run_texts(

--- a/tests/src/agent_runner.rs
+++ b/tests/src/agent_runner.rs
@@ -1,0 +1,286 @@
+//! Real agent runner harness for integration-style tests.
+//!
+//! Provides a lightweight wrapper around the MoFA runtime `AgentRunner`
+//! with an isolated workspace and deterministic mock LLM.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use mofa_foundation::agent::executor::{AgentExecutor, AgentExecutorConfig};
+use mofa_kernel::agent::context::AgentContext;
+use mofa_kernel::agent::core::MoFAAgent;
+use mofa_kernel::agent::error::{AgentError, AgentResult};
+use mofa_kernel::agent::types::{AgentInput, AgentOutput, ChatCompletionRequest};
+use mofa_kernel::agent::types::{ChatCompletionResponse, ToolCall};
+use mofa_kernel::agent::AgentCapabilities;
+use mofa_runtime::runner::{AgentRunner, RunnerState, RunnerStats};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use thiserror::Error;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+/// Errors returned by the agent runner harness itself.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AgentRunnerError {
+    #[error("failed to create test workspace: {0}")]
+    WorkspaceIo(#[from] std::io::Error),
+
+    #[error("agent runner failure: {0}")]
+    Agent(#[from] AgentError),
+}
+
+/// Metadata captured for each run.
+#[derive(Debug, Clone)]
+pub struct AgentRunMetadata {
+    pub agent_id: String,
+    pub agent_name: String,
+    pub execution_id: String,
+    pub session_id: Option<String>,
+    pub workspace_root: PathBuf,
+    pub runner_state: RunnerState,
+    pub runner_stats: RunnerStats,
+    pub started_at: DateTime<Utc>,
+}
+
+/// Result of a single agent run.
+#[derive(Debug)]
+pub struct AgentRunResult {
+    pub output: Option<AgentOutput>,
+    pub error: Option<AgentError>,
+    pub duration: Duration,
+    pub metadata: AgentRunMetadata,
+}
+
+impl AgentRunResult {
+    pub fn is_success(&self) -> bool {
+        self.error.is_none()
+    }
+
+    pub fn output_text(&self) -> Option<String> {
+        self.output.as_ref().map(AgentOutput::to_text)
+    }
+}
+
+/// Simple deterministic LLM provider for tests.
+#[derive(Debug)]
+pub struct MockAgentLLMProvider {
+    name: String,
+    responses: RwLock<VecDeque<String>>,
+    default_response: RwLock<String>,
+}
+
+impl MockAgentLLMProvider {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            responses: RwLock::new(VecDeque::new()),
+            default_response: RwLock::new("This is a mock response.".to_string()),
+        }
+    }
+
+    pub async fn add_response(&self, response: impl Into<String>) {
+        self.responses.write().await.push_back(response.into());
+    }
+
+    pub async fn set_default_response(&self, response: impl Into<String>) {
+        *self.default_response.write().await = response.into();
+    }
+
+    pub async fn pending_responses(&self) -> usize {
+        self.responses.read().await.len()
+    }
+}
+
+#[async_trait]
+impl mofa_kernel::agent::types::LLMProvider for MockAgentLLMProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn chat(
+        &self,
+        _request: ChatCompletionRequest,
+    ) -> AgentResult<ChatCompletionResponse> {
+        let response = {
+            let mut responses = self.responses.write().await;
+            if let Some(next) = responses.pop_front() {
+                next
+            } else {
+                self.default_response.read().await.clone()
+            }
+        };
+
+        Ok(ChatCompletionResponse {
+            content: Some(response),
+            tool_calls: Some(Vec::<ToolCall>::new()),
+            usage: None,
+        })
+    }
+}
+
+struct SessionAwareExecutor {
+    executor: AgentExecutor,
+}
+
+impl SessionAwareExecutor {
+    fn new(executor: AgentExecutor) -> Self {
+        Self { executor }
+    }
+}
+
+#[async_trait]
+impl MoFAAgent for SessionAwareExecutor {
+    fn id(&self) -> &str {
+        self.executor.id()
+    }
+
+    fn name(&self) -> &str {
+        self.executor.name()
+    }
+
+    fn capabilities(&self) -> &AgentCapabilities {
+        self.executor.capabilities()
+    }
+
+    fn state(&self) -> mofa_kernel::agent::AgentState {
+        self.executor.state()
+    }
+
+    async fn initialize(&mut self, ctx: &AgentContext) -> AgentResult<()> {
+        self.executor.initialize(ctx).await
+    }
+
+    async fn execute(
+        &mut self,
+        input: AgentInput,
+        ctx: &AgentContext,
+    ) -> AgentResult<AgentOutput> {
+        let message = input.as_text().unwrap_or("");
+        let session_key = ctx.session_id.as_deref().unwrap_or("default");
+        let response = self.executor.process_message(session_key, message).await?;
+        Ok(AgentOutput::text(response))
+    }
+
+    async fn shutdown(&mut self) -> AgentResult<()> {
+        self.executor.shutdown().await
+    }
+}
+
+struct TempWorkspace {
+    root: PathBuf,
+}
+
+impl TempWorkspace {
+    fn new(prefix: &str) -> Result<Self, AgentRunnerError> {
+        let root = std::env::temp_dir().join(format!("{}-{}", prefix, Uuid::now_v7()));
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TempWorkspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+/// Test harness for running real agent execution paths.
+pub struct AgentTestRunner {
+    workspace: TempWorkspace,
+    session_id: String,
+    execution_id: String,
+    llm: Arc<MockAgentLLMProvider>,
+    runner: AgentRunner<SessionAwareExecutor>,
+}
+
+impl AgentTestRunner {
+    pub async fn new() -> Result<Self, AgentRunnerError> {
+        Self::with_config(AgentExecutorConfig::default()).await
+    }
+
+    pub async fn with_config(config: AgentExecutorConfig) -> Result<Self, AgentRunnerError> {
+        let workspace = TempWorkspace::new("mofa-agent-test")?;
+        let llm = Arc::new(MockAgentLLMProvider::new("mock-llm"));
+        let executor = AgentExecutor::with_config(llm.clone(), workspace.path(), config).await?;
+        let agent = SessionAwareExecutor::new(executor);
+
+        let execution_id = Uuid::now_v7().to_string();
+        let session_id = Uuid::now_v7().to_string();
+        let context = AgentContext::with_session(&execution_id, &session_id);
+
+        let runner = AgentRunner::with_context(agent, context).await?;
+
+        Ok(Self {
+            workspace,
+            session_id,
+            execution_id,
+            llm,
+            runner,
+        })
+    }
+
+    pub fn workspace(&self) -> &Path {
+        self.workspace.path()
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    pub fn execution_id(&self) -> &str {
+        &self.execution_id
+    }
+
+    pub fn mock_llm(&self) -> Arc<MockAgentLLMProvider> {
+        Arc::clone(&self.llm)
+    }
+
+    pub async fn run_text(&mut self, input: &str) -> Result<AgentRunResult, AgentRunnerError> {
+        self.run_input(AgentInput::text(input)).await
+    }
+
+    pub async fn run_input(
+        &mut self,
+        input: AgentInput,
+    ) -> Result<AgentRunResult, AgentRunnerError> {
+        let started_at = Utc::now();
+        let timer = Instant::now();
+        let result = self.runner.execute(input).await;
+        let duration = timer.elapsed();
+
+        let (output, error) = match result {
+            Ok(output) => (Some(output), None),
+            Err(err) => (None, Some(err)),
+        };
+
+        let metadata = AgentRunMetadata {
+            agent_id: self.runner.agent().id().to_string(),
+            agent_name: self.runner.agent().name().to_string(),
+            execution_id: self.runner.context().execution_id.clone(),
+            session_id: self.runner.context().session_id.clone(),
+            workspace_root: self.workspace.path().to_path_buf(),
+            runner_state: self.runner.state().await,
+            runner_stats: self.runner.stats().await,
+            started_at,
+        };
+
+        Ok(AgentRunResult {
+            output,
+            error,
+            duration,
+            metadata,
+        })
+    }
+
+    pub async fn shutdown(self) -> Result<(), AgentRunnerError> {
+        self.runner.shutdown().await?;
+        Ok(())
+    }
+}

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -522,6 +522,16 @@ pub fn assert_workspace_has_file(snapshot: &WorkspaceSnapshot, relative_path: &s
     let _ = find_file(snapshot, relative_path);
 }
 
+/// Assert that the workspace snapshot before execution contains the given file.
+pub fn assert_workspace_file_exists_before(result: &AgentRunResult, relative_path: &str) {
+    assert_workspace_has_file(&result.metadata.workspace_snapshot_before, relative_path);
+}
+
+/// Assert that the workspace snapshot after execution contains the given file.
+pub fn assert_workspace_file_exists_after(result: &AgentRunResult, relative_path: &str) {
+    assert_workspace_has_file(&result.metadata.workspace_snapshot_after, relative_path);
+}
+
 /// Assert that the workspace snapshot does not contain the given file.
 pub fn assert_workspace_missing_file(snapshot: &WorkspaceSnapshot, relative_path: &str) {
     let found = snapshot
@@ -532,6 +542,29 @@ pub fn assert_workspace_missing_file(snapshot: &WorkspaceSnapshot, relative_path
         !found,
         "Expected workspace file '{}' to be absent, but snapshot contained it",
         relative_path
+    );
+}
+
+/// Assert that the workspace file count delta matches the expected change.
+pub fn assert_workspace_file_count_delta(result: &AgentRunResult, expected_delta: isize) {
+    let before = result.metadata.workspace_snapshot_before.files.len() as isize;
+    let after = result.metadata.workspace_snapshot_after.files.len() as isize;
+    let actual_delta = after - before;
+    assert_eq!(
+        actual_delta, expected_delta,
+        "Expected workspace file count delta {}, got {} (before {}, after {})",
+        expected_delta, actual_delta, before, after
+    );
+}
+
+/// Assert that a workspace file checksum changed across the run.
+pub fn assert_workspace_file_checksum_changed(result: &AgentRunResult, relative_path: &str) {
+    let before = find_file(&result.metadata.workspace_snapshot_before, relative_path);
+    let after = find_file(&result.metadata.workspace_snapshot_after, relative_path);
+    assert_ne!(
+        before.checksum, after.checksum,
+        "Expected workspace file '{}' checksum to change, but it stayed {}",
+        relative_path, before.checksum
     );
 }
 

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -1,6 +1,13 @@
-//! Convenience assertion macros for mock verification.
+//! Assertion helpers for mock verification and structured agent-run results.
 //!
-//! Reduces boilerplate when checking that mocks were called as expected.
+//! Keeps tests focused on behavior instead of hand-parsing run metadata.
+
+use std::time::Duration;
+
+use regex::Regex;
+use serde_json::Value;
+
+use crate::agent_runner::{AgentRunResult, ToolCallRecord, WorkspaceFileSnapshot, WorkspaceSnapshot};
 
 /// Assert the named tool was called at least once.
 ///
@@ -110,5 +117,335 @@ pub fn assert_session_messages(
             "Expected content '{}' at index {}, got '{}'",
             content, idx, msg.content
         );
+    }
+}
+
+/// Assert that a structured run completed without an execution error.
+pub fn assert_run_success(result: &AgentRunResult) {
+    assert!(
+        result.error.is_none(),
+        "Expected run to succeed, but got error: {:?}",
+        result.error
+    );
+}
+
+/// Assert that a structured run failed with an error containing the expected text.
+pub fn assert_run_failure_contains(result: &AgentRunResult, expected: &str) {
+    let error = result
+        .error
+        .as_ref()
+        .unwrap_or_else(|| panic!("Expected run to fail with '{expected}', but it succeeded"));
+    let actual = error.to_string();
+    assert!(
+        actual.contains(expected),
+        "Expected error containing '{}', got '{}'",
+        expected,
+        actual
+    );
+}
+
+/// Assert that the final text output contains the expected substring.
+pub fn assert_output_contains(result: &AgentRunResult, expected: &str) {
+    let output = result
+        .output_text()
+        .unwrap_or_else(|| panic!("Expected output containing '{expected}', but run had no output"));
+    assert!(
+        output.contains(expected),
+        "Expected output containing '{}', got '{}'",
+        expected,
+        output
+    );
+}
+
+/// Assert that the final text output matches the given regex.
+pub fn assert_output_matches_regex(result: &AgentRunResult, pattern: &str) {
+    let output = result
+        .output_text()
+        .unwrap_or_else(|| panic!("Expected output matching '{pattern}', but run had no output"));
+    let regex = Regex::new(pattern)
+        .unwrap_or_else(|err| panic!("Invalid regex pattern '{}': {}", pattern, err));
+    assert!(
+        regex.is_match(&output),
+        "Expected output matching '{}', got '{}'",
+        pattern,
+        output
+    );
+}
+
+/// Assert that the run duration is less than or equal to the threshold.
+pub fn assert_duration_under(result: &AgentRunResult, max: Duration) {
+    assert!(
+        result.duration <= max,
+        "Expected run duration <= {:?}, got {:?}",
+        max,
+        result.duration
+    );
+}
+
+/// Assert that the last captured LLM request contains the expected text.
+pub fn assert_llm_request_contains(result: &AgentRunResult, expected: &str) {
+    let request = result.metadata.llm_last_request.as_ref().unwrap_or_else(|| {
+        panic!("Expected LLM request containing '{}', but none was captured", expected)
+    });
+    let messages = request
+        .messages
+        .iter()
+        .filter_map(|msg| msg.content.as_deref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        messages.contains(expected),
+        "Expected LLM request containing '{}', got '{}'",
+        expected,
+        messages
+    );
+}
+
+/// Assert that the last captured LLM response contains the expected text.
+pub fn assert_llm_response_contains(result: &AgentRunResult, expected: &str) {
+    let response = result.metadata.llm_last_response.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected LLM response containing '{}', but none was captured",
+            expected
+        )
+    });
+    let content = response.content.as_deref().unwrap_or("");
+    assert!(
+        content.contains(expected),
+        "Expected LLM response containing '{}', got '{}'",
+        expected,
+        content
+    );
+}
+
+/// Assert that the captured session snapshot has the expected length.
+pub fn assert_session_len(result: &AgentRunResult, expected: usize) {
+    let session = result.metadata.session_snapshot.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected session snapshot with {} messages, but none was captured",
+            expected
+        )
+    });
+    assert_eq!(
+        session.len(),
+        expected,
+        "Expected {} session messages, got {}",
+        expected,
+        session.len()
+    );
+}
+
+/// Assert that the captured session contains a message with the expected role/content.
+pub fn assert_session_contains(
+    result: &AgentRunResult,
+    role: &str,
+    expected_content: &str,
+) {
+    let session = result.metadata.session_snapshot.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected session message '{}:{}', but no snapshot was captured",
+            role, expected_content
+        )
+    });
+    let found = session
+        .messages
+        .iter()
+        .any(|msg| msg.role == role && msg.content == expected_content);
+    assert!(
+        found,
+        "Expected session to contain role '{}' with content '{}', got {:?}",
+        role,
+        expected_content,
+        session
+            .messages
+            .iter()
+            .map(|msg| (&msg.role, &msg.content))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn find_tool_call<'a>(result: &'a AgentRunResult, tool_name: &str) -> &'a ToolCallRecord {
+    result
+        .metadata
+        .tool_calls
+        .iter()
+        .find(|call| call.tool_name == tool_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "Expected tool '{}' in run metadata, got {:?}",
+                tool_name,
+                result
+                    .metadata
+                    .tool_calls
+                    .iter()
+                    .map(|call| &call.tool_name)
+                    .collect::<Vec<_>>()
+            )
+        })
+}
+
+/// Assert that a given tool was called during the run.
+pub fn assert_run_tool_called(result: &AgentRunResult, tool_name: &str) {
+    let _ = find_tool_call(result, tool_name);
+}
+
+/// Assert that a given tool was not called during the run.
+pub fn assert_run_tool_not_called(result: &AgentRunResult, tool_name: &str) {
+    let found = result
+        .metadata
+        .tool_calls
+        .iter()
+        .any(|call| call.tool_name == tool_name);
+    assert!(
+        !found,
+        "Expected tool '{}' not to be called, but it was. Calls: {:?}",
+        tool_name,
+        result
+            .metadata
+            .tool_calls
+            .iter()
+            .map(|call| &call.tool_name)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Assert that a given tool was called the expected number of times.
+pub fn assert_run_tool_call_count(result: &AgentRunResult, tool_name: &str, expected: usize) {
+    let count = result
+        .metadata
+        .tool_calls
+        .iter()
+        .filter(|call| call.tool_name == tool_name)
+        .count();
+    assert_eq!(
+        count, expected,
+        "Expected tool '{}' to be called {} time(s), got {}",
+        tool_name, expected, count
+    );
+}
+
+/// Assert that a tool call used the expected input JSON.
+pub fn assert_run_tool_input(result: &AgentRunResult, tool_name: &str, expected: &Value) {
+    let call = find_tool_call(result, tool_name);
+    assert_eq!(
+        &call.input, expected,
+        "Expected tool '{}' input {:?}, got {:?}",
+        tool_name, expected, call.input
+    );
+}
+
+/// Assert that a tool call completed successfully.
+pub fn assert_run_tool_succeeded(result: &AgentRunResult, tool_name: &str) {
+    let call = find_tool_call(result, tool_name);
+    assert!(
+        call.success,
+        "Expected tool '{}' to succeed, but metadata was {:?}",
+        tool_name,
+        call
+    );
+}
+
+/// Assert that a tool call output contains the expected substring.
+pub fn assert_run_tool_output_contains(
+    result: &AgentRunResult,
+    tool_name: &str,
+    expected: &str,
+) {
+    let call = find_tool_call(result, tool_name);
+    let output = call
+        .output
+        .as_ref()
+        .unwrap_or_else(|| panic!("Expected tool '{}' output, but it was None", tool_name))
+        .to_string();
+    assert!(
+        output.contains(expected),
+        "Expected tool '{}' output containing '{}', got '{}'",
+        tool_name,
+        expected,
+        output
+    );
+}
+
+/// Assert that a tool call recorded a duration.
+pub fn assert_run_tool_duration_recorded(result: &AgentRunResult, tool_name: &str) {
+    let call = find_tool_call(result, tool_name);
+    assert!(
+        call.duration_ms.is_some(),
+        "Expected tool '{}' to record duration metadata, got {:?}",
+        tool_name,
+        call
+    );
+}
+
+fn find_file<'a>(snapshot: &'a WorkspaceSnapshot, relative_path: &str) -> &'a WorkspaceFileSnapshot {
+    snapshot
+        .files
+        .iter()
+        .find(|file| file.relative_path == relative_path)
+        .unwrap_or_else(|| {
+            panic!(
+                "Expected workspace file '{}', got {:?}",
+                relative_path,
+                snapshot
+                    .files
+                    .iter()
+                    .map(|file| &file.relative_path)
+                    .collect::<Vec<_>>()
+            )
+        })
+}
+
+/// Assert that the workspace snapshot contains the given file.
+pub fn assert_workspace_has_file(snapshot: &WorkspaceSnapshot, relative_path: &str) {
+    let _ = find_file(snapshot, relative_path);
+}
+
+/// Assert that the workspace snapshot does not contain the given file.
+pub fn assert_workspace_missing_file(snapshot: &WorkspaceSnapshot, relative_path: &str) {
+    let found = snapshot
+        .files
+        .iter()
+        .any(|file| file.relative_path == relative_path);
+    assert!(
+        !found,
+        "Expected workspace file '{}' to be absent, but snapshot contained it",
+        relative_path
+    );
+}
+
+/// Assert that the run created or changed the given workspace file.
+pub fn assert_workspace_file_changed(result: &AgentRunResult, relative_path: &str) {
+    let before = result
+        .metadata
+        .workspace_snapshot_before
+        .files
+        .iter()
+        .find(|file| file.relative_path == relative_path);
+    let after = result
+        .metadata
+        .workspace_snapshot_after
+        .files
+        .iter()
+        .find(|file| file.relative_path == relative_path);
+
+    match (before, after) {
+        (None, Some(_)) => {}
+        (Some(before), Some(after)) => {
+            assert!(
+                before.size_bytes != after.size_bytes
+                    || before.modified_ms != after.modified_ms
+                    || before.checksum != after.checksum,
+                "Expected workspace file '{}' to change, but snapshots were unchanged",
+                relative_path
+            );
+        }
+        (Some(_), None) => panic!(
+            "Expected workspace file '{}' to change, but it disappeared after the run",
+            relative_path
+        ),
+        (None, None) => panic!(
+            "Expected workspace file '{}' to change, but it never existed in snapshots",
+            relative_path
+        ),
     }
 }

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -375,6 +375,22 @@ pub fn assert_session_len(result: &AgentRunResult, expected: usize) {
     );
 }
 
+/// Assert that the captured session snapshot has at least the expected number of messages.
+pub fn assert_session_len_at_least(result: &AgentRunResult, minimum: usize) {
+    let session = result.metadata.session_snapshot.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected session snapshot with at least {} messages, but none was captured",
+            minimum
+        )
+    });
+    assert!(
+        session.len() >= minimum,
+        "Expected at least {} session messages, got {}",
+        minimum,
+        session.len()
+    );
+}
+
 /// Assert that the captured session contains a message with the expected role/content.
 pub fn assert_session_contains(
     result: &AgentRunResult,
@@ -396,6 +412,43 @@ pub fn assert_session_contains(
         "Expected session to contain role '{}' with content '{}', got {:?}",
         role,
         expected_content,
+        session
+            .messages
+            .iter()
+            .map(|msg| (&msg.role, &msg.content))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Assert that the captured session contains the expected messages in order.
+pub fn assert_session_contains_in_order(
+    result: &AgentRunResult,
+    expected: &[(&str, &str)],
+) {
+    let session = result.metadata.session_snapshot.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected session to contain {:?} in order, but no snapshot was captured",
+            expected
+        )
+    });
+
+    let mut expected_idx = 0usize;
+    for message in &session.messages {
+        if expected_idx >= expected.len() {
+            break;
+        }
+
+        let (role, content) = expected[expected_idx];
+        if message.role == role && message.content == content {
+            expected_idx += 1;
+        }
+    }
+
+    assert_eq!(
+        expected_idx,
+        expected.len(),
+        "Expected session to contain {:?} in order, got {:?}",
+        expected,
         session
             .messages
             .iter()

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -405,6 +405,17 @@ pub fn assert_run_tool_succeeded(result: &AgentRunResult, tool_name: &str) {
     );
 }
 
+/// Assert that a tool call failed.
+pub fn assert_run_tool_failed(result: &AgentRunResult, tool_name: &str) {
+    let call = find_tool_call(result, tool_name);
+    assert!(
+        !call.success,
+        "Expected tool '{}' to fail, but metadata was {:?}",
+        tool_name,
+        call
+    );
+}
+
 /// Assert that a tool call output contains the expected substring.
 pub fn assert_run_tool_output_contains(
     result: &AgentRunResult,
@@ -426,12 +437,63 @@ pub fn assert_run_tool_output_contains(
     );
 }
 
+/// Assert that a tool call output matches the expected JSON value.
+pub fn assert_run_tool_output_equals_json(
+    result: &AgentRunResult,
+    tool_name: &str,
+    expected: &Value,
+) {
+    let call = find_tool_call(result, tool_name);
+    let output = call
+        .output
+        .as_ref()
+        .unwrap_or_else(|| panic!("Expected tool '{}' output, but it was None", tool_name));
+    assert_eq!(
+        output, expected,
+        "Expected tool '{}' output {:?}, got {:?}",
+        tool_name, expected, output
+    );
+}
+
 /// Assert that a tool call recorded a duration.
 pub fn assert_run_tool_duration_recorded(result: &AgentRunResult, tool_name: &str) {
     let call = find_tool_call(result, tool_name);
     assert!(
         call.duration_ms.is_some(),
         "Expected tool '{}' to record duration metadata, got {:?}",
+        tool_name,
+        call
+    );
+}
+
+/// Assert that a tool call duration is less than or equal to the threshold.
+pub fn assert_run_tool_duration_under(
+    result: &AgentRunResult,
+    tool_name: &str,
+    max_duration_ms: u64,
+) {
+    let call = find_tool_call(result, tool_name);
+    let duration_ms = call.duration_ms.unwrap_or_else(|| {
+        panic!(
+            "Expected tool '{}' to record duration metadata, got {:?}",
+            tool_name, call
+        )
+    });
+    assert!(
+        duration_ms <= max_duration_ms,
+        "Expected tool '{}' duration <= {} ms, got {} ms",
+        tool_name,
+        max_duration_ms,
+        duration_ms
+    );
+}
+
+/// Assert that a tool call was marked as timed out.
+pub fn assert_run_tool_timed_out(result: &AgentRunResult, tool_name: &str) {
+    let call = find_tool_call(result, tool_name);
+    assert!(
+        call.timed_out,
+        "Expected tool '{}' to time out, but metadata was {:?}",
         tool_name,
         call
     );

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -186,6 +186,60 @@ pub fn assert_runner_state_after(result: &AgentRunResult, expected: RunnerState)
     );
 }
 
+/// Assert that total executions changed by the expected delta.
+pub fn assert_total_executions_delta(result: &AgentRunResult, expected_delta: u64) {
+    let before = result.metadata.runner_stats_before.total_executions;
+    let after = result.metadata.runner_stats_after.total_executions;
+    assert_eq!(
+        after.saturating_sub(before),
+        expected_delta,
+        "Expected total executions delta {}, got {} (before {}, after {})",
+        expected_delta,
+        after.saturating_sub(before),
+        before,
+        after
+    );
+}
+
+/// Assert that successful executions changed by the expected delta.
+pub fn assert_successful_executions_delta(result: &AgentRunResult, expected_delta: u64) {
+    let before = result.metadata.runner_stats_before.successful_executions;
+    let after = result.metadata.runner_stats_after.successful_executions;
+    assert_eq!(
+        after.saturating_sub(before),
+        expected_delta,
+        "Expected successful executions delta {}, got {} (before {}, after {})",
+        expected_delta,
+        after.saturating_sub(before),
+        before,
+        after
+    );
+}
+
+/// Assert that failed executions changed by the expected delta.
+pub fn assert_failed_executions_delta(result: &AgentRunResult, expected_delta: u64) {
+    let before = result.metadata.runner_stats_before.failed_executions;
+    let after = result.metadata.runner_stats_after.failed_executions;
+    assert_eq!(
+        after.saturating_sub(before),
+        expected_delta,
+        "Expected failed executions delta {}, got {} (before {}, after {})",
+        expected_delta,
+        after.saturating_sub(before),
+        before,
+        after
+    );
+}
+
+/// Assert that the runner recorded a last execution time.
+pub fn assert_last_execution_time_recorded(result: &AgentRunResult) {
+    assert!(
+        result.metadata.runner_stats_after.last_execution_time_ms.is_some(),
+        "Expected runner stats to record last execution time, got {:?}",
+        result.metadata.runner_stats_after
+    );
+}
+
 /// Assert that the agent state before execution matches the expected state.
 pub fn assert_agent_state_before(result: &AgentRunResult, expected: AgentState) {
     assert_eq!(

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -4,6 +4,8 @@
 
 use std::time::Duration;
 
+use mofa_kernel::agent::AgentState;
+use mofa_runtime::runner::RunnerState;
 use regex::Regex;
 use serde_json::Value;
 
@@ -141,6 +143,64 @@ pub fn assert_run_failure_contains(result: &AgentRunResult, expected: &str) {
         "Expected error containing '{}', got '{}'",
         expected,
         actual
+    );
+}
+
+/// Assert that the run metadata includes a non-empty execution id.
+pub fn assert_execution_id_present(result: &AgentRunResult) {
+    assert!(
+        !result.metadata.execution_id.trim().is_empty(),
+        "Expected non-empty execution id"
+    );
+}
+
+/// Assert that the captured session id matches the expected value.
+pub fn assert_session_id_equals(result: &AgentRunResult, expected: &str) {
+    let actual = result
+        .metadata
+        .session_id
+        .as_deref()
+        .unwrap_or_else(|| panic!("Expected session id '{}', but none was captured", expected));
+    assert_eq!(
+        actual, expected,
+        "Expected session id '{}', got '{}'",
+        expected, actual
+    );
+}
+
+/// Assert that the runner state before execution matches the expected state.
+pub fn assert_runner_state_before(result: &AgentRunResult, expected: RunnerState) {
+    assert_eq!(
+        result.metadata.runner_state_before, expected,
+        "Expected runner state before {:?}, got {:?}",
+        expected, result.metadata.runner_state_before
+    );
+}
+
+/// Assert that the runner state after execution matches the expected state.
+pub fn assert_runner_state_after(result: &AgentRunResult, expected: RunnerState) {
+    assert_eq!(
+        result.metadata.runner_state_after, expected,
+        "Expected runner state after {:?}, got {:?}",
+        expected, result.metadata.runner_state_after
+    );
+}
+
+/// Assert that the agent state before execution matches the expected state.
+pub fn assert_agent_state_before(result: &AgentRunResult, expected: AgentState) {
+    assert_eq!(
+        result.metadata.agent_state_before, expected,
+        "Expected agent state before {:?}, got {:?}",
+        expected, result.metadata.agent_state_before
+    );
+}
+
+/// Assert that the agent state after execution matches the expected state.
+pub fn assert_agent_state_after(result: &AgentRunResult, expected: AgentState) {
+    assert_eq!(
+        result.metadata.agent_state_after, expected,
+        "Expected agent state after {:?}, got {:?}",
+        expected, result.metadata.agent_state_after
     );
 }
 

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -84,3 +84,31 @@ macro_rules! assert_bus_message_sent {
         );
     }};
 }
+
+/// Assert a session's messages match the expected (role, content) pairs.
+pub fn assert_session_messages(
+    session: &mofa_foundation::agent::session::Session,
+    expected: &[(&str, &str)],
+) {
+    assert_eq!(
+        session.messages.len(),
+        expected.len(),
+        "Expected {} session messages, got {}",
+        expected.len(),
+        session.messages.len()
+    );
+
+    for (idx, (role, content)) in expected.iter().enumerate() {
+        let msg = &session.messages[idx];
+        assert_eq!(
+            msg.role, *role,
+            "Expected role '{}' at index {}, got '{}'",
+            role, idx, msg.role
+        );
+        assert_eq!(
+            msg.content, *content,
+            "Expected content '{}' at index {}, got '{}'",
+            content, idx, msg.content
+        );
+    }
+}

--- a/tests/src/assertions.rs
+++ b/tests/src/assertions.rs
@@ -261,6 +261,42 @@ pub fn assert_llm_request_contains(result: &AgentRunResult, expected: &str) {
     );
 }
 
+/// Assert that the last captured LLM request has the expected number of messages.
+pub fn assert_llm_request_message_count(result: &AgentRunResult, expected: usize) {
+    let request = result.metadata.llm_last_request.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected LLM request with {} messages, but none was captured",
+            expected
+        )
+    });
+    assert_eq!(
+        request.messages.len(),
+        expected,
+        "Expected LLM request to have {} messages, got {}",
+        expected,
+        request.messages.len()
+    );
+}
+
+/// Assert that the last captured LLM request includes a system message.
+pub fn assert_llm_request_has_system_message(result: &AgentRunResult) {
+    let request = result
+        .metadata
+        .llm_last_request
+        .as_ref()
+        .unwrap_or_else(|| panic!("Expected LLM request with system message, but none was captured"));
+    let has_system = request.messages.iter().any(|msg| msg.role == "system");
+    assert!(
+        has_system,
+        "Expected LLM request to include a system message, got roles {:?}",
+        request
+            .messages
+            .iter()
+            .map(|msg| msg.role.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Assert that the last captured LLM response contains the expected text.
 pub fn assert_llm_response_contains(result: &AgentRunResult, expected: &str) {
     let response = result.metadata.llm_last_response.as_ref().unwrap_or_else(|| {
@@ -275,6 +311,50 @@ pub fn assert_llm_response_contains(result: &AgentRunResult, expected: &str) {
         "Expected LLM response containing '{}', got '{}'",
         expected,
         content
+    );
+}
+
+/// Assert that the last captured LLM response content equals the expected text.
+pub fn assert_llm_response_equals(result: &AgentRunResult, expected: &str) {
+    let response = result.metadata.llm_last_response.as_ref().unwrap_or_else(|| {
+        panic!(
+            "Expected LLM response equal to '{}', but none was captured",
+            expected
+        )
+    });
+    let content = response.content.as_deref().unwrap_or("");
+    assert_eq!(
+        content, expected,
+        "Expected LLM response content '{}', got '{}'",
+        expected, content
+    );
+}
+
+/// Assert that the last captured LLM response includes at least one tool call.
+pub fn assert_llm_response_has_tool_calls(result: &AgentRunResult) {
+    let response = result
+        .metadata
+        .llm_last_response
+        .as_ref()
+        .unwrap_or_else(|| panic!("Expected LLM response with tool calls, but none was captured"));
+    let tool_calls = response.tool_calls.as_ref().map(|calls| calls.len()).unwrap_or(0);
+    assert!(
+        tool_calls > 0,
+        "Expected LLM response to include tool calls, got {:?}",
+        response.tool_calls
+    );
+}
+
+/// Assert that the last captured LLM response does not include any tool calls.
+pub fn assert_llm_response_has_no_tool_calls(result: &AgentRunResult) {
+    let response = result.metadata.llm_last_response.as_ref().unwrap_or_else(|| {
+        panic!("Expected LLM response without tool calls, but none was captured")
+    });
+    let tool_calls = response.tool_calls.as_ref().map(|calls| calls.len()).unwrap_or(0);
+    assert_eq!(
+        tool_calls, 0,
+        "Expected LLM response to have no tool calls, got {:?}",
+        response.tool_calls
     );
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,7 +17,7 @@ pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use agent_runner::{
     AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
-    ToolCallRecord,
+    ToolCallRecord, WorkspaceFileSnapshot, WorkspaceSnapshot,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,6 +17,7 @@ pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use agent_runner::{
     AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
+    ToolCallRecord,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,6 +4,7 @@
 //! control for testing MoFA agents.
 
 pub mod adversarial;
+pub mod agent_runner;
 pub mod assertions;
 pub mod backend;
 pub mod bus;
@@ -14,6 +15,9 @@ pub mod tools;
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use agent_runner::{
+    AgentRunMetadata, AgentRunResult, AgentRunnerError, AgentTestRunner, MockAgentLLMProvider,
+};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -20,6 +20,7 @@ pub struct MockTool {
     category: ToolCategory,
     pub stubbed_result: Arc<RwLock<ToolResult>>,
     pub call_history: Arc<RwLock<Vec<ToolInput>>>,
+    pub result_history: Arc<RwLock<Vec<ToolResult>>>,
     failure_queue: Arc<RwLock<VecDeque<String>>>,
     failure_patterns: Arc<RwLock<Vec<(Value, String)>>>,
     result_sequence: Arc<RwLock<VecDeque<ToolResult>>>,
@@ -37,6 +38,7 @@ impl MockTool {
                 "Mock execution default",
             ))),
             call_history: Arc::new(RwLock::new(Vec::new())),
+            result_history: Arc::new(RwLock::new(Vec::new())),
             failure_queue: Arc::new(RwLock::new(VecDeque::new())),
             failure_patterns: Arc::new(RwLock::new(Vec::new())),
             result_sequence: Arc::new(RwLock::new(VecDeque::new())),
@@ -56,6 +58,16 @@ impl MockTool {
     /// Number of times this tool has been executed.
     pub async fn call_count(&self) -> usize {
         self.call_history.read().await.len()
+    }
+
+    /// Retrieve a clone of the full result history.
+    pub async fn results(&self) -> Vec<ToolResult> {
+        self.result_history.read().await.clone()
+    }
+
+    /// Returns the most recent result, or `None` if never executed.
+    pub async fn last_result(&self) -> Option<ToolResult> {
+        self.result_history.read().await.last().cloned()
     }
 
     /// Queue failures for the next N calls.
@@ -115,7 +127,9 @@ impl SimpleTool for MockTool {
         {
             let mut queue = self.failure_queue.write().await;
             if let Some(err) = queue.pop_front() {
-                return ToolResult::failure(err);
+                let result = ToolResult::failure(err);
+                self.result_history.write().await.push(result.clone());
+                return result;
             }
         }
 
@@ -124,7 +138,9 @@ impl SimpleTool for MockTool {
             let patterns = self.failure_patterns.read().await;
             for (pattern, err) in patterns.iter() {
                 if input.arguments == *pattern {
-                    return ToolResult::failure(err);
+                    let result = ToolResult::failure(err);
+                    self.result_history.write().await.push(result.clone());
+                    return result;
                 }
             }
         }
@@ -133,11 +149,14 @@ impl SimpleTool for MockTool {
         {
             let mut seq = self.result_sequence.write().await;
             if let Some(result) = seq.pop_front() {
+                self.result_history.write().await.push(result.clone());
                 return result;
             }
         }
 
-        self.stubbed_result.read().await.clone()
+        let result = self.stubbed_result.read().await.clone();
+        self.result_history.write().await.push(result.clone());
+        result
     }
 
     fn category(&self) -> ToolCategory {

--- a/tests/src/tools.rs
+++ b/tests/src/tools.rs
@@ -122,12 +122,16 @@ impl SimpleTool for MockTool {
 
     async fn execute(&self, input: ToolInput) -> ToolResult {
         self.call_history.write().await.push(input.clone());
+        let start = std::time::Instant::now();
 
         // 1. Drain failure queue
         {
             let mut queue = self.failure_queue.write().await;
             if let Some(err) = queue.pop_front() {
-                let result = ToolResult::failure(err);
+                let mut result = ToolResult::failure(err);
+                result
+                    .metadata
+                    .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                 self.result_history.write().await.push(result.clone());
                 return result;
             }
@@ -138,7 +142,10 @@ impl SimpleTool for MockTool {
             let patterns = self.failure_patterns.read().await;
             for (pattern, err) in patterns.iter() {
                 if input.arguments == *pattern {
-                    let result = ToolResult::failure(err);
+                    let mut result = ToolResult::failure(err);
+                    result
+                        .metadata
+                        .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                     self.result_history.write().await.push(result.clone());
                     return result;
                 }
@@ -149,12 +156,19 @@ impl SimpleTool for MockTool {
         {
             let mut seq = self.result_sequence.write().await;
             if let Some(result) = seq.pop_front() {
+                let mut result = result;
+                result
+                    .metadata
+                    .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
                 self.result_history.write().await.push(result.clone());
                 return result;
             }
         }
 
-        let result = self.stubbed_result.read().await.clone();
+        let mut result = self.stubbed_result.read().await.clone();
+        result
+            .metadata
+            .insert("duration_ms".to_string(), start.elapsed().as_millis().to_string());
         self.result_history.write().await.push(result.clone());
         result
     }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,0 +1,66 @@
+use mofa_testing::agent_runner::AgentTestRunner;
+
+#[tokio::test]
+async fn agent_runner_executes_and_captures_output() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_response("Mocked response")
+        .await;
+
+    let result = runner
+        .run_text("hello")
+        .await
+        .expect("run should succeed");
+
+    assert!(result.is_success());
+    assert_eq!(result.output_text().as_deref(), Some("Mocked response"));
+    assert_eq!(
+        result.metadata.session_id.as_deref(),
+        Some(runner.session_id())
+    );
+    assert_eq!(result.metadata.execution_id, runner.execution_id());
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_creates_isolated_workspaces() {
+    let mut runner_a = AgentTestRunner::new().await.expect("runner A initializes");
+    let mut runner_b = AgentTestRunner::new().await.expect("runner B initializes");
+
+    assert_ne!(runner_a.workspace(), runner_b.workspace());
+
+    runner_a
+        .mock_llm()
+        .add_response("Response A")
+        .await;
+    runner_b
+        .mock_llm()
+        .add_response("Response B")
+        .await;
+
+    let _ = runner_a
+        .run_text("hi")
+        .await
+        .expect("runner A executes");
+    let _ = runner_b
+        .run_text("hi")
+        .await
+        .expect("runner B executes");
+
+    let session_a = runner_a
+        .workspace()
+        .join("sessions")
+        .join(format!("{}.jsonl", runner_a.session_id()));
+    let session_b = runner_b
+        .workspace()
+        .join("sessions")
+        .join(format!("{}.jsonl", runner_b.session_id()));
+
+    assert!(session_a.exists());
+    assert!(session_b.exists());
+
+    runner_a.shutdown().await.expect("shutdown A");
+    runner_b.shutdown().await.expect("shutdown B");
+}

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,4 +1,5 @@
 use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::assertions::assert_session_messages;
 use mofa_testing::tools::MockTool;
 use serde_json::json;
 
@@ -27,6 +28,25 @@ async fn agent_runner_executes_and_captures_output() {
     assert!(result.metadata.session_snapshot.is_some());
     let snapshot = result.metadata.session_snapshot.as_ref().unwrap();
     assert_eq!(snapshot.len(), 2);
+    assert_session_messages(snapshot, &[("user", "hello"), ("assistant", "Mocked response")]);
+
+    let expected_session_path = format!("sessions/{}.jsonl", runner.session_id());
+    assert!(
+        !result
+            .metadata
+            .workspace_snapshot_before
+            .files
+            .iter()
+            .any(|file| file.relative_path == expected_session_path)
+    );
+    assert!(
+        result
+            .metadata
+            .workspace_snapshot_after
+            .files
+            .iter()
+            .any(|file| file.relative_path == expected_session_path)
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -56,6 +76,7 @@ async fn agent_runner_creates_isolated_workspaces() {
         .await
         .expect("runner B executes");
 
+    // Session files should exist in each separate workspace.
     let session_a = runner_a
         .workspace()
         .join("sessions")
@@ -93,6 +114,7 @@ async fn agent_runner_executes_tool_calls() {
         .await
         .expect("tool registered");
 
+    // First response triggers a tool call; second response is the final answer.
     runner
         .mock_llm()
         .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
@@ -107,6 +129,7 @@ async fn agent_runner_executes_tool_calls() {
         .await
         .expect("run should succeed");
 
+    // Tool call should be captured in both tool history and run metadata.
     assert_eq!(result.output_text().as_deref(), Some("Final response"));
     assert_eq!(tool.call_count().await, 1);
     let last_call = tool.last_call().await.expect("tool call captured");
@@ -120,6 +143,7 @@ async fn agent_runner_executes_tool_calls() {
         record.output,
         Some(json!("Mock execution default"))
     );
+    assert!(record.duration_ms.is_some());
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -146,6 +170,7 @@ async fn agent_runner_loads_bootstrap_files() {
         .last_request()
         .await
         .expect("request captured");
+    // Validate the system message includes the bootstrap content.
     let system_message = request
         .messages
         .first()
@@ -160,6 +185,7 @@ async fn agent_runner_loads_bootstrap_files() {
 
 #[tokio::test]
 async fn agent_runner_supports_multi_turn_runs() {
+    // Multi-turn helper should keep the same session and extend history.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner.mock_llm().add_response("First reply").await;
     runner.mock_llm().add_response("Second reply").await;
@@ -173,17 +199,28 @@ async fn agent_runner_supports_multi_turn_runs() {
     assert_eq!(results[0].output_text().as_deref(), Some("First reply"));
     assert_eq!(results[1].output_text().as_deref(), Some("Second reply"));
 
+    // Session snapshot should contain two user/assistant pairs.
     let snapshot = results
         .last()
         .and_then(|result| result.metadata.session_snapshot.as_ref())
         .expect("session snapshot captured");
     assert_eq!(snapshot.len(), 4);
+    assert_session_messages(
+        snapshot,
+        &[
+            ("user", "turn one"),
+            ("assistant", "First reply"),
+            ("user", "turn two"),
+            ("assistant", "Second reply"),
+        ],
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
 
 #[tokio::test]
 async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
+    // Custom identity + bootstrap list should appear in the system prompt.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner
         .write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")
@@ -210,6 +247,7 @@ async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
         .last_request()
         .await
         .expect("request captured");
+    // Validate custom identity and bootstrap content.
     let system_message = request
         .messages
         .first()
@@ -226,6 +264,7 @@ async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
 
 #[tokio::test]
 async fn agent_runner_captures_llm_failure() {
+    // LLM failures should surface in AgentRunResult with failed stats.
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
     runner
         .mock_llm()

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -1,4 +1,6 @@
 use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::tools::MockTool;
+use serde_json::json;
 
 #[tokio::test]
 async fn agent_runner_executes_and_captures_output() {
@@ -20,6 +22,11 @@ async fn agent_runner_executes_and_captures_output() {
         Some(runner.session_id())
     );
     assert_eq!(result.metadata.execution_id, runner.execution_id());
+    assert_eq!(result.metadata.runner_stats_before.total_executions, 0);
+    assert_eq!(result.metadata.runner_stats_after.total_executions, 1);
+    assert!(result.metadata.session_snapshot.is_some());
+    let snapshot = result.metadata.session_snapshot.as_ref().unwrap();
+    assert_eq!(snapshot.len(), 2);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -63,4 +70,102 @@ async fn agent_runner_creates_isolated_workspaces() {
 
     runner_a.shutdown().await.expect("shutdown A");
     runner_b.shutdown().await.expect("shutdown B");
+}
+
+#[tokio::test]
+async fn agent_runner_executes_tool_calls() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo the provided input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+
+    runner
+        .register_simple_tool(tool.clone())
+        .await
+        .expect("tool registered");
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner
+        .mock_llm()
+        .add_response("Final response")
+        .await;
+
+    let result = runner
+        .run_text("use tool")
+        .await
+        .expect("run should succeed");
+
+    assert_eq!(result.output_text().as_deref(), Some("Final response"));
+    assert_eq!(tool.call_count().await, 1);
+    let last_call = tool.last_call().await.expect("tool call captured");
+    assert_eq!(last_call.arguments, json!({ "input": "ping" }));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_loads_bootstrap_files() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .write_bootstrap_file("AGENTS.md", "Bootstrap content for agent test.")
+        .expect("bootstrap file written");
+
+    runner
+        .mock_llm()
+        .add_response("Bootstrapped response")
+        .await;
+
+    let _ = runner
+        .run_text("check prompt")
+        .await
+        .expect("run should succeed");
+
+    let request = runner
+        .mock_llm()
+        .last_request()
+        .await
+        .expect("request captured");
+    let system_message = request
+        .messages
+        .first()
+        .and_then(|msg| msg.content.as_deref())
+        .expect("system message content");
+
+    assert!(system_message.contains("AGENTS.md"));
+    assert!(system_message.contains("Bootstrap content for agent test."));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_captures_llm_failure() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_error_response("mock failure")
+        .await;
+
+    let result = runner
+        .run_text("trigger failure")
+        .await
+        .expect("run should return result");
+
+    assert!(!result.is_success());
+    let error = result.error.expect("error captured");
+    assert!(error.to_string().contains("mock failure"));
+    assert_eq!(result.metadata.runner_stats_after.failed_executions, 1);
+
+    runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -89,7 +89,7 @@ async fn agent_runner_executes_tool_calls() {
     );
 
     runner
-        .register_simple_tool(tool.clone())
+        .register_mock_tool(tool.clone())
         .await
         .expect("tool registered");
 
@@ -111,6 +111,15 @@ async fn agent_runner_executes_tool_calls() {
     assert_eq!(tool.call_count().await, 1);
     let last_call = tool.last_call().await.expect("tool call captured");
     assert_eq!(last_call.arguments, json!({ "input": "ping" }));
+    assert_eq!(result.metadata.tool_calls.len(), 1);
+    let record = &result.metadata.tool_calls[0];
+    assert_eq!(record.tool_name, "echo_tool");
+    assert_eq!(record.input, json!({ "input": "ping" }));
+    assert!(record.success);
+    assert_eq!(
+        record.output,
+        Some(json!("Mock execution default"))
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -145,6 +154,72 @@ async fn agent_runner_loads_bootstrap_files() {
 
     assert!(system_message.contains("AGENTS.md"));
     assert!(system_message.contains("Bootstrap content for agent test."));
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_supports_multi_turn_runs() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("First reply").await;
+    runner.mock_llm().add_response("Second reply").await;
+
+    let results = runner
+        .run_texts(&["turn one", "turn two"])
+        .await
+        .expect("multi-turn run succeeds");
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].output_text().as_deref(), Some("First reply"));
+    assert_eq!(results[1].output_text().as_deref(), Some("Second reply"));
+
+    let snapshot = results
+        .last()
+        .and_then(|result| result.metadata.session_snapshot.as_ref())
+        .expect("session snapshot captured");
+    assert_eq!(snapshot.len(), 4);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn agent_runner_customizes_prompt_identity_and_bootstraps() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .write_bootstrap_file("CUSTOM.md", "Custom bootstrap content.")
+        .expect("bootstrap file written");
+    runner
+        .configure_prompt(
+            Some(mofa_foundation::agent::context::prompt::AgentIdentity {
+                name: "TestAgent".to_string(),
+                description: "Custom identity".to_string(),
+                icon: None,
+            }),
+            Some(vec!["CUSTOM.md".to_string()]),
+        )
+        .await;
+
+    runner.mock_llm().add_response("Custom response").await;
+    let _ = runner
+        .run_text("custom prompt")
+        .await
+        .expect("run should succeed");
+
+    let request = runner
+        .mock_llm()
+        .last_request()
+        .await
+        .expect("request captured");
+    let system_message = request
+        .messages
+        .first()
+        .and_then(|msg| msg.content.as_deref())
+        .expect("system message content");
+
+    assert!(system_message.contains("TestAgent"));
+    assert!(system_message.contains("Custom identity"));
+    assert!(system_message.contains("CUSTOM.md"));
+    assert!(system_message.contains("Custom bootstrap content."));
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/agent_runner_tests.rs
+++ b/tests/tests/agent_runner_tests.rs
@@ -283,3 +283,29 @@ async fn agent_runner_captures_llm_failure() {
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
+
+#[tokio::test]
+async fn agent_runner_allows_custom_session_keys() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .mock_llm()
+        .add_response("Custom session response")
+        .await;
+
+    let result = runner
+        .run_text_with_session("custom-session", "hello session")
+        .await
+        .expect("run should succeed");
+
+    assert_eq!(
+        result.metadata.session_id.as_deref(),
+        Some("custom-session")
+    );
+    let session_path = runner
+        .workspace()
+        .join("sessions")
+        .join("custom-session.jsonl");
+    assert!(session_path.exists());
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -1,12 +1,16 @@
 use std::time::Duration;
 
+use mofa_kernel::agent::AgentState;
+use mofa_runtime::runner::RunnerState;
 use mofa_testing::agent_runner::AgentTestRunner;
 use mofa_testing::assertions::{
-    assert_duration_under, assert_llm_request_contains, assert_llm_response_contains,
+    assert_agent_state_after, assert_agent_state_before, assert_duration_under,
+    assert_execution_id_present, assert_llm_request_contains, assert_llm_response_contains,
     assert_output_contains, assert_output_matches_regex, assert_run_failure_contains,
     assert_run_success, assert_run_tool_call_count, assert_run_tool_called,
     assert_run_tool_duration_recorded, assert_run_tool_input, assert_run_tool_not_called,
-    assert_run_tool_output_contains, assert_run_tool_succeeded, assert_session_contains,
+    assert_run_tool_output_contains, assert_run_tool_succeeded, assert_runner_state_after,
+    assert_runner_state_before, assert_session_contains, assert_session_id_equals,
     assert_session_len, assert_workspace_file_changed, assert_workspace_has_file,
     assert_workspace_missing_file,
 };
@@ -21,6 +25,12 @@ async fn artifact_assertions_cover_success_output_and_llm_capture() {
     let result = runner.run_text("hello").await.expect("run succeeds");
 
     assert_run_success(&result);
+    assert_execution_id_present(&result);
+    assert_session_id_equals(&result, runner.session_id());
+    assert_runner_state_before(&result, RunnerState::Created);
+    assert_runner_state_after(&result, RunnerState::Running);
+    assert_agent_state_before(&result, AgentState::Ready);
+    assert_agent_state_after(&result, AgentState::Ready);
     assert_output_contains(&result, "assertions");
     assert_output_matches_regex(&result, "Hello .* assertions");
     assert_duration_under(&result, Duration::from_secs(2));
@@ -94,6 +104,12 @@ async fn artifact_assertions_cover_failures() {
     let result = runner.run_text("trigger failure").await.expect("run returns result");
 
     assert_run_failure_contains(&result, "boom failure");
+    assert_execution_id_present(&result);
+    assert_session_id_equals(&result, runner.session_id());
+    assert_runner_state_before(&result, RunnerState::Created);
+    assert_runner_state_after(&result, RunnerState::Running);
+    assert_agent_state_before(&result, AgentState::Ready);
+    assert_agent_state_after(&result, AgentState::Ready);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -11,16 +11,18 @@ use mofa_testing::assertions::{
     assert_llm_response_contains, assert_llm_response_equals,
     assert_llm_response_has_no_tool_calls,
     assert_output_contains, assert_output_matches_regex, assert_run_failure_contains,
-    assert_run_success, assert_run_tool_call_count, assert_run_tool_called,
-    assert_run_tool_duration_recorded, assert_run_tool_duration_under,
-    assert_run_tool_failed, assert_run_tool_input, assert_run_tool_not_called,
-    assert_run_tool_output_contains, assert_run_tool_output_equals_json,
-    assert_run_tool_succeeded, assert_run_tool_timed_out, assert_runner_state_after,
-    assert_runner_state_before, assert_session_contains, assert_session_contains_in_order,
-    assert_session_id_equals, assert_session_len, assert_session_len_at_least,
-    assert_workspace_file_changed, assert_workspace_file_checksum_changed,
-    assert_workspace_file_count_delta, assert_workspace_file_exists_after,
-    assert_workspace_file_exists_before, assert_workspace_has_file, assert_workspace_missing_file,
+    assert_failed_executions_delta, assert_last_execution_time_recorded, assert_run_success,
+    assert_run_tool_call_count, assert_run_tool_called, assert_run_tool_duration_recorded,
+    assert_run_tool_duration_under, assert_run_tool_failed, assert_run_tool_input,
+    assert_run_tool_not_called, assert_run_tool_output_contains,
+    assert_run_tool_output_equals_json, assert_run_tool_succeeded,
+    assert_run_tool_timed_out, assert_runner_state_after, assert_runner_state_before,
+    assert_session_contains, assert_session_contains_in_order, assert_session_id_equals,
+    assert_session_len, assert_session_len_at_least, assert_successful_executions_delta,
+    assert_total_executions_delta, assert_workspace_file_changed,
+    assert_workspace_file_checksum_changed, assert_workspace_file_count_delta,
+    assert_workspace_file_exists_after, assert_workspace_file_exists_before,
+    assert_workspace_has_file, assert_workspace_missing_file,
 };
 use mofa_testing::tools::MockTool;
 use serde_json::json;
@@ -39,6 +41,10 @@ async fn artifact_assertions_cover_success_output_and_llm_capture() {
     assert_runner_state_after(&result, RunnerState::Running);
     assert_agent_state_before(&result, AgentState::Ready);
     assert_agent_state_after(&result, AgentState::Ready);
+    assert_total_executions_delta(&result, 1);
+    assert_successful_executions_delta(&result, 1);
+    assert_failed_executions_delta(&result, 0);
+    assert_last_execution_time_recorded(&result);
     assert_output_contains(&result, "assertions");
     assert_output_matches_regex(&result, "Hello .* assertions");
     assert_duration_under(&result, Duration::from_secs(2));
@@ -193,6 +199,10 @@ async fn artifact_assertions_cover_failures() {
     assert_runner_state_after(&result, RunnerState::Running);
     assert_agent_state_before(&result, AgentState::Ready);
     assert_agent_state_after(&result, AgentState::Ready);
+    assert_total_executions_delta(&result, 1);
+    assert_successful_executions_delta(&result, 0);
+    assert_failed_executions_delta(&result, 1);
+    assert_last_execution_time_recorded(&result);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -14,6 +14,8 @@ use mofa_testing::assertions::{
     assert_run_tool_output_equals_json, assert_run_tool_succeeded, assert_run_tool_timed_out,
     assert_runner_state_after, assert_runner_state_before, assert_session_contains,
     assert_session_id_equals, assert_session_len, assert_workspace_file_changed,
+    assert_workspace_file_checksum_changed, assert_workspace_file_count_delta,
+    assert_workspace_file_exists_after, assert_workspace_file_exists_before,
     assert_workspace_has_file, assert_workspace_missing_file,
 };
 use mofa_testing::tools::MockTool;
@@ -86,6 +88,9 @@ async fn artifact_assertions_cover_tool_records() {
 #[tokio::test]
 async fn artifact_assertions_cover_workspace_snapshots() {
     let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner
+        .write_workspace_file("notes.txt", "before")
+        .expect("workspace file written");
     runner.mock_llm().add_response("workspace ok").await;
 
     let result = runner.run_text("write session").await.expect("run succeeds");
@@ -93,7 +98,28 @@ async fn artifact_assertions_cover_workspace_snapshots() {
 
     assert_workspace_missing_file(&result.metadata.workspace_snapshot_before, &session_file);
     assert_workspace_has_file(&result.metadata.workspace_snapshot_after, &session_file);
+    assert_workspace_file_exists_before(&result, "notes.txt");
+    assert_workspace_file_exists_after(&result, "notes.txt");
+    assert_workspace_file_count_delta(&result, 1);
     assert_workspace_file_changed(&result, &session_file);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_workspace_checksum_changes() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    let session_file = format!("sessions/{}.jsonl", runner.session_id());
+    runner
+        .write_workspace_file(&session_file, "seed\n")
+        .expect("workspace file written");
+    runner.mock_llm().add_response("checksum ok").await;
+
+    let result = runner.run_text("checksum run").await.expect("run succeeds");
+
+    assert_workspace_file_exists_before(&result, &session_file);
+    assert_workspace_file_exists_after(&result, &session_file);
+    assert_workspace_file_checksum_changed(&result, &session_file);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -1,0 +1,99 @@
+use std::time::Duration;
+
+use mofa_testing::agent_runner::AgentTestRunner;
+use mofa_testing::assertions::{
+    assert_duration_under, assert_llm_request_contains, assert_llm_response_contains,
+    assert_output_contains, assert_output_matches_regex, assert_run_failure_contains,
+    assert_run_success, assert_run_tool_call_count, assert_run_tool_called,
+    assert_run_tool_duration_recorded, assert_run_tool_input, assert_run_tool_not_called,
+    assert_run_tool_output_contains, assert_run_tool_succeeded, assert_session_contains,
+    assert_session_len, assert_workspace_file_changed, assert_workspace_has_file,
+    assert_workspace_missing_file,
+};
+use mofa_testing::tools::MockTool;
+use serde_json::json;
+
+#[tokio::test]
+async fn artifact_assertions_cover_success_output_and_llm_capture() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("Hello from assertions").await;
+
+    let result = runner.run_text("hello").await.expect("run succeeds");
+
+    assert_run_success(&result);
+    assert_output_contains(&result, "assertions");
+    assert_output_matches_regex(&result, "Hello .* assertions");
+    assert_duration_under(&result, Duration::from_secs(2));
+    assert_llm_request_contains(&result, "hello");
+    assert_llm_response_contains(&result, "Hello from assertions");
+    assert_session_len(&result, 2);
+    assert_session_contains(&result, "user", "hello");
+    assert_session_contains(&result, "assistant", "Hello from assertions");
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_tool_records() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    let tool = MockTool::new(
+        "echo_tool",
+        "Echo input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+    runner
+        .register_mock_tool(tool)
+        .await
+        .expect("tool registered");
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("echo_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner.mock_llm().add_response("tool complete").await;
+
+    let result = runner.run_text("use a tool").await.expect("run succeeds");
+
+    assert_run_tool_called(&result, "echo_tool");
+    assert_run_tool_not_called(&result, "missing_tool");
+    assert_run_tool_call_count(&result, "echo_tool", 1);
+    assert_run_tool_input(&result, "echo_tool", &json!({ "input": "ping" }));
+    assert_run_tool_succeeded(&result, "echo_tool");
+    assert_run_tool_output_contains(&result, "echo_tool", "Mock execution default");
+    assert_run_tool_duration_recorded(&result, "echo_tool");
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_workspace_snapshots() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("workspace ok").await;
+
+    let result = runner.run_text("write session").await.expect("run succeeds");
+    let session_file = format!("sessions/{}.jsonl", runner.session_id());
+
+    assert_workspace_missing_file(&result.metadata.workspace_snapshot_before, &session_file);
+    assert_workspace_has_file(&result.metadata.workspace_snapshot_after, &session_file);
+    assert_workspace_file_changed(&result, &session_file);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_failures() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_error_response("boom failure").await;
+
+    let result = runner.run_text("trigger failure").await.expect("run returns result");
+
+    assert_run_failure_contains(&result, "boom failure");
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use mofa_kernel::agent::AgentState;
+use mofa_kernel::agent::components::tool::ToolResult;
 use mofa_runtime::runner::RunnerState;
 use mofa_testing::agent_runner::AgentTestRunner;
 use mofa_testing::assertions::{
@@ -8,11 +9,12 @@ use mofa_testing::assertions::{
     assert_execution_id_present, assert_llm_request_contains, assert_llm_response_contains,
     assert_output_contains, assert_output_matches_regex, assert_run_failure_contains,
     assert_run_success, assert_run_tool_call_count, assert_run_tool_called,
-    assert_run_tool_duration_recorded, assert_run_tool_input, assert_run_tool_not_called,
-    assert_run_tool_output_contains, assert_run_tool_succeeded, assert_runner_state_after,
-    assert_runner_state_before, assert_session_contains, assert_session_id_equals,
-    assert_session_len, assert_workspace_file_changed, assert_workspace_has_file,
-    assert_workspace_missing_file,
+    assert_run_tool_duration_recorded, assert_run_tool_duration_under, assert_run_tool_failed,
+    assert_run_tool_input, assert_run_tool_not_called, assert_run_tool_output_contains,
+    assert_run_tool_output_equals_json, assert_run_tool_succeeded, assert_run_tool_timed_out,
+    assert_runner_state_after, assert_runner_state_before, assert_session_contains,
+    assert_session_id_equals, assert_session_len, assert_workspace_file_changed,
+    assert_workspace_has_file, assert_workspace_missing_file,
 };
 use mofa_testing::tools::MockTool;
 use serde_json::json;
@@ -92,6 +94,47 @@ async fn artifact_assertions_cover_workspace_snapshots() {
     assert_workspace_missing_file(&result.metadata.workspace_snapshot_before, &session_file);
     assert_workspace_has_file(&result.metadata.workspace_snapshot_after, &session_file);
     assert_workspace_file_changed(&result, &session_file);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_failed_and_timed_out_tools() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    let tool = MockTool::new(
+        "fragile_tool",
+        "Fails on purpose",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+    tool.set_result(ToolResult::failure("tool timed out")).await;
+    runner
+        .register_mock_tool(tool)
+        .await
+        .expect("tool registered");
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("fragile_tool", json!({ "input": "ping" }), None)
+        .await;
+    runner.mock_llm().add_response("tool failed handled").await;
+
+    let result = runner
+        .run_text("use fragile tool")
+        .await
+        .expect("run succeeds");
+
+    assert_run_tool_called(&result, "fragile_tool");
+    assert_run_tool_failed(&result, "fragile_tool");
+    assert_run_tool_timed_out(&result, "fragile_tool");
+    assert_run_tool_output_equals_json(&result, "fragile_tool", &json!(null));
+    assert_run_tool_duration_recorded(&result, "fragile_tool");
+    assert_run_tool_duration_under(&result, "fragile_tool", 1_000);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -6,17 +6,20 @@ use mofa_runtime::runner::RunnerState;
 use mofa_testing::agent_runner::AgentTestRunner;
 use mofa_testing::assertions::{
     assert_agent_state_after, assert_agent_state_before, assert_duration_under,
-    assert_execution_id_present, assert_llm_request_contains, assert_llm_response_contains,
+    assert_execution_id_present, assert_llm_request_contains,
+    assert_llm_request_has_system_message, assert_llm_request_message_count,
+    assert_llm_response_contains, assert_llm_response_equals,
+    assert_llm_response_has_no_tool_calls,
     assert_output_contains, assert_output_matches_regex, assert_run_failure_contains,
     assert_run_success, assert_run_tool_call_count, assert_run_tool_called,
-    assert_run_tool_duration_recorded, assert_run_tool_duration_under, assert_run_tool_failed,
-    assert_run_tool_input, assert_run_tool_not_called, assert_run_tool_output_contains,
-    assert_run_tool_output_equals_json, assert_run_tool_succeeded, assert_run_tool_timed_out,
-    assert_runner_state_after, assert_runner_state_before, assert_session_contains,
-    assert_session_id_equals, assert_session_len, assert_workspace_file_changed,
-    assert_workspace_file_checksum_changed, assert_workspace_file_count_delta,
-    assert_workspace_file_exists_after, assert_workspace_file_exists_before,
-    assert_workspace_has_file, assert_workspace_missing_file,
+    assert_run_tool_duration_recorded, assert_run_tool_duration_under,
+    assert_run_tool_failed, assert_run_tool_input, assert_run_tool_not_called,
+    assert_run_tool_output_contains, assert_run_tool_output_equals_json,
+    assert_run_tool_succeeded, assert_run_tool_timed_out, assert_runner_state_after,
+    assert_runner_state_before, assert_session_contains, assert_session_id_equals,
+    assert_session_len, assert_workspace_file_changed, assert_workspace_file_checksum_changed,
+    assert_workspace_file_count_delta, assert_workspace_file_exists_after,
+    assert_workspace_file_exists_before, assert_workspace_has_file, assert_workspace_missing_file,
 };
 use mofa_testing::tools::MockTool;
 use serde_json::json;
@@ -39,7 +42,11 @@ async fn artifact_assertions_cover_success_output_and_llm_capture() {
     assert_output_matches_regex(&result, "Hello .* assertions");
     assert_duration_under(&result, Duration::from_secs(2));
     assert_llm_request_contains(&result, "hello");
+    assert_llm_request_message_count(&result, 2);
+    assert_llm_request_has_system_message(&result);
     assert_llm_response_contains(&result, "Hello from assertions");
+    assert_llm_response_equals(&result, "Hello from assertions");
+    assert_llm_response_has_no_tool_calls(&result);
     assert_session_len(&result, 2);
     assert_session_contains(&result, "user", "hello");
     assert_session_contains(&result, "assistant", "Hello from assertions");
@@ -81,6 +88,7 @@ async fn artifact_assertions_cover_tool_records() {
     assert_run_tool_succeeded(&result, "echo_tool");
     assert_run_tool_output_contains(&result, "echo_tool", "Mock execution default");
     assert_run_tool_duration_recorded(&result, "echo_tool");
+    assert_llm_response_has_no_tool_calls(&result);
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -179,6 +187,42 @@ async fn artifact_assertions_cover_failures() {
     assert_runner_state_after(&result, RunnerState::Running);
     assert_agent_state_before(&result, AgentState::Ready);
     assert_agent_state_after(&result, AgentState::Ready);
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_llm_tool_call_capture() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    let tool = MockTool::new(
+        "observe_tool",
+        "Observes input",
+        json!({
+            "type": "object",
+            "properties": {
+                "input": { "type": "string" }
+            },
+            "required": ["input"]
+        }),
+    );
+    runner
+        .register_mock_tool(tool)
+        .await
+        .expect("tool registered");
+
+    runner
+        .mock_llm()
+        .add_tool_call_response("observe_tool", json!({ "input": "inspect" }), Some("calling tool".into()))
+        .await;
+    runner.mock_llm().add_response("done").await;
+
+    let result = runner.run_text("inspect this").await.expect("run succeeds");
+
+    assert_llm_request_message_count(&result, 4);
+    assert_llm_request_has_system_message(&result);
+    assert_llm_response_equals(&result, "done");
+    assert_llm_response_has_no_tool_calls(&result);
+    assert_run_tool_called(&result, "observe_tool");
 
     runner.shutdown().await.expect("shutdown succeeds");
 }

--- a/tests/tests/artifact_assertions_tests.rs
+++ b/tests/tests/artifact_assertions_tests.rs
@@ -16,8 +16,9 @@ use mofa_testing::assertions::{
     assert_run_tool_failed, assert_run_tool_input, assert_run_tool_not_called,
     assert_run_tool_output_contains, assert_run_tool_output_equals_json,
     assert_run_tool_succeeded, assert_run_tool_timed_out, assert_runner_state_after,
-    assert_runner_state_before, assert_session_contains, assert_session_id_equals,
-    assert_session_len, assert_workspace_file_changed, assert_workspace_file_checksum_changed,
+    assert_runner_state_before, assert_session_contains, assert_session_contains_in_order,
+    assert_session_id_equals, assert_session_len, assert_session_len_at_least,
+    assert_workspace_file_changed, assert_workspace_file_checksum_changed,
     assert_workspace_file_count_delta, assert_workspace_file_exists_after,
     assert_workspace_file_exists_before, assert_workspace_has_file, assert_workspace_missing_file,
 };
@@ -48,8 +49,13 @@ async fn artifact_assertions_cover_success_output_and_llm_capture() {
     assert_llm_response_equals(&result, "Hello from assertions");
     assert_llm_response_has_no_tool_calls(&result);
     assert_session_len(&result, 2);
+    assert_session_len_at_least(&result, 2);
     assert_session_contains(&result, "user", "hello");
     assert_session_contains(&result, "assistant", "Hello from assertions");
+    assert_session_contains_in_order(
+        &result,
+        &[("user", "hello"), ("assistant", "Hello from assertions")],
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }
@@ -223,6 +229,32 @@ async fn artifact_assertions_cover_llm_tool_call_capture() {
     assert_llm_response_equals(&result, "done");
     assert_llm_response_has_no_tool_calls(&result);
     assert_run_tool_called(&result, "observe_tool");
+
+    runner.shutdown().await.expect("shutdown succeeds");
+}
+
+#[tokio::test]
+async fn artifact_assertions_cover_session_ordering() {
+    let mut runner = AgentTestRunner::new().await.expect("runner initializes");
+    runner.mock_llm().add_response("First reply").await;
+    runner.mock_llm().add_response("Second reply").await;
+
+    let results = runner
+        .run_texts(&["turn one", "turn two"])
+        .await
+        .expect("multi-turn run succeeds");
+    let result = results.last().expect("last result present");
+
+    assert_session_len_at_least(result, 4);
+    assert_session_contains_in_order(
+        result,
+        &[
+            ("user", "turn one"),
+            ("assistant", "First reply"),
+            ("user", "turn two"),
+            ("assistant", "Second reply"),
+        ],
+    );
 
     runner.shutdown().await.expect("shutdown succeeds");
 }


### PR DESCRIPTION
## Summary

This PR is rebased on #1447 and adds `mofa testing` with artifact-backed assertions for real agent-run metadata captured by the agent runner harness.

It builds on `#1447`, which introduced `AgentTestRunner`, `AgentRunResult`, `AgentRunMetadata`, session snapshots, tool-call records, LLM request/response capture, and workspace snapshots. This PR turns that captured runtime data into a reusable assertion layer for agent tests and examples.

## What This Adds

### 1. Runtime and result assertions

Adds assertions over structured run metadata, including:

- run success / failure: validate outcome without unpacking `error` manually
- execution id presence: check that every captured run has traceable identity
- session id equality: assert session routing directly
- runner state before / after: validate runtime lifecycle transitions
- agent state before / after: keep agent lifecycle state visible in assertions
- run duration thresholds: express simple latency expectations

### 2. LLM capture assertions

Adds assertions for captured LLM request/response metadata:

- request contains text: check what prompt context was actually sent
- request message count: validate turn structure and tool-turn expansion
- request has system message: make prompt/bootstrap presence testable
- response contains text: support loose response validation
- response content equals expected text: support exact final-response checks
- response has tool calls / no tool calls: distinguish tool-routing from plain completion paths

### 3. Session assertions

Adds session-oriented assertions over captured session snapshots:

- exact session length: support strict turn-count validation
- minimum session length: support looser multi-turn checks
- session contains specific message: verify persisted conversation content
- session contains expected messages in order: validate dialogue progression across turns
- existing exact ordered session helper remains available: keep stricter snapshot matching when needed

### 4. Tool-call assertions

Adds assertions over captured tool call metadata:

- tool called / not called: validate basic routing behavior
- tool call count: check repeated or missing invocations
- tool input equality: validate the arguments sent to the tool
- tool succeeded / failed: check execution outcome directly from metadata
- tool timed out: cover failure-path and resilience testing
- tool output contains expected text: support lightweight output validation
- tool output equals expected JSON: support structured output checks
- tool duration recorded: ensure performance metadata capture is testable
- tool duration under threshold: express basic tool-latency expectations

### 5. Workspace snapshot assertions

Adds assertions over before/after workspace snapshots:

- file exists before: support precondition checks on seeded workspace state
- file exists after: validate run-created artifacts
- file missing in snapshot: assert clean pre-run state
- file count delta: support quick filesystem-side-effect checks
- file checksum changed: validate content changes without manual file reads
- file changed across the run: cover general before/after file mutation checks

### 6. Runner stats assertions

Adds assertions over runner stats deltas:

- total executions delta: verify stats movement on each run
- successful executions delta: check success-path accounting
- failed executions delta: check failure-path accounting
- last execution time recorded: assert that timing stats are captured

### 7. Focused test coverage

Adds and expands focused coverage in:

- `tests/tests/artifact_assertions_tests.rs`

The suite now covers:

- successful runs
- failure runs
- tool-call success paths
- tool-call failure / timeout paths
- session ordering
- workspace snapshot changes
- LLM capture behavior in both simple and tool-call flows

### 8. Assertion-focused examples

Adds distinct examples showing how to use the new API:

- `examples/agent_runner_assertions_basic`
- `examples/agent_runner_assertions_tools`

These examples are intentionally distinct from the runner demos in `#1447` and focus on using the assertion layer rather than only printing captured metadata.

## Why This Matters

MoFA already had mock assertions and runner metadata capture, but contributors still had to inspect raw result structures manually.

This PR closes that gap by making runtime assertions first-class. Tests can now validate agent behavior against structured artifacts instead of hand-parsing output, session, tool, and workspace metadata in each test.

That makes the testing stack more contributor-facing and moves Idea 6 closer to a real agent testing platform.

## Files Changed

### Core assertion layer

- `tests/src/assertions.rs`

### Focused tests

- `tests/tests/artifact_assertions_tests.rs`

### Example workspace wiring

- `examples/Cargo.toml`

### New examples

- `examples/agent_runner_assertions_basic/Cargo.toml`
- `examples/agent_runner_assertions_basic/src/main.rs`
- `examples/agent_runner_assertions_tools/Cargo.toml`
- `examples/agent_runner_assertions_tools/src/main.rs`

## Validation

Ran:

- `cargo test -p mofa-testing --test artifact_assertions_tests -- --nocapture`

This passed with the full focused assertion suite.

## Dependency

This PR is intended to build on top of `#1447`.

`#1447` captures structured runtime artifacts.
This PR adds the reusable assertion layer over those artifacts.
