### PR TITLE
feat(testing): add swarm artifact viewer GUI

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "resume_from_checkpoint",
     "claw_demo",
     "swarm_orchestrator",
+    "swarm_testing_demo",
 ]
 
 [workspace.package]

--- a/examples/swarm_testing_demo/Cargo.toml
+++ b/examples/swarm_testing_demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "swarm_testing_demo"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+futures = { workspace = true }
+mofa-foundation = { path = "../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../crates/mofa-kernel" }
+mofa-testing = { path = "../../tests" }
+tokio = { workspace = true }

--- a/examples/swarm_testing_demo/src/main.rs
+++ b/examples/swarm_testing_demo/src/main.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    ParallelScheduler, RiskLevel, SubtaskDAG, SwarmScheduler, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+use mofa_testing::SwarmRunArtifact;
+
+#[tokio::main]
+async fn main() -> GlobalResult<()> {
+    let mut dag = SubtaskDAG::new("incident-response");
+
+    let triage = dag.add_task(
+        SwarmSubtask::new("triage", "Triage incoming incident")
+            .with_capabilities(vec!["triage".into()]),
+    );
+    let investigate = dag.add_task(
+        SwarmSubtask::new("investigate", "Investigate impact")
+            .with_capabilities(vec!["analysis".into()]),
+    );
+    let remediate = dag.add_task(
+        SwarmSubtask::new("remediate", "Apply remediation")
+            .with_capabilities(vec!["ops".into()])
+            .with_risk_level(RiskLevel::High),
+    );
+    let report = dag.add_task(
+        SwarmSubtask::new("report", "Publish summary")
+            .with_capabilities(vec!["reporting".into()]),
+    );
+
+    dag.add_dependency(triage, investigate)?;
+    dag.add_dependency(investigate, remediate)?;
+    dag.add_dependency(remediate, report)?;
+
+    dag.assign_agent(triage, "router");
+    dag.assign_agent(investigate, "analyst");
+    dag.assign_agent(remediate, "operator");
+    dag.assign_agent(report, "communicator");
+
+    let executor = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(15)).await;
+            Ok(format!(
+                "{} handled by {}",
+                task.id,
+                task.assigned_agent.unwrap_or_else(|| "unassigned".into())
+            ))
+        })
+    });
+
+    let scheduler = ParallelScheduler::new();
+    let summary = scheduler.execute(&mut dag, executor).await?;
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    println!("{}", artifact.to_markdown());
+    println!("{}", artifact.to_json());
+
+    Ok(())
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,3 +15,4 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
+futures = { workspace = true }

--- a/tests/gui/Cargo.toml
+++ b/tests/gui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mofa-swarm-artifact-gui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+leptos = { version = "0.6", features = ["csr"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+gloo-file = "0.3"
+gloo-net = "0.5"
+web-sys = { version = "0.3", features = ["HtmlInputElement"] }
+
+[workspace]

--- a/tests/gui/index.html
+++ b/tests/gui/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MoFA Swarm Artifact Viewer</title>
+    <link data-trunk rel="css" href="src/style.css" />
+    <link data-trunk rel="rust" />
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: false, theme: "neutral" });
+      window.renderMermaid = async (id, code) => {
+        try {
+          const { svg } = await mermaid.render(id + "_svg", code);
+          const el = document.getElementById(id);
+          if (el) {
+            el.innerHTML = svg;
+          }
+        } catch (err) {
+          const el = document.getElementById(id);
+          if (el) {
+            el.textContent = "Mermaid render error: " + err;
+          }
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/tests/gui/server/Cargo.toml
+++ b/tests/gui/server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mofa-swarm-artifact-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { version = "0.7", features = ["json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tower-http = { version = "0.6", features = ["cors"] }
+futures = "0.3"
+chrono = { version = "0.4", features = ["serde"] }
+
+mofa-testing = { path = "../../../tests" }
+mofa-foundation = { path = "../../../crates/mofa-foundation" }
+mofa-kernel = { path = "../../../crates/mofa-kernel" }
+
+[workspace]

--- a/tests/gui/server/src/main.rs
+++ b/tests/gui/server/src/main.rs
@@ -1,0 +1,182 @@
+//! HTTP backend for the swarm artifact viewer.
+//!
+//! The server exposes:
+//! - `POST /swarm/run` to execute the demo incident-response swarm
+//! - `GET /swarm/artifact` to return the latest generated `SwarmRunArtifact`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    AuditEvent, AuditEventKind, CoordinationPattern, ParallelScheduler, RiskLevel, SubtaskDAG,
+    SwarmMetrics, SwarmResult, SwarmScheduler, SwarmStatus, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalResult;
+use mofa_testing::SwarmRunArtifact;
+use serde_json::{json, Value};
+use tokio::sync::RwLock;
+use tower_http::cors::{Any, CorsLayer};
+
+/// Start the local HTTP server that powers the swarm artifact viewer.
+#[tokio::main]
+async fn main() {
+    // Keep only the latest artifact in memory; the GUI can fetch it after a run completes.
+    let state = Arc::new(RwLock::new(None::<Value>));
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([axum::http::Method::GET, axum::http::Method::POST])
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/swarm/run", post(run_swarm))
+        .route("/swarm/artifact", get(get_artifact))
+        .with_state(state)
+        .layer(cors);
+
+    let addr = "127.0.0.1:3001";
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind server address");
+
+    println!("Swarm artifact server listening on http://{addr}");
+
+    axum::serve(listener, app)
+        .await
+        .expect("server failed");
+}
+
+/// Execute the demo swarm and return the freshly generated artifact payload.
+async fn run_swarm(State(state): State<Arc<RwLock<Option<Value>>>>) -> impl IntoResponse {
+    match build_demo_artifact().await {
+        Ok(value) => {
+            // Persist the most recent run so `GET /swarm/artifact` can serve it back.
+            *state.write().await = Some(value.clone());
+            (StatusCode::OK, Json(value)).into_response()
+        }
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// Return the most recently generated artifact without running the swarm again.
+async fn get_artifact(State(state): State<Arc<RwLock<Option<Value>>>>) -> impl IntoResponse {
+    let artifact = state.read().await.clone();
+    match artifact {
+        Some(value) => (StatusCode::OK, Json(value)).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "no artifact available" })),
+        )
+            .into_response(),
+    }
+}
+
+/// Build the incident-response demo DAG, execute it, and convert it into a rich test artifact.
+async fn build_demo_artifact() -> GlobalResult<Value> {
+    let mut dag = SubtaskDAG::new("incident-response");
+
+    let triage = dag.add_task(
+        SwarmSubtask::new("triage", "Triage incoming incident")
+            .with_capabilities(vec!["triage".into()]),
+    );
+    let investigate = dag.add_task(
+        SwarmSubtask::new("investigate", "Investigate impact")
+            .with_capabilities(vec!["analysis".into()]),
+    );
+    let remediate = dag.add_task(
+        SwarmSubtask::new("remediate", "Apply remediation")
+            .with_capabilities(vec!["ops".into()])
+            .with_risk_level(RiskLevel::High),
+    );
+    let report = dag.add_task(
+        SwarmSubtask::new("report", "Publish summary")
+            .with_capabilities(vec!["reporting".into()]),
+    );
+
+    dag.add_dependency(triage, investigate)?;
+    dag.add_dependency(investigate, remediate)?;
+    dag.add_dependency(remediate, report)?;
+
+    dag.assign_agent(triage, "router");
+    dag.assign_agent(investigate, "analyst");
+    dag.assign_agent(remediate, "operator");
+    dag.assign_agent(report, "communicator");
+
+    let executor = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(15)).await;
+            Ok(format!(
+                "{} handled by {}",
+                task.id,
+                task.assigned_agent.unwrap_or_else(|| "unassigned".into())
+            ))
+        })
+    });
+
+    let scheduler = ParallelScheduler::new();
+    let summary = scheduler.execute(&mut dag, executor).await?;
+
+    // Build a richer artifact payload than the raw scheduler summary so the GUI can show metrics.
+    let mut metrics = SwarmMetrics::default();
+    for _ in 0..summary.succeeded {
+        metrics.record_task_completed();
+    }
+    for _ in 0..summary.failed {
+        metrics.record_task_failed();
+    }
+    metrics.record_agent_tokens("router", 42);
+    metrics.record_agent_tokens("analyst", 84);
+    metrics.record_agent_tokens("operator", 96);
+    metrics.record_agent_tokens("communicator", 33);
+    metrics.set_duration_ms(summary.total_wall_time.as_millis() as u64);
+
+    // Seed a small audit trail so the UI can exercise event rendering end to end.
+    let audit_events = vec![
+        AuditEvent::new(AuditEventKind::SwarmStarted, "Incident-response swarm started")
+            .with_data(json!({"swarm_id":"incident-response"})),
+        AuditEvent::new(AuditEventKind::AgentAssigned, "Agents assigned to subtasks").with_data(
+            json!({
+                "router":"triage",
+                "analyst":"investigate",
+                "operator":"remediate",
+                "communicator":"report"
+            }),
+        ),
+        AuditEvent::new(
+            AuditEventKind::SwarmCompleted,
+            "Incident-response swarm completed successfully",
+        )
+        .with_data(json!({"swarm_id":"incident-response","succeeded":summary.succeeded})),
+    ];
+
+    let result = SwarmResult {
+        config_id: "demo-incident-response".into(),
+        status: SwarmStatus::Completed,
+        dag,
+        output: Some("Incident triaged, remediated, and reported".into()),
+        metrics,
+        audit_events,
+        started_at: chrono::Utc::now(),
+        completed_at: Some(chrono::Utc::now()),
+    };
+    // Reuse the testing artifact constructor so GUI output matches test/CI artifact semantics.
+    let artifact = SwarmRunArtifact::from_swarm_result(
+        &result,
+        CoordinationPattern::Parallel,
+        Some(&summary),
+    );
+
+    Ok(serde_json::to_value(artifact).expect("artifact serialization should succeed"))
+}

--- a/tests/gui/src/main.rs
+++ b/tests/gui/src/main.rs
@@ -1,0 +1,628 @@
+//! Browser UI for viewing and triggering swarm testing artifacts.
+//!
+//! This Leptos app can:
+//! - trigger a demo swarm run over HTTP
+//! - fetch the latest `SwarmRunArtifact`
+//! - render swarm summary, graph, task state, agent ownership, metrics, and audit data
+
+use gloo_file::callbacks::read_as_text;
+use gloo_file::File;
+use gloo_net::http::Request;
+use leptos::*;
+use serde_json::Value;
+use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlInputElement;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = renderMermaid)]
+    fn render_mermaid(id: &str, code: &str);
+}
+
+fn main() {
+    mount_to_body(App);
+}
+
+#[component]
+fn App() -> impl IntoView {
+    let (json_text, set_json_text) = create_signal(String::new());
+    let (artifact, set_artifact) = create_signal::<Option<Value>>(None);
+    let (error, set_error) = create_signal::<Option<String>>(None);
+    let (mermaid_code, set_mermaid_code) = create_signal(String::new());
+    let (server_url, set_server_url) = create_signal(String::from("http://127.0.0.1:3001"));
+    let (status_msg, set_status_msg) = create_signal::<Option<String>>(None);
+    let (_file_readers, set_file_readers) = create_signal::<Vec<gloo_file::callbacks::FileReader>>(
+        Vec::new(),
+    );
+
+    // Keep the text area as the single source of truth and derive parsed state from it.
+    create_effect(move |_| {
+        let text = json_text.get();
+        if text.trim().is_empty() {
+            set_artifact.set(None);
+            set_error.set(None);
+            set_mermaid_code.set(String::new());
+            return;
+        }
+
+        match serde_json::from_str::<Value>(&text) {
+            Ok(value) => {
+                set_error.set(None);
+                set_artifact.set(Some(value.clone()));
+                let code = build_mermaid(&value);
+                set_mermaid_code.set(code);
+            }
+            Err(err) => {
+                set_error.set(Some(format!("JSON parse error: {err}")));
+                set_artifact.set(None);
+                set_mermaid_code.set(String::new());
+            }
+        }
+    });
+
+    // Mermaid is initialized in `index.html`; this effect pushes updated graph code into it.
+    create_effect(move |_| {
+        let code = mermaid_code.get();
+        if !code.trim().is_empty() {
+            render_mermaid("mermaid-graph", &code);
+        }
+    });
+
+    let on_file_change = move |ev| {
+        let input = event_target::<HtmlInputElement>(&ev);
+        if let Some(file) = input.files().and_then(|list| list.get(0)) {
+            let file = File::from(file);
+            let setter = set_json_text.clone();
+            let reader = read_as_text(&file, move |res| {
+                if let Ok(contents) = res {
+                    setter.set(contents);
+                }
+            });
+            set_file_readers.update(|readers| readers.push(reader));
+        }
+    };
+
+    let run_swarm = move |_| {
+        let url = server_url.get();
+        let set_status_msg = set_status_msg.clone();
+        let set_error = set_error.clone();
+        let set_json_text = set_json_text.clone();
+        spawn_local(async move {
+            set_status_msg.set(Some("Running swarm...".to_string()));
+            set_error.set(None);
+            let endpoint = format!("{}/swarm/run", url.trim_end_matches('/'));
+            let resp = Request::post(&endpoint).send().await;
+            match resp {
+                Ok(resp) if resp.ok() => {
+                    match resp.json::<Value>().await {
+                        Ok(value) => {
+                            let text = pretty_json(value);
+                            set_json_text.set(text);
+                            set_status_msg.set(Some("Swarm run complete.".to_string()));
+                        }
+                        Err(err) => {
+                            set_error.set(Some(format!("Failed to parse artifact: {err}")));
+                            set_status_msg.set(None);
+                        }
+                    }
+                }
+                Ok(resp) => {
+                    set_error.set(Some(format!("Run failed: HTTP {}", resp.status())));
+                    set_status_msg.set(None);
+                }
+                Err(err) => {
+                    set_error.set(Some(format!("Run request failed: {err}")));
+                    set_status_msg.set(None);
+                }
+            }
+        });
+    };
+
+    let fetch_artifact = move |_| {
+        let url = server_url.get();
+        let set_status_msg = set_status_msg.clone();
+        let set_error = set_error.clone();
+        let set_json_text = set_json_text.clone();
+        spawn_local(async move {
+            set_status_msg.set(Some("Fetching latest artifact...".to_string()));
+            set_error.set(None);
+            let endpoint = format!("{}/swarm/artifact", url.trim_end_matches('/'));
+            // This path is useful when the swarm was triggered outside the current browser session.
+            let resp = Request::get(&endpoint).send().await;
+            match resp {
+                Ok(resp) if resp.ok() => match resp.json::<Value>().await {
+                    Ok(value) => {
+                        let text = pretty_json(value);
+                        set_json_text.set(text);
+                        set_status_msg.set(Some("Artifact loaded.".to_string()));
+                    }
+                    Err(err) => {
+                        set_error.set(Some(format!("Failed to parse artifact: {err}")));
+                        set_status_msg.set(None);
+                    }
+                },
+                Ok(resp) => {
+                    set_error.set(Some(format!("Fetch failed: HTTP {}", resp.status())));
+                    set_status_msg.set(None);
+                }
+                Err(err) => {
+                    set_error.set(Some(format!("Fetch request failed: {err}")));
+                    set_status_msg.set(None);
+                }
+            }
+        });
+    };
+
+    view! {
+        <div class="header">
+            <div>
+                <h1>"Swarm Artifact Viewer"</h1>
+                <p>"Load a SwarmRunArtifact JSON file and explore task state, metrics, and orchestration flow."</p>
+            </div>
+        </div>
+
+        <section class="panel">
+            <div class="controls">
+                <label class="badge">"JSON Input"</label>
+                <input type="file" accept="application/json" on:change=on_file_change />
+                <label class="badge">"Server"</label>
+                <input
+                    class="text-input"
+                    type="text"
+                    prop:value=server_url
+                    on:input=move |ev| {
+                        set_server_url.set(event_target_value(&ev));
+                    }
+                />
+                <button class="button" on:click=run_swarm>"Run Swarm"</button>
+                <button class="button secondary" on:click=fetch_artifact>"Fetch Latest"</button>
+            </div>
+            <textarea
+                placeholder="Paste SwarmRunArtifact JSON here..."
+                prop:value=json_text
+                on:input=move |ev| {
+                    set_json_text.set(event_target_value(&ev));
+                }
+            ></textarea>
+            <Show
+                when=move || error.get().is_some()
+                fallback=|| ()
+            >
+                <p class="error">{move || error.get().unwrap_or_default()}</p>
+            </Show>
+            <Show
+                when=move || status_msg.get().is_some()
+                fallback=|| ()
+            >
+                <p class="status">{move || status_msg.get().unwrap_or_default()}</p>
+            </Show>
+        </section>
+
+        <Show
+            when=move || artifact.get().is_some()
+            fallback=|| ()
+        >
+            <section class="panel">
+                <div class="grid">
+                    {move || artifact.get().map(render_summary)}
+                </div>
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Dependency Graph"</h2>
+                <div id="mermaid-graph" class="mermaid"></div>
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Tasks"</h2>
+                {move || artifact.get().map(render_tasks)}
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Execution Trace"</h2>
+                {move || artifact.get().map(render_execution)}
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Agent Collaboration"</h2>
+                {move || artifact.get().map(render_agents)}
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Metrics"</h2>
+                {move || artifact.get().map(render_metrics)}
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Audit Trail"</h2>
+                {move || artifact.get().map(render_audit)}
+            </section>
+
+            <section class="panel">
+                <h2 class="section-title">"Raw JSON"</h2>
+                <pre>{move || artifact.get().map(pretty_json).unwrap_or_default()}</pre>
+            </section>
+        </Show>
+    }
+}
+
+/// Render top-level run metadata cards for quick inspection.
+fn render_summary(value: Value) -> impl IntoView {
+    let name = pick_string(&value, "name");
+    let pattern = pick_string(&value, "pattern");
+    let status = pick_string(&value, "swarm_status");
+    let total_tasks = pick_number(&value, "total_tasks");
+    let succeeded = pick_number(&value, "succeeded");
+    let failed = pick_number(&value, "failed");
+    let skipped = pick_number(&value, "skipped");
+    let wall_time = pick_number(&value, "total_wall_time_ms");
+    let success_rate = value
+        .get("success_rate")
+        .and_then(|v| v.as_f64())
+        .map(|v| format!("{:.1}%", v * 100.0))
+        .unwrap_or_else(|| "-".to_string());
+    let output = pick_string(&value, "output");
+
+    view! {
+        <div class="card">
+            <h3>"Run Summary"</h3>
+            <div class="stat-list">
+                <p><strong>"Name"</strong><span>{name}</span></p>
+                <p><strong>"Pattern"</strong><span>{pattern}</span></p>
+                <p><strong>"Swarm Status"</strong><span>{status}</span></p>
+                <p><strong>"Total Tasks"</strong><span>{total_tasks}</span></p>
+            </div>
+        </div>
+        <div class="card">
+            <h3>"Outcomes"</h3>
+            <div class="stat-list">
+                <p><strong>"Succeeded"</strong><span>{succeeded}</span></p>
+                <p><strong>"Failed"</strong><span>{failed}</span></p>
+                <p><strong>"Skipped"</strong><span>{skipped}</span></p>
+                <p><strong>"Success Rate"</strong><span>{success_rate}</span></p>
+            </div>
+        </div>
+        <div class="card">
+            <h3>"Timing"</h3>
+            <div class="stat-list">
+                <p><strong>"Wall Time (ms)"</strong><span>{wall_time}</span></p>
+                <p><strong>"Final Output"</strong><span>{output}</span></p>
+            </div>
+        </div>
+    }
+}
+
+/// Render the canonical task list captured in the artifact.
+fn render_tasks(value: Value) -> impl IntoView {
+    let tasks = value.get("tasks").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    if tasks.is_empty() {
+        return view! { <div><p>"No tasks found in artifact."</p></div> };
+    }
+
+    view! {
+        <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>"Task"</th>
+                    <th>"Status"</th>
+                    <th>"Agent"</th>
+                    <th>"Dependencies"</th>
+                    <th>"Capabilities"</th>
+                    <th>"Risk"</th>
+                    <th>"HITL"</th>
+                </tr>
+            </thead>
+            <tbody>
+                {tasks.into_iter().map(|task| {
+                    let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+                    let status = task.get("status").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let agent = task.get("assigned_agent").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+                    let deps = task.get("dependencies").map(join_array).unwrap_or_else(|| "-".to_string());
+                    let caps = task.get("required_capabilities").map(join_array).unwrap_or_else(|| "-".to_string());
+                    let risk = task.get("risk_level").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let hitl = task
+                        .get("hitl_required")
+                        .and_then(|v| v.as_bool())
+                        .map(|v| if v { "required" } else { "no" })
+                        .unwrap_or("-")
+                        .to_string();
+
+                    view! {
+                        <tr>
+                            <td>{id}</td>
+                            <td>{status}</td>
+                            <td>{agent}</td>
+                            <td>{deps}</td>
+                            <td>{caps}</td>
+                            <td>{risk}</td>
+                            <td>{hitl}</td>
+                        </tr>
+                    }
+                }).collect_view()}
+            </tbody>
+        </table>
+        </div>
+    }
+}
+
+/// Render the ordered execution trace emitted by the scheduler.
+fn render_execution(value: Value) -> impl IntoView {
+    let rows = value
+        .get("execution")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    if rows.is_empty() {
+        return view! { <div><p>"No execution records found."</p></div> };
+    }
+
+    view! {
+        <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>"Order"</th>
+                    <th>"Task"</th>
+                    <th>"Outcome"</th>
+                    <th>"Detail"</th>
+                    <th>"Duration (ms)"</th>
+                    <th>"Attempt"</th>
+                </tr>
+            </thead>
+            <tbody>
+                {rows.into_iter().enumerate().map(|(idx, row)| {
+                    let task_id = row.get("task_id").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+                    let outcome = row.get("outcome").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let detail = row.get("detail").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+                    let duration = row.get("wall_time_ms").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let attempt = row.get("attempt").map(value_to_string).unwrap_or_else(|| "-".to_string());
+
+                    view! {
+                        <tr>
+                            <td>{(idx + 1).to_string()}</td>
+                            <td>{task_id}</td>
+                            <td>{outcome}</td>
+                            <td>{detail}</td>
+                            <td>{duration}</td>
+                            <td>{attempt}</td>
+                        </tr>
+                    }
+                }).collect_view()}
+            </tbody>
+        </table>
+        </div>
+    }
+}
+
+/// Group tasks by assigned agent to show ownership across the swarm.
+fn render_agents(value: Value) -> impl IntoView {
+    let tasks = value.get("tasks").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    if tasks.is_empty() {
+        return view! { <div><p>"No tasks to group by agent."</p></div> };
+    }
+
+    use std::collections::BTreeMap;
+    let mut by_agent: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    for task in tasks {
+        let agent = task.get("assigned_agent").and_then(|v| v.as_str()).unwrap_or("unassigned").to_string();
+        let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+        let status = task.get("status").map(value_to_string).unwrap_or_else(|| "-".to_string());
+        by_agent.entry(agent).or_default().push((id, status));
+    }
+
+    view! {
+        <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>"Agent"</th>
+                    <th>"Tasks"</th>
+                    <th>"Terminal States"</th>
+                </tr>
+            </thead>
+            <tbody>
+                {by_agent.into_iter().map(|(agent, tasks)| {
+                    let task_ids: Vec<String> = tasks.iter().map(|(id, _)| id.clone()).collect();
+                    let states: Vec<String> = tasks
+                        .iter()
+                        .map(|(id, status)| format!("{}:{}", id, status))
+                        .collect();
+
+                    view! {
+                        <tr>
+                            <td>{agent}</td>
+                            <td>{task_ids.join(", ")}</td>
+                            <td>{states.join(", ")}</td>
+                        </tr>
+                    }
+                }).collect_view()}
+            </tbody>
+        </table>
+        </div>
+    }
+}
+
+/// Render aggregate swarm metrics and per-agent token usage when present.
+fn render_metrics(value: Value) -> impl IntoView {
+    let metrics = match value.get("metrics") {
+        Some(v) => v.clone(),
+        None => return view! { <div><p>"No metrics snapshot in artifact."</p></div> },
+    };
+
+    let total_tokens = metrics.get("total_tokens").map(value_to_string).unwrap_or_else(|| "-".to_string());
+    let duration = metrics.get("duration_ms").map(value_to_string).unwrap_or_else(|| "-".to_string());
+    let tasks_completed = metrics.get("tasks_completed").map(value_to_string).unwrap_or_else(|| "-".to_string());
+    let tasks_failed = metrics.get("tasks_failed").map(value_to_string).unwrap_or_else(|| "-".to_string());
+    let hitl = metrics.get("hitl_interventions").map(value_to_string).unwrap_or_else(|| "-".to_string());
+    let reassignments = metrics.get("reassignments").map(value_to_string).unwrap_or_else(|| "-".to_string());
+
+    let agent_tokens = metrics.get("agent_tokens").cloned().unwrap_or(Value::Null);
+
+    view! {
+        <div>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>"Total Tokens"</th>
+                        <th>"Duration"</th>
+                        <th>"Tasks Completed"</th>
+                        <th>"Tasks Failed"</th>
+                        <th>"HITL"</th>
+                        <th>"Reassignments"</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>{total_tokens}</td>
+                        <td>{duration}</td>
+                        <td>{tasks_completed}</td>
+                        <td>{tasks_failed}</td>
+                        <td>{hitl}</td>
+                        <td>{reassignments}</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h3>"Agent Tokens"</h3>
+            <pre>{pretty_json(agent_tokens)}</pre>
+        </div>
+    }
+}
+
+/// Render normalized audit events captured during the swarm run.
+fn render_audit(value: Value) -> impl IntoView {
+    let events = value
+        .get("audit_events")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    if events.is_empty() {
+        return view! { <div><p>"No audit events recorded."</p></div> };
+    }
+
+    view! {
+        <div>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>"Kind"</th>
+                    <th>"Description"</th>
+                    <th>"Timestamp"</th>
+                    <th>"Data"</th>
+                </tr>
+            </thead>
+            <tbody>
+                {events.into_iter().map(|event| {
+                    let kind = event.get("kind").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let description = event.get("description").and_then(|v| v.as_str()).unwrap_or("-").to_string();
+                    let timestamp = event.get("timestamp_ms").map(value_to_string).unwrap_or_else(|| "-".to_string());
+                    let data = event.get("data").cloned().unwrap_or(Value::Null);
+                    view! {
+                        <tr>
+                            <td>{kind}</td>
+                            <td>{description}</td>
+                            <td>{timestamp}</td>
+                            <td><pre>{pretty_json(data)}</pre></td>
+                        </tr>
+                    }
+                }).collect_view()}
+            </tbody>
+        </table>
+        </div>
+    }
+}
+
+/// Convert task dependencies into Mermaid graph syntax for browser rendering.
+fn build_mermaid(value: &Value) -> String {
+    let tasks = value.get("tasks").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    if tasks.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = vec!["graph TD".to_string()];
+    for task in tasks {
+        let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("task");
+        let safe_id = sanitize_id(id);
+        let deps = task.get("dependencies").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+        // Mirror the markdown artifact graph so the browser view stays aligned with PR output.
+        if deps.is_empty() {
+            lines.push(format!("    {}[\"{}\"]", safe_id, id));
+        } else {
+            for dep in deps {
+                let dep_id = dep.as_str().unwrap_or("dep");
+                let dep_safe = sanitize_id(dep_id);
+                lines.push(format!("    {}[\"{}\"] --> {}[\"{}\"]", dep_safe, dep_id, safe_id, id));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Sanitize task ids so they are valid Mermaid node identifiers.
+fn sanitize_id(input: &str) -> String {
+    let mut out = String::new();
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push_str("task");
+    }
+    out
+}
+
+/// Read a string field from the artifact and provide a stable fallback for missing data.
+fn pick_string(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("-")
+        .to_string()
+}
+
+/// Read numeric fields used in summary cards and table cells.
+fn pick_number(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(|v| v.as_i64())
+        .map(|v| v.to_string())
+        .or_else(|| value.get(key).and_then(|v| v.as_u64()).map(|v| v.to_string()))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Join string arrays from artifact fields into a compact display value.
+fn join_array(value: &Value) -> String {
+    value
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Normalize mixed JSON values into plain display strings for the tables.
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => "-".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Pretty-print JSON for the text area and raw artifact panel.
+fn pretty_json(value: Value) -> String {
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+}

--- a/tests/gui/src/style.css
+++ b/tests/gui/src/style.css
@@ -1,0 +1,270 @@
+:root {
+  --bg: #0b0f15;
+  --bg-glow: #1a2436;
+  --panel: rgba(20, 26, 36, 0.88);
+  --panel-strong: #101720;
+  --accent: #3fd3ff;
+  --accent-soft: rgba(63, 211, 255, 0.14);
+  --muted: #96a3b8;
+  --text: #e6edf7;
+  --border: #26364b;
+  --border-soft: rgba(84, 109, 143, 0.28);
+  --shadow: 0 22px 48px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(63, 211, 255, 0.1), transparent 30%),
+    radial-gradient(circle at top, var(--bg-glow) 0%, var(--bg) 55%);
+  color: var(--text);
+  font-family: "IBM Plex Sans", "Space Grotesk", "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+main {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 18px 40px 72px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(32px, 4vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.header p {
+  max-width: 760px;
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 20px;
+}
+
+.panel {
+  background: var(--panel);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--border-soft);
+  border-radius: 20px;
+  padding: 24px;
+  margin-top: 22px;
+  box-shadow: var(--shadow);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.controls input[type="file"] {
+  color: var(--muted);
+}
+
+.text-input {
+  background: rgba(8, 12, 18, 0.72);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  padding: 10px 14px;
+  min-width: 320px;
+  font-size: 15px;
+}
+
+.button {
+  background: var(--accent);
+  color: #051018;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 15px;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.button.secondary {
+  background: #1c2635;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+textarea {
+  width: 100%;
+  min-height: 240px;
+  background: #0d131c;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.card {
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px 18px 20px;
+  background: linear-gradient(180deg, rgba(18, 24, 34, 0.95), rgba(12, 17, 24, 0.95));
+}
+
+.card h3 {
+  margin: 0 0 16px;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+
+.stat-list {
+  display: grid;
+  gap: 12px;
+}
+
+.stat-list p {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.stat-list strong {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-list span {
+  text-align: right;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.section-title {
+  margin: 0 0 16px;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(15, 20, 27, 0.7);
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  background: rgba(11, 16, 24, 0.9);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+pre {
+  background: #0c1219;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border-soft);
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.mermaid {
+  overflow-x: auto;
+  min-height: 220px;
+  background: radial-gradient(circle at top, rgba(63, 211, 255, 0.06), transparent 35%), #0d131b;
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+.error {
+  color: #ff6b6b;
+  font-size: 14px;
+  margin: 14px 0 0;
+}
+
+.status {
+  color: var(--accent);
+  font-size: 14px;
+  margin: 14px 0 0;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 14px 18px 48px;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header p {
+    font-size: 17px;
+  }
+
+  .text-input {
+    min-width: 100%;
+  }
+
+  .stat-list p {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stat-list span {
+    text-align: left;
+    font-size: 20px;
+  }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod report;
+pub mod swarm;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
@@ -18,4 +19,5 @@ pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
 };
+pub use swarm::{SwarmRunArtifact, SwarmTaskRecord};
 pub use tools::MockTool;

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -3,7 +3,8 @@
 use std::collections::HashMap;
 
 use mofa_foundation::swarm::{
-    CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG, SubtaskStatus, TaskOutcome,
+    AuditEvent, AuditEventKind, CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG,
+    SubtaskStatus, SwarmMetrics, SwarmResult, SwarmStatus, TaskOutcome,
 };
 use serde::{Deserialize, Serialize};
 
@@ -27,12 +28,16 @@ pub struct SwarmTaskRecord {
 pub struct SwarmRunArtifact {
     pub name: String,
     pub pattern: CoordinationPattern,
+    pub swarm_status: Option<SwarmStatus>,
     pub total_tasks: usize,
     pub succeeded: usize,
     pub failed: usize,
     pub skipped: usize,
     pub total_wall_time_ms: u64,
     pub success_rate: f64,
+    pub output: Option<String>,
+    pub metrics: Option<SwarmMetricsRecord>,
+    pub audit_events: Vec<SwarmAuditRecord>,
     pub tasks: Vec<SwarmTaskRecord>,
     pub execution: Vec<SwarmExecutionRecord>,
 }
@@ -48,73 +53,99 @@ pub struct SwarmExecutionRecord {
     pub attempt: u32,
 }
 
+/// Normalized metrics snapshot for swarm testing artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmMetricsRecord {
+    pub total_tokens: u64,
+    pub duration_ms: u64,
+    pub tasks_completed: usize,
+    pub tasks_failed: usize,
+    pub hitl_interventions: usize,
+    pub reassignments: usize,
+    pub agent_tokens: HashMap<String, u64>,
+}
+
+/// Normalized audit event for assertion and visual review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmAuditRecord {
+    pub kind: AuditEventKind,
+    pub description: String,
+    pub timestamp_ms: i64,
+    pub data: serde_json::Value,
+}
+
 impl SwarmRunArtifact {
     /// Build an artifact from a scheduler summary and the final DAG state.
     pub fn from_scheduler_run(dag: &SubtaskDAG, summary: &SchedulerSummary) -> Self {
-        let mut tasks = Vec::new();
-
-        let ordered = dag
-            .topological_order()
-            .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
-
-        for idx in ordered {
-            if let Some(task) = dag.get_task(idx) {
-                let dependencies = dag
-                    .dependencies_of(idx)
-                    .into_iter()
-                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
-                    .collect();
-                let dependents = dag
-                    .dependents_of(idx)
-                    .into_iter()
-                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
-                    .collect();
-
-                tasks.push(SwarmTaskRecord {
-                    id: task.id.clone(),
-                    description: task.description.clone(),
-                    status: task.status.clone(),
-                    assigned_agent: task.assigned_agent.clone(),
-                    output: task.output.clone(),
-                    dependencies,
-                    dependents,
-                    required_capabilities: task.required_capabilities.clone(),
-                    risk_level: task.risk_level.clone(),
-                    hitl_required: task.hitl_required,
-                });
-            }
-        }
-
-        let execution = summary
-            .results
-            .iter()
-            .map(|result| {
-                let (outcome, detail) = match &result.outcome {
-                    TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
-                    TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
-                    TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
-                };
-
-                SwarmExecutionRecord {
-                    task_id: result.task_id.clone(),
-                    node_index: result.node_index,
-                    outcome,
-                    detail,
-                    wall_time_ms: result.wall_time.as_millis() as u64,
-                    attempt: result.attempt,
-                }
-            })
-            .collect();
+        let tasks = snapshot_tasks(dag);
+        let execution = snapshot_execution(summary);
 
         Self {
             name: dag.name.clone(),
             pattern: summary.pattern.clone(),
+            swarm_status: None,
             total_tasks: summary.total_tasks,
             succeeded: summary.succeeded,
             failed: summary.failed,
             skipped: summary.skipped,
             total_wall_time_ms: summary.total_wall_time.as_millis() as u64,
             success_rate: summary.success_rate(),
+            output: None,
+            metrics: None,
+            audit_events: Vec::new(),
+            tasks,
+            execution,
+        }
+    }
+
+    /// Build an artifact from a full swarm result, including metrics and audit events.
+    pub fn from_swarm_result(
+        result: &SwarmResult,
+        pattern: CoordinationPattern,
+        summary: Option<&SchedulerSummary>,
+    ) -> Self {
+        let tasks = snapshot_tasks(&result.dag);
+        let execution = summary.map(snapshot_execution).unwrap_or_default();
+        let total_tasks = result.dag.task_count();
+        let succeeded = summary.map(|it| it.succeeded).unwrap_or_else(|| {
+            result
+                .dag
+                .all_tasks()
+                .iter()
+                .filter(|(_, task)| task.status == SubtaskStatus::Completed)
+                .count()
+        });
+        let failed = summary.map(|it| it.failed).unwrap_or(result.metrics.tasks_failed);
+        let skipped = summary.map(|it| it.skipped).unwrap_or_else(|| {
+            result
+                .dag
+                .all_tasks()
+                .iter()
+                .filter(|(_, task)| task.status == SubtaskStatus::Skipped)
+                .count()
+        });
+        let total_wall_time_ms = summary
+            .map(|it| it.total_wall_time.as_millis() as u64)
+            .unwrap_or(result.metrics.duration_ms);
+        let success_rate = if total_tasks == 0 {
+            1.0
+        } else {
+            succeeded as f64 / total_tasks as f64
+        };
+
+        Self {
+            name: result.dag.name.clone(),
+            pattern,
+            swarm_status: Some(result.status.clone()),
+            total_tasks,
+            succeeded,
+            failed,
+            skipped,
+            total_wall_time_ms,
+            success_rate,
+            output: result.output.clone(),
+            metrics: Some(SwarmMetricsRecord::from(&result.metrics)),
+            audit_events: result.audit_events.iter().map(SwarmAuditRecord::from).collect(),
             tasks,
             execution,
         }
@@ -137,10 +168,16 @@ impl SwarmRunArtifact {
         out.push_str(&format!("- Failed: `{}`\n", self.failed));
         out.push_str(&format!("- Skipped: `{}`\n", self.skipped));
         out.push_str(&format!("- Success rate: `{:.1}%`\n", self.success_rate * 100.0));
+        if let Some(status) = &self.swarm_status {
+            out.push_str(&format!("- Swarm status: `{}`\n", swarm_status_label(status)));
+        }
         out.push_str(&format!(
             "- Total wall time: `{} ms`\n\n",
             self.total_wall_time_ms
         ));
+        if let Some(output) = &self.output {
+            out.push_str(&format!("- Final output: `{}`\n\n", compact(output)));
+        }
 
         out.push_str("## Dependency Graph\n\n```mermaid\ngraph TD\n");
         for task in &self.tasks {
@@ -218,6 +255,47 @@ impl SwarmRunArtifact {
                         join_or_dash(&statuses)
                     ));
                 }
+            }
+        }
+
+        if let Some(metrics) = &self.metrics {
+            let mut agents: Vec<_> = metrics.agent_tokens.iter().collect();
+            agents.sort_by(|a, b| a.0.cmp(b.0));
+
+            out.push_str("\n## Metrics\n\n");
+            out.push_str("| Total Tokens | Duration | Tasks Completed | Tasks Failed | HITL | Reassignments |\n");
+            out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+            out.push_str(&format!(
+                "| {} | {} ms | {} | {} | {} | {} |\n",
+                metrics.total_tokens,
+                metrics.duration_ms,
+                metrics.tasks_completed,
+                metrics.tasks_failed,
+                metrics.hitl_interventions,
+                metrics.reassignments
+            ));
+
+            if !agents.is_empty() {
+                out.push_str("\n| Agent | Tokens |\n");
+                out.push_str("| --- | --- |\n");
+                for (agent, tokens) in agents {
+                    out.push_str(&format!("| {} | {} |\n", agent, tokens));
+                }
+            }
+        }
+
+        if !self.audit_events.is_empty() {
+            out.push_str("\n## Audit Trail\n\n");
+            out.push_str("| Event | Description | Data |\n");
+            out.push_str("| --- | --- | --- |\n");
+            for event in &self.audit_events {
+                // Keep event payloads compact so the markdown stays PR-comment friendly.
+                out.push_str(&format!(
+                    "| {} | {} | `{}` |\n",
+                    audit_kind_label(&event.kind),
+                    compact(&event.description),
+                    compact(&event.data.to_string())
+                ));
             }
         }
 
@@ -363,6 +441,44 @@ impl SwarmRunArtifact {
         }
     }
 
+    /// Assert swarm-level metrics match expected HITL and reassignment counts.
+    pub fn assert_metrics(
+        &self,
+        hitl_interventions: usize,
+        reassignments: usize,
+    ) -> Result<(), String> {
+        let metrics = self
+            .metrics
+            .as_ref()
+            .ok_or_else(|| "artifact has no metrics snapshot".to_string())?;
+
+        if metrics.hitl_interventions == hitl_interventions
+            && metrics.reassignments == reassignments
+        {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected metrics hitl/reassignments = {}/{}, got {}/{}",
+                hitl_interventions,
+                reassignments,
+                metrics.hitl_interventions,
+                metrics.reassignments
+            ))
+        }
+    }
+
+    /// Assert at least one audit event of the given kind exists.
+    pub fn assert_audit_event_kind(&self, kind: AuditEventKind) -> Result<(), String> {
+        if self.audit_events.iter().any(|event| event.kind == kind) {
+            Ok(())
+        } else {
+            Err(format!(
+                "artifact does not contain audit event `{}`",
+                audit_kind_label(&kind)
+            ))
+        }
+    }
+
     fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {
         self.tasks.iter().find(|task| task.id == task_id)
     }
@@ -378,6 +494,93 @@ impl SwarmRunArtifact {
             CoordinationPattern::Routing => "routing",
         }
     }
+}
+
+impl From<&SwarmMetrics> for SwarmMetricsRecord {
+    fn from(value: &SwarmMetrics) -> Self {
+        Self {
+            total_tokens: value.total_tokens,
+            duration_ms: value.duration_ms,
+            tasks_completed: value.tasks_completed,
+            tasks_failed: value.tasks_failed,
+            hitl_interventions: value.hitl_interventions,
+            reassignments: value.reassignments,
+            agent_tokens: value.agent_tokens.clone(),
+        }
+    }
+}
+
+impl From<&AuditEvent> for SwarmAuditRecord {
+    fn from(value: &AuditEvent) -> Self {
+        Self {
+            kind: value.kind.clone(),
+            description: value.description.clone(),
+            timestamp_ms: value.timestamp.timestamp_millis(),
+            data: value.data.clone(),
+        }
+    }
+}
+
+fn snapshot_tasks(dag: &SubtaskDAG) -> Vec<SwarmTaskRecord> {
+    // Prefer topological order so the rendered artifact reads like the intended
+    // orchestration plan rather than raw graph insertion order.
+    let ordered = dag
+        .topological_order()
+        .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
+
+    let mut tasks = Vec::new();
+    for idx in ordered {
+        if let Some(task) = dag.get_task(idx) {
+            let dependencies = dag
+                .dependencies_of(idx)
+                .into_iter()
+                .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                .collect();
+            let dependents = dag
+                .dependents_of(idx)
+                .into_iter()
+                .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                .collect();
+
+            tasks.push(SwarmTaskRecord {
+                id: task.id.clone(),
+                description: task.description.clone(),
+                status: task.status.clone(),
+                assigned_agent: task.assigned_agent.clone(),
+                output: task.output.clone(),
+                dependencies,
+                dependents,
+                required_capabilities: task.required_capabilities.clone(),
+                risk_level: task.risk_level.clone(),
+                hitl_required: task.hitl_required,
+            });
+        }
+    }
+    tasks
+}
+
+fn snapshot_execution(summary: &SchedulerSummary) -> Vec<SwarmExecutionRecord> {
+    summary
+        .results
+        .iter()
+        .map(|result| {
+            // Normalize scheduler outcomes to stable strings
+            let (outcome, detail) = match &result.outcome {
+                TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
+                TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
+                TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
+            };
+
+            SwarmExecutionRecord {
+                task_id: result.task_id.clone(),
+                node_index: result.node_index,
+                outcome,
+                detail,
+                wall_time_ms: result.wall_time.as_millis() as u64,
+                attempt: result.attempt,
+            }
+        })
+        .collect()
 }
 
 fn join_or_dash(values: &[String]) -> String {
@@ -411,5 +614,35 @@ fn status_label(status: &SubtaskStatus) -> String {
         SubtaskStatus::Completed => "completed".to_string(),
         SubtaskStatus::Failed(reason) => format!("failed ({reason})"),
         SubtaskStatus::Skipped => "skipped".to_string(),
+    }
+}
+
+fn swarm_status_label(status: &SwarmStatus) -> String {
+    match status {
+        SwarmStatus::Running => "running".to_string(),
+        SwarmStatus::Completed => "completed".to_string(),
+        SwarmStatus::Failed(reason) => format!("failed ({reason})"),
+        SwarmStatus::Cancelled => "cancelled".to_string(),
+        SwarmStatus::Escalated => "escalated".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn audit_kind_label(kind: &AuditEventKind) -> &'static str {
+    match kind {
+        AuditEventKind::SwarmStarted => "swarm_started",
+        AuditEventKind::TaskDecomposed => "task_decomposed",
+        AuditEventKind::AgentAssigned => "agent_assigned",
+        AuditEventKind::PatternSelected => "pattern_selected",
+        AuditEventKind::SubtaskStarted => "subtask_started",
+        AuditEventKind::SubtaskCompleted => "subtask_completed",
+        AuditEventKind::SubtaskFailed => "subtask_failed",
+        AuditEventKind::HITLRequested => "hitl_requested",
+        AuditEventKind::HITLDecision => "hitl_decision",
+        AuditEventKind::SLAWarning => "sla_warning",
+        AuditEventKind::SLABreach => "sla_breach",
+        AuditEventKind::AgentReassigned => "agent_reassigned",
+        AuditEventKind::SwarmCompleted => "swarm_completed",
+        _ => "unknown_event",
     }
 }

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -1,0 +1,373 @@
+//! Swarm/orchestrator testing helpers with visual artifact rendering.
+
+use std::collections::HashMap;
+
+use mofa_foundation::swarm::{
+    CoordinationPattern, RiskLevel, SchedulerSummary, SubtaskDAG, SubtaskStatus, TaskOutcome,
+};
+use serde::{Deserialize, Serialize};
+
+/// Canonical snapshot of one swarm task for testing and review output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmTaskRecord {
+    pub id: String,
+    pub description: String,
+    pub status: SubtaskStatus,
+    pub assigned_agent: Option<String>,
+    pub output: Option<String>,
+    pub dependencies: Vec<String>,
+    pub dependents: Vec<String>,
+    pub required_capabilities: Vec<String>,
+    pub risk_level: RiskLevel,
+    pub hitl_required: bool,
+}
+
+/// Visualizable artifact for one orchestrated swarm run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmRunArtifact {
+    pub name: String,
+    pub pattern: CoordinationPattern,
+    pub total_tasks: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub total_wall_time_ms: u64,
+    pub success_rate: f64,
+    pub tasks: Vec<SwarmTaskRecord>,
+    pub execution: Vec<SwarmExecutionRecord>,
+}
+
+/// One scheduler result entry normalized for rendering/assertion.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwarmExecutionRecord {
+    pub task_id: String,
+    pub node_index: usize,
+    pub outcome: String,
+    pub detail: Option<String>,
+    pub wall_time_ms: u64,
+    pub attempt: u32,
+}
+
+impl SwarmRunArtifact {
+    /// Build an artifact from a scheduler summary and the final DAG state.
+    pub fn from_scheduler_run(dag: &SubtaskDAG, summary: &SchedulerSummary) -> Self {
+        let mut tasks = Vec::new();
+
+        let ordered = dag
+            .topological_order()
+            .unwrap_or_else(|_| dag.all_tasks().into_iter().map(|(idx, _)| idx).collect());
+
+        for idx in ordered {
+            if let Some(task) = dag.get_task(idx) {
+                let dependencies = dag
+                    .dependencies_of(idx)
+                    .into_iter()
+                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                    .collect();
+                let dependents = dag
+                    .dependents_of(idx)
+                    .into_iter()
+                    .filter_map(|dep| dag.get_task(dep).map(|task| task.id.clone()))
+                    .collect();
+
+                tasks.push(SwarmTaskRecord {
+                    id: task.id.clone(),
+                    description: task.description.clone(),
+                    status: task.status.clone(),
+                    assigned_agent: task.assigned_agent.clone(),
+                    output: task.output.clone(),
+                    dependencies,
+                    dependents,
+                    required_capabilities: task.required_capabilities.clone(),
+                    risk_level: task.risk_level.clone(),
+                    hitl_required: task.hitl_required,
+                });
+            }
+        }
+
+        let execution = summary
+            .results
+            .iter()
+            .map(|result| {
+                let (outcome, detail) = match &result.outcome {
+                    TaskOutcome::Success(output) => ("success".to_string(), Some(output.clone())),
+                    TaskOutcome::Failure(error) => ("failure".to_string(), Some(error.clone())),
+                    TaskOutcome::Skipped(reason) => ("skipped".to_string(), Some(reason.clone())),
+                };
+
+                SwarmExecutionRecord {
+                    task_id: result.task_id.clone(),
+                    node_index: result.node_index,
+                    outcome,
+                    detail,
+                    wall_time_ms: result.wall_time.as_millis() as u64,
+                    attempt: result.attempt,
+                }
+            })
+            .collect();
+
+        Self {
+            name: dag.name.clone(),
+            pattern: summary.pattern.clone(),
+            total_tasks: summary.total_tasks,
+            succeeded: summary.succeeded,
+            failed: summary.failed,
+            skipped: summary.skipped,
+            total_wall_time_ms: summary.total_wall_time.as_millis() as u64,
+            success_rate: summary.success_rate(),
+            tasks,
+            execution,
+        }
+    }
+
+    /// Render the artifact as pretty JSON for CI/artifacts.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("swarm artifact serialization should not fail")
+    }
+
+    /// Render the artifact as markdown with a Mermaid dependency graph.
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+
+        out.push_str(&format!("# Swarm Test Artifact: {}\n\n", self.name));
+        out.push_str(&format!("- Pattern: `{}`\n", self.pattern_label()));
+        out.push_str(&format!("- Total tasks: `{}`\n", self.total_tasks));
+        out.push_str(&format!("- Succeeded: `{}`\n", self.succeeded));
+        out.push_str(&format!("- Failed: `{}`\n", self.failed));
+        out.push_str(&format!("- Skipped: `{}`\n", self.skipped));
+        out.push_str(&format!("- Success rate: `{:.1}%`\n", self.success_rate * 100.0));
+        out.push_str(&format!(
+            "- Total wall time: `{} ms`\n\n",
+            self.total_wall_time_ms
+        ));
+
+        out.push_str("## Dependency Graph\n\n```mermaid\ngraph TD\n");
+        for task in &self.tasks {
+            if task.dependencies.is_empty() {
+                out.push_str(&format!("    {}[\"{}\"]\n", sanitize_node_id(&task.id), task.id));
+            } else {
+                for dep in &task.dependencies {
+                    out.push_str(&format!(
+                        "    {}[\"{}\"] --> {}[\"{}\"]\n",
+                        sanitize_node_id(dep),
+                        dep,
+                        sanitize_node_id(&task.id),
+                        task.id
+                    ));
+                }
+            }
+        }
+        out.push_str("```\n\n");
+
+        out.push_str("## Tasks\n\n");
+        out.push_str("| Task | Status | Agent | Depends On | Capabilities | HITL |\n");
+        out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+        for task in &self.tasks {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} | {} |\n",
+                task.id,
+                status_label(&task.status),
+                task.assigned_agent.as_deref().unwrap_or("-"),
+                join_or_dash(&task.dependencies),
+                join_or_dash(&task.required_capabilities),
+                if task.hitl_required { "required" } else { "no" }
+            ));
+            if let Some(output) = &task.output {
+                out.push_str(&format!("| output | `{}` |  |  |  |  |\n", compact(output)));
+            }
+        }
+
+        out.push_str("\n## Execution Trace\n\n");
+        out.push_str("| Order | Task | Outcome | Detail | Duration |\n");
+        out.push_str("| --- | --- | --- | --- | --- |\n");
+        for (order, record) in self.execution.iter().enumerate() {
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {} ms |\n",
+                order + 1,
+                record.task_id,
+                record.outcome,
+                record
+                    .detail
+                    .as_deref()
+                    .map(compact)
+                    .unwrap_or_else(|| "-".to_string()),
+                record.wall_time_ms
+            ));
+        }
+
+        out
+    }
+
+    /// Assert a specific task exists and has the expected status.
+    pub fn assert_task_status(
+        &self,
+        task_id: &str,
+        expected: SubtaskStatus,
+    ) -> Result<(), String> {
+        let actual = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        if actual.status == expected {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` expected status `{}` but was `{}`",
+                status_label(&expected),
+                status_label(&actual.status)
+            ))
+        }
+    }
+
+    /// Assert that all tasks completed successfully.
+    pub fn assert_all_completed(&self) -> Result<(), String> {
+        let incomplete: Vec<String> = self
+            .tasks
+            .iter()
+            .filter(|task| task.status != SubtaskStatus::Completed)
+            .map(|task| format!("{}:{}", task.id, status_label(&task.status)))
+            .collect();
+
+        if incomplete.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected all tasks completed, found non-completed tasks: {}",
+                incomplete.join(", ")
+            ))
+        }
+    }
+
+    /// Assert aggregate scheduler counts.
+    pub fn assert_counts(
+        &self,
+        succeeded: usize,
+        failed: usize,
+        skipped: usize,
+    ) -> Result<(), String> {
+        if self.succeeded == succeeded && self.failed == failed && self.skipped == skipped {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected counts success/fail/skip = {}/{}/{}, got {}/{}/{}",
+                succeeded, failed, skipped, self.succeeded, self.failed, self.skipped
+            ))
+        }
+    }
+
+    /// Assert a dependency edge exists in the decomposed task graph.
+    pub fn assert_dependency(&self, task_id: &str, dependency_id: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        if task.dependencies.iter().any(|dep| dep == dependency_id) {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` does not depend on `{dependency_id}`"
+            ))
+        }
+    }
+
+    /// Assert a task output contains the provided substring.
+    pub fn assert_output_contains(&self, task_id: &str, needle: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+        let output = task
+            .output
+            .as_deref()
+            .ok_or_else(|| format!("task `{task_id}` has no output"))?;
+
+        if output.contains(needle) {
+            Ok(())
+        } else {
+            Err(format!(
+                "task `{task_id}` output did not contain `{needle}`"
+            ))
+        }
+    }
+
+    /// Assert a task failed and its failure message contains the provided substring.
+    pub fn assert_task_failed_contains(&self, task_id: &str, needle: &str) -> Result<(), String> {
+        let task = self
+            .task(task_id)
+            .ok_or_else(|| format!("task `{task_id}` not found"))?;
+
+        match &task.status {
+            SubtaskStatus::Failed(reason) if reason.contains(needle) => Ok(()),
+            SubtaskStatus::Failed(reason) => Err(format!(
+                "task `{task_id}` failed, but `{reason}` did not contain `{needle}`"
+            )),
+            status => Err(format!(
+                "task `{task_id}` expected failed status but was `{}`",
+                status_label(status)
+            )),
+        }
+    }
+
+    /// Group tasks by assigned agent for multi-agent collaboration assertions.
+    pub fn tasks_by_agent(&self) -> HashMap<String, Vec<&SwarmTaskRecord>> {
+        let mut by_agent = HashMap::new();
+        for task in &self.tasks {
+            if let Some(agent) = &task.assigned_agent {
+                by_agent
+                    .entry(agent.clone())
+                    .or_insert_with(Vec::new)
+                    .push(task);
+            }
+        }
+        by_agent
+    }
+
+    fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {
+        self.tasks.iter().find(|task| task.id == task_id)
+    }
+
+    fn pattern_label(&self) -> &'static str {
+        match self.pattern {
+            CoordinationPattern::Sequential => "sequential",
+            CoordinationPattern::Parallel => "parallel",
+            CoordinationPattern::Debate => "debate",
+            CoordinationPattern::Consensus => "consensus",
+            CoordinationPattern::MapReduce => "map_reduce",
+            CoordinationPattern::Supervision => "supervision",
+            CoordinationPattern::Routing => "routing",
+        }
+    }
+}
+
+fn join_or_dash(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn sanitize_node_id(id: &str) -> String {
+    id.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn compact(value: &str) -> String {
+    let trimmed = value.replace('\n', " ");
+    if trimmed.len() > 60 {
+        format!("{}...", &trimmed[..57])
+    } else {
+        trimmed
+    }
+}
+
+fn status_label(status: &SubtaskStatus) -> String {
+    match status {
+        SubtaskStatus::Pending => "pending".to_string(),
+        SubtaskStatus::Ready => "ready".to_string(),
+        SubtaskStatus::Running => "running".to_string(),
+        SubtaskStatus::Completed => "completed".to_string(),
+        SubtaskStatus::Failed(reason) => format!("failed ({reason})"),
+        SubtaskStatus::Skipped => "skipped".to_string(),
+    }
+}

--- a/tests/src/swarm.rs
+++ b/tests/src/swarm.rs
@@ -128,6 +128,7 @@ impl SwarmRunArtifact {
     /// Render the artifact as markdown with a Mermaid dependency graph.
     pub fn to_markdown(&self) -> String {
         let mut out = String::new();
+        let tasks_by_agent = self.tasks_by_agent();
 
         out.push_str(&format!("# Swarm Test Artifact: {}\n\n", self.name));
         out.push_str(&format!("- Pattern: `{}`\n", self.pattern_label()));
@@ -193,6 +194,31 @@ impl SwarmRunArtifact {
                     .unwrap_or_else(|| "-".to_string()),
                 record.wall_time_ms
             ));
+        }
+
+        if !tasks_by_agent.is_empty() {
+            let mut agent_names: Vec<_> = tasks_by_agent.keys().cloned().collect();
+            agent_names.sort();
+
+            out.push_str("\n## Agent Collaboration View\n\n");
+            out.push_str("| Agent | Tasks | Terminal States |\n");
+            out.push_str("| --- | --- | --- |\n");
+
+            for agent in agent_names {
+                if let Some(tasks) = tasks_by_agent.get(&agent) {
+                    let task_ids: Vec<String> = tasks.iter().map(|task| task.id.clone()).collect();
+                    let statuses: Vec<String> = tasks
+                        .iter()
+                        .map(|task| format!("{}:{}", task.id, status_label(&task.status)))
+                        .collect();
+                    out.push_str(&format!(
+                        "| {} | {} | {} |\n",
+                        agent,
+                        join_or_dash(&task_ids),
+                        join_or_dash(&statuses)
+                    ));
+                }
+            }
         }
 
         out
@@ -319,6 +345,22 @@ impl SwarmRunArtifact {
             }
         }
         by_agent
+    }
+
+    /// Assert that a given agent was assigned the expected task.
+    pub fn assert_agent_has_task(&self, agent_id: &str, task_id: &str) -> Result<(), String> {
+        let by_agent = self.tasks_by_agent();
+        let tasks = by_agent
+            .get(agent_id)
+            .ok_or_else(|| format!("agent `{agent_id}` not found in artifact"))?;
+
+        if tasks.iter().any(|task| task.id == task_id) {
+            Ok(())
+        } else {
+            Err(format!(
+                "agent `{agent_id}` was not assigned task `{task_id}`"
+            ))
+        }
     }
 
     fn task(&self, task_id: &str) -> Option<&SwarmTaskRecord> {

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -7,10 +7,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use futures::future::BoxFuture;
 use mofa_foundation::swarm::{
-    FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmScheduler,
-    SwarmSchedulerConfig, SwarmSubtask,
+    AuditEvent, AuditEventKind, FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG,
+    SubtaskStatus, SwarmMetrics, SwarmResult, SwarmScheduler, SwarmSchedulerConfig, SwarmStatus,
+    SwarmSubtask, CoordinationPattern,
 };
 use mofa_kernel::agent::types::error::GlobalError;
 use mofa_testing::SwarmRunArtifact;
@@ -127,7 +129,7 @@ async fn swarm_artifact_surfaces_failed_orchestration_state() {
 
     let err = artifact.assert_all_completed().unwrap_err();
     assert!(err.contains("approve"));
-    assert!(artifact.to_markdown().contains("failed (approval rejected)"));
+    assert!(artifact.to_markdown().contains("approval rejected"));
     assert!(artifact.to_json().contains("\"outcome\": \"failure\""));
     let approve = dag.find_by_id("approve").unwrap();
     let notify = dag.find_by_id("notify").unwrap();
@@ -136,4 +138,54 @@ async fn swarm_artifact_surfaces_failed_orchestration_state() {
         SubtaskStatus::Failed(_)
     ));
     assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Skipped);
+}
+
+#[tokio::test]
+async fn swarm_artifact_from_swarm_result_captures_metrics_and_audit() {
+    let dag = workflow_dag();
+
+    let mut metrics = SwarmMetrics::default();
+    metrics.record_task_completed();
+    metrics.record_task_completed();
+    metrics.record_task_failed();
+    metrics.record_hitl_intervention();
+    metrics.record_reassignment();
+    metrics.record_agent_tokens("reviewer", 120);
+    metrics.record_agent_tokens("analyst", 60);
+    metrics.set_duration_ms(321);
+
+    let audit_events = vec![
+        AuditEvent::new(AuditEventKind::SwarmStarted, "Swarm started")
+            .with_data(serde_json::json!({"swarm_id":"support-escalation"})),
+        AuditEvent::new(AuditEventKind::AgentReassigned, "Reviewer took over approve")
+            .with_data(serde_json::json!({"subtask_id":"approve","new_agent":"reviewer"})),
+        AuditEvent::new(AuditEventKind::SwarmCompleted, "Swarm completed")
+            .with_data(serde_json::json!({"swarm_id":"support-escalation"})),
+    ];
+
+    let result = SwarmResult {
+        config_id: "cfg-1".into(),
+        status: SwarmStatus::Completed,
+        dag,
+        output: Some("customer notified".into()),
+        metrics,
+        audit_events,
+        started_at: Utc::now(),
+        completed_at: Some(Utc::now()),
+    };
+
+    let artifact =
+        SwarmRunArtifact::from_swarm_result(&result, CoordinationPattern::Parallel, None);
+
+    artifact.assert_metrics(1, 1).unwrap();
+    artifact
+        .assert_audit_event_kind(AuditEventKind::AgentReassigned)
+        .unwrap();
+    assert_eq!(artifact.swarm_status, Some(SwarmStatus::Completed));
+    assert_eq!(artifact.output.as_deref(), Some("customer notified"));
+    assert_eq!(artifact.metrics.as_ref().unwrap().agent_tokens["reviewer"], 120);
+    assert!(artifact.to_markdown().contains("## Metrics"));
+    assert!(artifact.to_markdown().contains("## Audit Trail"));
+    assert!(artifact.to_markdown().contains("agent_reassigned"));
+    assert!(artifact.to_json().contains("\"hitl_interventions\": 1"));
 }

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -1,0 +1,136 @@
+//! Integration tests for swarm/orchestrator testing artifacts and assertions.
+//!
+//! Covers multi-agent task decomposition, orchestration state assertions,
+//! fail-fast cascade behavior, and the visual markdown/JSON artifacts exposed
+//! by `mofa-testing` for maintainers and CI review.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use mofa_foundation::swarm::{
+    FailurePolicy, ParallelScheduler, RiskLevel, SubtaskDAG, SubtaskStatus, SwarmScheduler,
+    SwarmSchedulerConfig, SwarmSubtask,
+};
+use mofa_kernel::agent::types::error::GlobalError;
+use mofa_testing::SwarmRunArtifact;
+
+fn workflow_dag() -> SubtaskDAG {
+    let mut dag = SubtaskDAG::new("support-escalation");
+    let classify = dag.add_task(
+        SwarmSubtask::new("classify", "Classify inbound request")
+            .with_capabilities(vec!["triage".into()]),
+    );
+    let investigate = dag.add_task(
+        SwarmSubtask::new("investigate", "Investigate account state")
+            .with_capabilities(vec!["lookup".into()])
+            .with_risk_level(RiskLevel::Medium),
+    );
+    let approve = dag.add_task(
+        SwarmSubtask::new("approve", "Approve account change")
+            .with_capabilities(vec!["approval".into()])
+            .with_risk_level(RiskLevel::High),
+    );
+    let notify = dag.add_task(
+        SwarmSubtask::new("notify", "Notify customer")
+            .with_capabilities(vec!["email".into()]),
+    );
+
+    dag.add_dependency(classify, investigate).unwrap();
+    dag.add_dependency(investigate, approve).unwrap();
+    dag.add_dependency(approve, notify).unwrap();
+
+    dag.assign_agent(classify, "router");
+    dag.assign_agent(investigate, "analyst");
+    dag.assign_agent(approve, "reviewer");
+    dag.assign_agent(notify, "notifier");
+
+    dag
+}
+
+#[tokio::test]
+async fn swarm_artifact_captures_decomposition_and_collaboration() {
+    let mut dag = workflow_dag();
+
+    let exec = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            Ok(format!("{} completed by {}", task.id, task.assigned_agent.unwrap()))
+        })
+    });
+
+    let scheduler = ParallelScheduler::new();
+    let summary = scheduler.execute(&mut dag, exec).await.unwrap();
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    artifact.assert_all_completed().unwrap();
+    artifact.assert_counts(4, 0, 0).unwrap();
+    artifact.assert_dependency("approve", "investigate").unwrap();
+    artifact
+        .assert_task_status("approve", SubtaskStatus::Completed)
+        .unwrap();
+    artifact
+        .assert_output_contains("notify", "notifier")
+        .unwrap();
+
+    let by_agent = artifact.tasks_by_agent();
+    assert_eq!(by_agent["reviewer"][0].id, "approve");
+    assert!(artifact.tasks.iter().any(|task| task.id == "approve" && task.hitl_required));
+    assert!(artifact
+        .to_markdown()
+        .contains("graph TD"));
+    assert!(artifact.to_markdown().contains("approve"));
+    assert!(artifact.to_json().contains("\"assigned_agent\": \"reviewer\""));
+
+    let approve_task = artifact
+        .tasks
+        .iter()
+        .find(|task| task.id == "approve")
+        .unwrap();
+    assert_eq!(approve_task.risk_level, RiskLevel::High);
+    let notify_task = artifact.tasks.iter().find(|task| task.id == "notify").unwrap();
+    assert_eq!(notify_task.dependencies, vec!["approve".to_string()]);
+    let approve = dag.find_by_id("approve").unwrap();
+    let notify = dag.find_by_id("notify").unwrap();
+    assert_eq!(dag.get_task(approve).unwrap().status, SubtaskStatus::Completed);
+    assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Completed);
+}
+
+#[tokio::test]
+async fn swarm_artifact_surfaces_failed_orchestration_state() {
+    let mut dag = workflow_dag();
+
+    let exec = Arc::new(|_idx, task: SwarmSubtask| -> BoxFuture<'static, _> {
+        Box::pin(async move {
+            if task.id == "approve" {
+                Err(GlobalError::runtime("approval rejected"))
+            } else {
+                Ok(format!("{} ok", task.id))
+            }
+        })
+    });
+
+    let mut config = SwarmSchedulerConfig::default();
+    config.failure_policy = FailurePolicy::FailFastCascade;
+    let scheduler = ParallelScheduler::with_config(config);
+    let summary = scheduler.execute(&mut dag, exec).await.unwrap();
+    let artifact = SwarmRunArtifact::from_scheduler_run(&dag, &summary);
+
+    artifact.assert_counts(2, 1, 1).unwrap();
+    artifact.assert_task_failed_contains("approve", "approval rejected").unwrap();
+    artifact
+        .assert_task_status("notify", SubtaskStatus::Skipped)
+        .unwrap();
+
+    let err = artifact.assert_all_completed().unwrap_err();
+    assert!(err.contains("approve"));
+    assert!(artifact.to_markdown().contains("failed (approval rejected)"));
+    assert!(artifact.to_json().contains("\"outcome\": \"failure\""));
+    let approve = dag.find_by_id("approve").unwrap();
+    let notify = dag.find_by_id("notify").unwrap();
+    assert!(matches!(
+        dag.get_task(approve).unwrap().status,
+        SubtaskStatus::Failed(_)
+    ));
+    assert_eq!(dag.get_task(notify).unwrap().status, SubtaskStatus::Skipped);
+}

--- a/tests/tests/swarm_testing_tests.rs
+++ b/tests/tests/swarm_testing_tests.rs
@@ -75,11 +75,14 @@ async fn swarm_artifact_captures_decomposition_and_collaboration() {
 
     let by_agent = artifact.tasks_by_agent();
     assert_eq!(by_agent["reviewer"][0].id, "approve");
+    artifact.assert_agent_has_task("reviewer", "approve").unwrap();
     assert!(artifact.tasks.iter().any(|task| task.id == "approve" && task.hitl_required));
     assert!(artifact
         .to_markdown()
         .contains("graph TD"));
     assert!(artifact.to_markdown().contains("approve"));
+    assert!(artifact.to_markdown().contains("Agent Collaboration View"));
+    assert!(artifact.to_markdown().contains("| reviewer | approve |"));
     assert!(artifact.to_json().contains("\"assigned_agent\": \"reviewer\""));
 
     let approve_task = artifact


### PR DESCRIPTION
## Summary

Add a Rust-based GUI for swarm testing artifacts so orchestrator runs can be triggered and inspected visually instead of only through Markdown/JSON output.

This PR is rebased on #1449 which adds visual swarm and orchestrator testing artifacts including SwarmRunArtifact, swarm specific assertions, Markdown/JSON rendering, integration tests, and the runnable incident response. On it, the pr introduces a Leptos + Trunk frontend under `tests/gui/` and a small Rust HTTP backend under `tests/gui/server/` that runs the existing incident response demo swarm and serves the latest `SwarmRunArtifact`.

## What Changed
[Screencast from 2026-03-24 22-43-09.webm](https://github.com/user-attachments/assets/5e03ee85-0182-41bc-90d0-d9a2cc202767)

## GUI

- Added a Leptos WASM viewer in `tests/gui/src/main.rs`
- Added page shell and Mermaid bootstrap in `tests/gui/index.html`
- Added styling in `tests/gui/src/style.css`
- Added GUI manifest in `tests/gui/Cargo.toml`

## Backend

- Added a small Axum server in `tests/gui/server/src/main.rs`
- Added server manifest in `tests/gui/server/Cargo.toml`

## Integration Flow

- `POST /swarm/run` triggers the demo incident response swarm
- `GET /swarm/artifact` returns the latest generated `SwarmRunArtifact`
- The GUI can:
  - trigger a swarm run
  - fetch the latest artifact
  - render summary, dependency graph, tasks, execution trace, agent collaboration, metrics, audit trail, and raw JSON

## Why

The existing swarm testing artifact work already produces strong Markdown and JSON outputs for CI and PR review. This adds an interactive inspection layer for local development and demos, making it easier to validate:

- task decomposition
- dependency relationships
- agent ownership
- execution ordering
- metrics
- audit events


## Files Changed

#### `tests/gui/Cargo.toml`

- Added the Leptos WASM frontend crate manifest.
- Added frontend dependencies for Leptos, JSON parsing, HTTP requests, file input, and WASM interop.
- Marked it as its own workspace root so Trunk can build it independently.

#### `tests/gui/index.html`

- Added the Trunk entry HTML for the GUI.
- Wired in the Rust app bootstrap and stylesheet.
- Added Mermaid initialization for dependency graph rendering in the browser.

#### `tests/gui/src/main.rs`

- Implemented the Leptos client app for the swarm artifact viewer.
- Added file upload, raw JSON paste, backend run trigger, and latest artifact fetch actions.
- Rendered summary cards, dependency graph, tasks, execution trace, agent collaboration, metrics, audit trail, and raw JSON.

#### `tests/gui/src/style.css`

- Added the full visual styling for the GUI.
- Styled layout, panels, controls, cards, tables, Mermaid container, raw JSON block, and responsive behavior.
- Tuned spacing and page padding after UI review.

#### `tests/gui/server/Cargo.toml`

- Added the backend server crate manifest.
- Added Axum, Tokio, CORS, JSON, and timing dependencies.
- Wired local path dependencies to `mofa-testing`, `mofa-foundation`, and `mofa-kernel`.

#### `tests/gui/server/src/main.rs`

- Implemented the Axum backend for the GUI.
- Added `POST /swarm/run` to execute the demo incident-response swarm.
- Added `GET /swarm/artifact` to return the most recent generated artifact.
- Built a richer artifact using `SwarmResult` so the GUI receives status, output, metrics, and audit events.
- Added module, function, and flow comments for the backend lifecycle.


# How To Run

Backend:

```bash
cd tests/gui/server
cargo run
```

Frontend:

```bash
cd tests/gui
NO_COLOR=false trunk serve
```

Then open `http://127.0.0.1:8080/` and click `Run Swarm`.

## Notes
- This PR is intended as a follow up to the swarm artifact/testing work, not a replacement for the existing Markdown/JSON artifact flow.
