### PR TITLE
fix(kernel): add tracing instrumentation to CircuitBreakerState trans…

### DIFF
--- a/crates/mofa-kernel/src/workflow/policy.rs
+++ b/crates/mofa-kernel/src/workflow/policy.rs
@@ -181,6 +181,10 @@ impl CircuitBreakerState {
         if inner.state == CircuitState::HalfOpen {
             inner.state = CircuitState::Closed;
             inner.opened_at = None;
+            tracing::info!(
+                circuit.transition = "HalfOpen -> Closed",
+                "circuit breaker recovered after successful probe"
+            );
         }
     }
 
@@ -198,8 +202,15 @@ impl CircuitBreakerState {
                 && inner.consecutive_failures >= inner.open_after);
 
         if should_open {
+            let prev = inner.state;
             inner.state = CircuitState::Open;
             inner.opened_at = Some(Instant::now());
+            tracing::warn!(
+                circuit.transition = %format!("{prev:?} -> Open"),
+                consecutive_failures = inner.consecutive_failures,
+                threshold = inner.open_after,
+                "circuit breaker opened — node requests will be short-circuited"
+            );
         }
     }
 
@@ -229,6 +240,10 @@ impl CircuitBreakerState {
             && let Some(opened_at) = inner.opened_at
                 && opened_at.elapsed() >= inner.reset_after {
                     inner.state = CircuitState::HalfOpen;
+                    tracing::info!(
+                        circuit.transition = "Open -> HalfOpen",
+                        "circuit breaker entering probe state — one request will be allowed through"
+                    );
                 }
         inner.state
     }
@@ -241,9 +256,14 @@ impl CircuitBreakerState {
     /// Force-close the circuit (useful for testing or operator override).
     pub async fn force_close(&self) {
         let mut inner = self.inner.write().await;
+        let prev = inner.state;
         inner.state = CircuitState::Closed;
         inner.consecutive_failures = 0;
         inner.opened_at = None;
+        tracing::info!(
+            circuit.transition = %format!("{prev:?} -> Closed"),
+            "circuit breaker force-closed by operator"
+        );
     }
 
     /// Returns the current consecutive failure count.


### PR DESCRIPTION
…itions

CircuitBreakerState transitions (Closed→Open, Open→HalfOpen, HalfOpen→Closed) were completely silent — no logs, no metrics. In production workflows calling external APIs or LLM providers, operators had zero visibility into which nodes' circuits were tripping.

Add tracing::warn! on circuit open (with failure count and threshold) and tracing::info! on recovery (HalfOpen→Closed), probe entry (Open→HalfOpen), and force-close operations.

Closes #1467

## 📋 Summary

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->

## 🔗 Related Issues

Closes #

Related to #

---

## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- 
- 
- 

---

## 🧪 How you Tested

<!--
Provide clear steps for reviewers to validate the change.
Include commands, endpoints, or scenarios.
-->

1. 
2. 
3. 

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [ ] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [ ] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [ ] Branch is up to date with `main`
- [ ] No unrelated commits
- [ ] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->

---

## 🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->