### PR TITLE
fix(runtime): use notify_waiters() in AgentInterrupt::trigger() to wake all concurrent tasks (#1473)

### DIFF
--- a/crates/mofa-runtime/src/interrupt.rs
+++ b/crates/mofa-runtime/src/interrupt.rs
@@ -23,12 +23,27 @@ impl AgentInterrupt {
         }
     }
 
-    // 触发中断
-    // Trigger interrupt
+    // 触发中断 — 唤醒所有等待的任务
+    // Trigger interrupt — wake ALL waiting tasks
     pub fn trigger(&self) {
         self.is_interrupted
             .store(true, std::sync::atomic::Ordering::SeqCst);
-        self.notify.notify_one();
+        self.notify.notify_waiters();
+    }
+
+    // 异步等待中断信号
+    // Asynchronously wait for an interrupt signal.
+    // Uses a loop to handle the race where a task calls wait() after
+    // trigger()/notify_waiters() has already drained.
+    pub async fn wait(&self) {
+        loop {
+            if self.is_interrupted
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return;
+            }
+            self.notify.notified().await;
+        }
     }
 
     // 检查是否中断


### PR DESCRIPTION
## Summary

Fixes #1473

AgentInterrupt::trigger() used notify_one() which only wakes **one** waiting task. When multiple concurrent tasks (parallel nodes, background streamers, periodic runners) share the same AgentInterrupt, all tasks except one silently miss the interrupt signal and become zombies - consuming CPU, making LLM API calls, and mutating state indefinitely.

## Changes

### crates/mofa-runtime/src/interrupt.rs

1. trigger(): Replace notify_one() with notify_waiters() to broadcast the interrupt signal to **all** waiting tasks, matching the broadcast cancellation semantics that AgentInterrupt is designed to provide.
2. New wait() method: Added an async wait() method with a defensive loop that re-checks the AtomicBool flag after each Notify wakeup. This handles the race where a task calls wait() after trigger()/notify_waiters() has already drained.
## Testing

- cargo check -p mofa-runtime passes with no errors
- - The fix is a minimal, targeted change (1 method modified, 1 method added) with no API breakage