### PR TITLE
Stabilize foundation enums for forward-compatible API evolution

### DIFF
--- a/crates/mofa-foundation/src/collaboration/types.rs
+++ b/crates/mofa-foundation/src/collaboration/types.rs
@@ -98,6 +98,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
+#[non_exhaustive]
 pub enum CollaborationMode {
     /// 请求-响应模式：适合一对一的确定性任务
     /// Request-Response mode: suitable for one-to-one deterministic tasks
@@ -188,6 +189,7 @@ pub struct CollaborationMessage {
 /// 支持多种内容格式，方便 LLM 理解和处理
 /// Supports multiple content formats for easy LLM understanding and processing
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum CollaborationContent {
     /// 纯文本内容（自然语言）
     /// Plain text content (natural language)

--- a/crates/mofa-foundation/src/hardware.rs
+++ b/crates/mofa-foundation/src/hardware.rs
@@ -2,6 +2,7 @@ use std::env::consts;
 
 /// Represents the operating system of the host machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OsClassification {
     MacOS,
     Windows,
@@ -11,6 +12,7 @@ pub enum OsClassification {
 
 /// Represents the CPU family/architecture of the host machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CpuFamily {
     AppleSilicon,
     X86_64,
@@ -20,6 +22,7 @@ pub enum CpuFamily {
 
 /// The type of GPU acceleration detected on the host.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GpuType {
     /// Apple Metal (available on all macOS 10.14+ devices, both Intel and Apple Silicon).
     Metal,

--- a/crates/mofa-foundation/src/secretary/default/types.rs
+++ b/crates/mofa-foundation/src/secretary/default/types.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 /// Todo 任务状态
 /// Todo task status
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TodoStatus {
     /// 待处理
     /// Pending
@@ -42,6 +43,7 @@ pub enum TodoStatus {
 /// Todo 任务优先级
 /// Todo task priority
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TodoPriority {
     Low = 0,
     Medium = 1,
@@ -270,6 +272,7 @@ pub struct CriticalDecision {
 /// 决策类型
 /// Decision type
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum DecisionType {
     /// 需求澄清
     /// Requirement clarification
@@ -353,6 +356,7 @@ pub struct Report {
 /// 汇报类型
 /// Report type
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
 pub enum ReportType {
     /// 任务完成汇报
     /// Task completion report
@@ -376,6 +380,7 @@ pub enum ReportType {
 /// 秘书 Agent 与执行 Agent 之间的 A2A 消息
 /// A2A message between Secretary Agent and Execution Agent
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SecretaryMessage {
     /// 分配任务
     /// Assign task
@@ -415,6 +420,7 @@ pub enum SecretaryMessage {
 /// 任务执行状态
 /// Task execution status
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum TaskExecutionStatus {
     /// 已接收
     /// Received
@@ -444,6 +450,7 @@ pub enum TaskExecutionStatus {
 /// 默认用户输入
 /// Default user input
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum DefaultInput {
     /// 新想法/需求
     /// New idea/requirement
@@ -470,6 +477,7 @@ pub enum DefaultInput {
 /// 查询类型
 /// Query type
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum QueryType {
     /// 获取 Todo 列表
     /// Get Todo list
@@ -491,6 +499,7 @@ pub enum QueryType {
 /// 秘书命令
 /// Secretary command
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum SecretaryCommand {
     /// 开始澄清某个 Todo
     /// Start clarifying a specific Todo
@@ -518,6 +527,7 @@ pub enum SecretaryCommand {
 /// 默认秘书输出
 /// Default secretary output
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum DefaultOutput {
     /// 确认消息
     /// Acknowledgment message
@@ -548,6 +558,7 @@ pub enum DefaultOutput {
 /// 秘书 Agent 工作阶段
 /// Secretary Agent work phase
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum WorkPhase {
     /// 阶段1: 接收想法
     /// Phase 1: Receiving idea

--- a/docs/mofa-doc/src/coding-standards/spec.md
+++ b/docs/mofa-doc/src/coding-standards/spec.md
@@ -35,6 +35,7 @@ pub enum KernelError {
 ### 1. Enum Extensibility
 
 - **MUST** add the `#[non_exhaustive]` attribute to public enums to ensure backward compatibility
+- **MUST** treat foundation-facing public enums as forward-compatible API surface; additive variants should not require downstream exhaustive-match rewrites
 
 ```rust
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Summary for this : - 

This PR improves API stability in the foundation layer by marking externally exposed enums as non-exhaustive where downstream consumers are expected to match on variants.

Why this change:-

Today, consumers can write exhaustive matches against several public enums. That creates an avoidable breaking-change risk: adding a new variant in a future release can fail downstream builds even when the upstream change is additive.
By using #[non_exhaustive], we preserve room for safe enum evolution and reduce upgrade friction for users.

What changed:-

Added #[non_exhaustive] to public hardware enums in [hardware.rs](vscode-file://vscode-app/c:/Users/princ/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added #[non_exhaustive] to collaboration-facing enums in [types.rs](vscode-file://vscode-app/c:/Users/princ/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added #[non_exhaustive] to default secretary public enums in [types.rs](vscode-file://vscode-app/c:/Users/princ/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added an explicit compatibility policy note to the coding standards in [spec.md](vscode-file://vscode-app/c:/Users/princ/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Impact
This is an API-compatibility hardening change.
No runtime behavior is changed.
The update clarifies and enforces a forward-compatibility contract for public foundation enums.

Validation
Ran crate tests for foundation:
cargo test -p mofa-foundation
Result: passing (unit, integration, and doc tests).



Closes : #1373 