### PR TITLE
test(dag): property-based tests for SubtaskDAG structural invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1295,7 +1295,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1303,6 +1312,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -3451,7 +3466,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -3461,7 +3476,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -3471,7 +3486,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex-automata",
  "regex-syntax",
 ]
@@ -5883,6 +5898,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "petgraph 0.7.1",
+ "proptest",
  "qdrant-client",
  "ractor",
  "rand 0.8.5",
@@ -7476,6 +7492,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7671,6 +7706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7852,6 +7893,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -8595,6 +8645,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -10729,6 +10791,12 @@ dependencies = [
  "serde",
  "spin 0.10.0",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/crates/mofa-foundation/Cargo.toml
+++ b/crates/mofa-foundation/Cargo.toml
@@ -172,6 +172,8 @@ workspace = true
 num_enum_derive = "0.7"
 tempfile = "3"
 criterion = { version = "0.5", features = ["html_reports"] }
+# property-based testing for DAG invariants
+proptest = "1"
 
 [[bench]]
 name = "context_compression"

--- a/crates/mofa-foundation/src/swarm/dag.rs
+++ b/crates/mofa-foundation/src/swarm/dag.rs
@@ -1004,3 +1004,226 @@ mod tests {
         assert_eq!(dag.critical_path_duration_secs().unwrap(), 0);
     }
 }
+
+// ── Property-based tests ──────────────────────────────────────────────────────
+//
+// These tests use proptest to generate tens of thousands of random DAG
+// topologies and verify structural invariants that hand-written unit tests
+// cannot exhaustively cover.
+//
+// The core risk this guards against: an LLM decomposes a goal into a
+// SubtaskDAG but its output is non-deterministic and may accidentally
+// encode cyclic dependencies (e.g. task A requires B, B requires A).
+// A cycle in the DAG causes the scheduler to spin forever -- a silent
+// deadlock with no error message.  These properties confirm the guard
+// holds across arbitrary random graphs.
+#[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::collections::HashMap;
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    /// Build a DAG with `task_count` nodes, then attempt to insert every
+    /// (from, to) pair from `edges`.  Cycle-creating edges are silently
+    /// discarded by `add_dependency`; valid edges are kept.
+    fn build_random_dag(
+        task_count: usize,
+        edges: &[(usize, usize)],
+    ) -> (SubtaskDAG, Vec<NodeIndex>) {
+        let mut dag = SubtaskDAG::new("pbt");
+        let indices: Vec<NodeIndex> = (0..task_count)
+            .map(|i| dag.add_task(SwarmSubtask::new(format!("t{i}"), format!("task {i}"))))
+            .collect();
+
+        for &(f, t) in edges {
+            let from = indices[f % task_count];
+            let to = indices[t % task_count];
+            if from != to {
+                let _ = dag.add_dependency(from, to);
+            }
+        }
+
+        (dag, indices)
+    }
+
+    // ── properties ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        /// After any sequence of add_dependency calls the graph must be acyclic.
+        ///
+        /// `topological_order()` uses petgraph's Kahn algorithm and returns
+        /// `Err` if and only if the graph contains a cycle.  A successful
+        /// return here proves no cycle was leaked into the graph regardless
+        /// of the random edge sequence attempted.
+        #[test]
+        fn dag_is_always_acyclic_after_random_insertions(
+            task_count in 2usize..=15usize,
+            edges in proptest::collection::vec(
+                (0usize..15usize, 0usize..15usize),
+                0usize..30usize,
+            ),
+        ) {
+            let (dag, _) = build_random_dag(task_count, &edges);
+            prop_assert!(
+                dag.topological_order().is_ok(),
+                "cycle detected after {} attempted insertions on {} nodes",
+                edges.len(),
+                task_count,
+            );
+        }
+
+        /// When add_dependency returns Err (cycle attempt), the edge must not
+        /// be retained in the graph.
+        ///
+        /// Strategy: build a valid DAG, record its edge count, then attempt a
+        /// known back-edge (last node in topological order -> first node).
+        /// If the call returns Err the edge count must be unchanged.
+        #[test]
+        fn rejected_cycle_edge_does_not_increase_edge_count(
+            task_count in 2usize..=10usize,
+            edges in proptest::collection::vec(
+                (0usize..10usize, 0usize..10usize),
+                0usize..15usize,
+            ),
+        ) {
+            let (mut dag, _) = build_random_dag(task_count, &edges);
+
+            if let Ok(order) = dag.topological_order() {
+                if order.len() >= 2 {
+                    let tail = *order.last().unwrap();
+                    let head = order[0];
+                    let count_before = dag.graph.edge_count();
+                    let result = dag.add_dependency(tail, head);
+                    if result.is_err() {
+                        prop_assert_eq!(
+                            dag.graph.edge_count(),
+                            count_before,
+                            "edge count changed after a rejected (cyclic) add_dependency"
+                        );
+                    }
+                }
+            }
+        }
+
+        /// Every task returned by ready_tasks() must have all hard
+        /// (Sequential / DataFlow) predecessors in a terminal state.
+        ///
+        /// This is the scheduler safety invariant: if a ready task has an
+        /// unsatisfied hard dependency the scheduler would start it too early,
+        /// producing incorrect results or data races.
+        #[test]
+        fn ready_tasks_have_all_hard_dependencies_satisfied(
+            task_count in 2usize..=12usize,
+            edges in proptest::collection::vec(
+                (0usize..12usize, 0usize..12usize),
+                0usize..20usize,
+            ),
+            complete_count in 0usize..=12usize,
+        ) {
+            let (mut dag, indices) = build_random_dag(task_count, &edges);
+
+            // Simulate partial execution: mark the first N ready tasks complete
+            // in topological order so the state is consistent.
+            let to_complete = complete_count.min(task_count);
+            if let Ok(order) = dag.topological_order() {
+                for &idx in order.iter().take(to_complete) {
+                    // only mark if actually ready (all deps satisfied)
+                    if dag.ready_tasks().contains(&idx) {
+                        dag.mark_complete(idx);
+                    }
+                }
+            }
+            let _ = indices; // suppress unused warning
+
+            for &ready_idx in &dag.ready_tasks() {
+                for edge in dag.graph.edges_directed(ready_idx, Direction::Incoming) {
+                    let dep = &dag.graph[edge.source()];
+                    match edge.weight().kind {
+                        DependencyKind::Sequential | DependencyKind::DataFlow => {
+                            prop_assert!(
+                                matches!(
+                                    dep.status,
+                                    SubtaskStatus::Completed
+                                        | SubtaskStatus::Skipped
+                                        | SubtaskStatus::Failed(_)
+                                ),
+                                "ready task has an unsatisfied hard dependency (status: {:?})",
+                                dep.status
+                            );
+                        }
+                        DependencyKind::Soft => {}
+                    }
+                }
+            }
+        }
+
+        /// For every edge (u -> v) in the graph, u must appear before v in
+        /// the topological order returned by topological_order().
+        ///
+        /// Violated topological ordering means the scheduler would hand a
+        /// task to an agent before its dependency has produced output.
+        #[test]
+        fn topological_order_respects_every_dependency_edge(
+            task_count in 2usize..=15usize,
+            edges in proptest::collection::vec(
+                (0usize..15usize, 0usize..15usize),
+                0usize..25usize,
+            ),
+        ) {
+            let (dag, _) = build_random_dag(task_count, &edges);
+
+            if let Ok(order) = dag.topological_order() {
+                let position: HashMap<NodeIndex, usize> =
+                    order.iter().enumerate().map(|(pos, &idx)| (idx, pos)).collect();
+
+                for edge in dag.graph.edge_indices() {
+                    let (u, v) = dag.graph.edge_endpoints(edge).unwrap();
+                    prop_assert!(
+                        position[&u] < position[&v],
+                        "topological order violated: node {:?} (pos {}) must precede {:?} (pos {})",
+                        u,
+                        position[&u],
+                        v,
+                        position[&v],
+                    );
+                }
+            }
+        }
+
+        /// progress() must be non-decreasing as tasks are marked terminal.
+        ///
+        /// A regression here would mean the UI / monitoring layer could show
+        /// execution going backwards, breaking operator trust in the dashboard.
+        #[test]
+        fn progress_never_decreases_as_tasks_complete(
+            task_count in 1usize..=10usize,
+            edges in proptest::collection::vec(
+                (0usize..10usize, 0usize..10usize),
+                0usize..15usize,
+            ),
+        ) {
+            let (mut dag, _) = build_random_dag(task_count, &edges);
+            let mut last = dag.progress();
+
+            if let Ok(order) = dag.topological_order() {
+                for idx in order {
+                    dag.mark_complete(idx);
+                    let current = dag.progress();
+                    prop_assert!(
+                        current >= last,
+                        "progress decreased from {last} to {current} after mark_complete"
+                    );
+                    last = current;
+                }
+                prop_assert!(
+                    (last - 1.0_f64).abs() < f64::EPSILON,
+                    "progress must be 1.0 after all tasks complete, got {last}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

The `SubtaskDAG` is the backbone of the entire swarm execution pipeline. Every agent assignment, HITL gate decision, and scheduler step depends on the DAG being structurally correct. A single LLM output that accidentally encodes a cyclic dependency — `A requires B, B requires A` — causes the scheduler to block forever waiting for a task that can never start. This is a silent deadlock with no error message.

The existing `test_cycle_detection` unit test covers a single two-node case. That is not enough. LLM output is non-deterministic. The actual failure mode involves arbitrary graph shapes across 5–20 nodes with complex dependency patterns that no human tester can enumerate manually.

**Property-based testing (PBT) with proptest** generates tens of thousands of random topologies automatically and checks that structural invariants hold across all of them. This is the only practical way to build confidence in DAG correctness.

## What was changed

Added a `prop_tests` module inside `mofa-foundation/src/swarm/dag.rs` with five properties, each targeting a distinct failure mode:


<img width="1179" height="412" alt="Screenshot 2026-03-28 at 12 14 33 PM" src="https://github.com/user-attachments/assets/7038bde4-2e78-4e60-8c36-348ce45530cc" />

### Property 1 — DAG is always acyclic

After any random sequence of `add_dependency` calls (cycle attempts silently rejected), `topological_order()` must return `Ok`. Runs 10 000 cases across graphs of 2–15 nodes with up to 30 attempted edges.

### Property 2 — Rejected edge does not leak into the graph

When `add_dependency` returns `Err` (because the edge would create a cycle), the graph's edge count must be identical to what it was before the call. Guards against the "add then rollback" implementation accidentally keeping the bad edge under any race or logic path.

### Property 3 — Ready tasks have all hard dependencies satisfied

Every task returned by `ready_tasks()` must have all `Sequential` and `DataFlow` predecessors in a terminal state (`Completed`, `Skipped`, or `Failed`). A violation here means the scheduler would hand a task to an agent before the data it depends on exists.

### Property 4 — Topological order respects every edge

For every edge `(u → v)` in the graph, `u` must appear before `v` in the order returned by `topological_order()`. A violation here would cause a scheduler to start downstream tasks before their upstream dependencies finish.

### Property 5 — Progress is monotone

`progress()` must never decrease as tasks are marked terminal. A regression here breaks the monitoring dashboard and operator trust.

## Why this PR exists now

This work directly addresses the feedback received on the GSoC 2026 proposal (Idea 5 — Cognitive Swarm Orchestrator). The mentor specifically highlighted that LLM-generated DAGs are the highest-risk input surface and that PBT should be implemented as early as possible because it catches failure modes that are impossible to enumerate with hand-written unit tests. This PR delivers that coverage before the coding period begins.

## Test results

```
test swarm::dag::prop_tests::dag_is_always_acyclic_after_random_insertions        ... ok
test swarm::dag::prop_tests::rejected_cycle_edge_does_not_increase_edge_count     ... ok
test swarm::dag::prop_tests::ready_tasks_have_all_hard_dependencies_satisfied     ... ok
test swarm::dag::prop_tests::topological_order_respects_every_dependency_edge     ... ok
test swarm::dag::prop_tests::progress_never_decreases_as_tasks_complete           ... ok
```

All 5 properties pass across 10,000 randomly generated topologies each.