### PR TITLE
feat(ffi): introduce typed UniFFI tool contracts alongside legacy JSON payloads

### DIFF
--- a/crates/mofa-ffi/README.md
+++ b/crates/mofa-ffi/README.md
@@ -78,6 +78,24 @@ mofa-sdk (Standard API)
 mofa-runtime, mofa-foundation, mofa-kernel
 ```
 
+## Typed Tool FFI Contracts
+
+The UniFFI tool bridge now supports two tool callback styles:
+
+- `FfiToolCallback`: legacy JSON-string contract
+- `TypedFfiToolCallback`: preferred typed contract for new bindings
+
+For new cross-language tools, prefer the typed path:
+
+- register tools with `register_typed_tool(...)`
+- inspect tool metadata with `list_typed_tools()`
+- execute tools with `execute_typed_tool(...)`
+
+The legacy JSON-string contract remains available for backward compatibility,
+but it should be treated as transitional. New bindings should prefer the typed
+tool contract so invalid payloads produce structured errors instead of silently
+falling back to string outputs.
+
 ## License
 
 Apache-2.0

--- a/crates/mofa-ffi/src/mofa.udl
+++ b/crates/mofa-ffi/src/mofa.udl
@@ -122,6 +122,65 @@ dictionary SessionMessageInfo {
 // Tool System Types
 // ============================================================================
 
+enum ToolValueKind {
+    "Null",
+    "Bool",
+    "Int",
+    "Float",
+    "String",
+    "List",
+    "Object",
+};
+
+dictionary ToolObjectEntry {
+    string key;
+    ToolValue value;
+};
+
+dictionary ToolValue {
+    ToolValueKind kind;
+    boolean? bool_value;
+    i64? int_value;
+    double? float_value;
+    string? string_value;
+    sequence<ToolValue>? list_value;
+    sequence<ToolObjectEntry>? object_entries;
+};
+
+enum ToolSchemaFormat {
+    "JsonSchema",
+};
+
+dictionary TypedToolSchema {
+    ToolSchemaFormat format;
+    ToolValue schema;
+};
+
+dictionary TypedToolInput {
+    ToolValue arguments;
+    string? raw_input;
+};
+
+enum FfiToolErrorKind {
+    "Validation",
+    "Execution",
+    "Serialization",
+    "Unknown",
+};
+
+dictionary FfiToolError {
+    FfiToolErrorKind kind;
+    string message;
+};
+
+dictionary TypedFfiToolResult {
+    boolean success;
+    ToolValue? output;
+    FfiToolError? error;
+};
+
+// Legacy description of a registered tool.
+// Prefer `TypedToolInfo` for new bindings.
 // Description of a registered tool
 dictionary ToolInfo {
     string name;
@@ -129,6 +188,15 @@ dictionary ToolInfo {
     string parameters_schema_json;
 };
 
+// Typed description of a registered tool for new bindings.
+dictionary TypedToolInfo {
+    string name;
+    string description;
+    TypedToolSchema parameters_schema;
+};
+
+// Legacy JSON-string tool result.
+// Prefer `TypedFfiToolResult` for new bindings.
 // Result from executing a tool
 dictionary FfiToolResult {
     boolean success;
@@ -144,6 +212,15 @@ callback interface FfiToolCallback {
     string description();
     string parameters_schema_json();
     FfiToolResult execute(string arguments_json);
+};
+
+// Typed callback interface for foreign-language tool implementations.
+// New bindings should prefer this over `FfiToolCallback`.
+callback interface TypedFfiToolCallback {
+    string name();
+    string description();
+    TypedToolSchema parameters_schema();
+    TypedFfiToolResult execute(TypedToolInput input);
 };
 
 // ============================================================================
@@ -308,16 +385,23 @@ interface ToolRegistry {
     // Create a new empty tool registry
     constructor();
 
-    // Register a foreign-language tool via callback
+    // Register a legacy JSON-string foreign-language tool via callback
     [Throws=MoFaError]
     void register_tool(FfiToolCallback tool);
+
+    // Register a typed foreign-language tool via callback
+    [Throws=MoFaError]
+    void register_typed_tool(TypedFfiToolCallback tool);
 
     // Unregister a tool by name
     [Throws=MoFaError]
     boolean unregister_tool(string name);
 
-    // List all registered tools
+    // List all registered tools through the legacy JSON-string contract
     sequence<ToolInfo> list_tools();
+
+    // List all registered tools through the typed contract
+    sequence<TypedToolInfo> list_typed_tools();
 
     // Get tool names
     sequence<string> list_tool_names();
@@ -328,7 +412,11 @@ interface ToolRegistry {
     // Get the number of registered tools
     u32 tool_count();
 
-    // Execute a tool by name with JSON arguments
+    // Execute a tool by name with JSON arguments (legacy path)
     [Throws=MoFaError]
     FfiToolResult execute_tool(string name, string arguments_json);
+
+    // Execute a tool by name through the typed contract
+    [Throws=MoFaError]
+    TypedFfiToolResult execute_typed_tool(string name, TypedToolInput input);
 };

--- a/crates/mofa-ffi/src/uniffi_bindings.rs
+++ b/crates/mofa-ffi/src/uniffi_bindings.rs
@@ -251,7 +251,275 @@ pub struct SessionMessageInfo {
 // Tool System Types
 // =============================================================================
 
-/// Tool description for listing
+/// Typed FFI value kind for tool schemas, arguments, and outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolValueKind {
+    Null,
+    Bool,
+    Int,
+    Float,
+    String,
+    List,
+    Object,
+}
+
+/// Object entry for a typed FFI value.
+#[derive(Debug, Clone)]
+pub struct ToolObjectEntry {
+    pub key: String,
+    pub value: ToolValue,
+}
+
+/// Typed FFI value used across the UniFFI tool contract.
+#[derive(Debug, Clone)]
+pub struct ToolValue {
+    pub kind: ToolValueKind,
+    pub bool_value: Option<bool>,
+    pub int_value: Option<i64>,
+    pub float_value: Option<f64>,
+    pub string_value: Option<String>,
+    pub list_value: Option<Vec<ToolValue>>,
+    pub object_entries: Option<Vec<ToolObjectEntry>>,
+}
+
+impl ToolValue {
+    fn null() -> Self {
+        Self {
+            kind: ToolValueKind::Null,
+            bool_value: None,
+            int_value: None,
+            float_value: None,
+            string_value: None,
+            list_value: None,
+            object_entries: None,
+        }
+    }
+
+    fn from_json_value(value: serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::Null => Self::null(),
+            serde_json::Value::Bool(v) => Self {
+                kind: ToolValueKind::Bool,
+                bool_value: Some(v),
+                int_value: None,
+                float_value: None,
+                string_value: None,
+                list_value: None,
+                object_entries: None,
+            },
+            serde_json::Value::Number(v) => {
+                if let Some(i) = v.as_i64() {
+                    Self {
+                        kind: ToolValueKind::Int,
+                        bool_value: None,
+                        int_value: Some(i),
+                        float_value: None,
+                        string_value: None,
+                        list_value: None,
+                        object_entries: None,
+                    }
+                } else if let Some(u) = v.as_u64() {
+                    if let Ok(i) = i64::try_from(u) {
+                        Self {
+                            kind: ToolValueKind::Int,
+                            bool_value: None,
+                            int_value: Some(i),
+                            float_value: None,
+                            string_value: None,
+                            list_value: None,
+                            object_entries: None,
+                        }
+                    } else {
+                        Self {
+                            kind: ToolValueKind::Float,
+                            bool_value: None,
+                            int_value: None,
+                            float_value: Some(u as f64),
+                            string_value: None,
+                            list_value: None,
+                            object_entries: None,
+                        }
+                    }
+                } else {
+                    Self {
+                        kind: ToolValueKind::Float,
+                        bool_value: None,
+                        int_value: None,
+                        float_value: v.as_f64(),
+                        string_value: None,
+                        list_value: None,
+                        object_entries: None,
+                    }
+                }
+            }
+            serde_json::Value::String(v) => Self {
+                kind: ToolValueKind::String,
+                bool_value: None,
+                int_value: None,
+                float_value: None,
+                string_value: Some(v),
+                list_value: None,
+                object_entries: None,
+            },
+            serde_json::Value::Array(values) => Self {
+                kind: ToolValueKind::List,
+                bool_value: None,
+                int_value: None,
+                float_value: None,
+                string_value: None,
+                list_value: Some(values.into_iter().map(Self::from_json_value).collect()),
+                object_entries: None,
+            },
+            serde_json::Value::Object(values) => Self {
+                kind: ToolValueKind::Object,
+                bool_value: None,
+                int_value: None,
+                float_value: None,
+                string_value: None,
+                list_value: None,
+                object_entries: Some(
+                    values
+                        .into_iter()
+                        .map(|(key, value)| ToolObjectEntry {
+                            key,
+                            value: Self::from_json_value(value),
+                        })
+                        .collect(),
+                ),
+            },
+        }
+    }
+
+    fn to_json_value(&self) -> MoFaResult<serde_json::Value> {
+        match self.kind {
+            ToolValueKind::Null => Ok(serde_json::Value::Null),
+            ToolValueKind::Bool => self.bool_value.map(serde_json::Value::Bool).ok_or_else(|| {
+                MoFaError::InvalidArgument("ToolValue.bool_value is required".to_string())
+            }),
+            ToolValueKind::Int => self.int_value.map(serde_json::Value::from).ok_or_else(|| {
+                MoFaError::InvalidArgument("ToolValue.int_value is required".to_string())
+            }),
+            ToolValueKind::Float => {
+                let value = self.float_value.ok_or_else(|| {
+                    MoFaError::InvalidArgument("ToolValue.float_value is required".to_string())
+                })?;
+                let number = serde_json::Number::from_f64(value).ok_or_else(|| {
+                    MoFaError::InvalidArgument(format!(
+                        "ToolValue.float_value must be finite, got {}",
+                        value
+                    ))
+                })?;
+                Ok(serde_json::Value::Number(number))
+            }
+            ToolValueKind::String => self
+                .string_value
+                .clone()
+                .map(serde_json::Value::String)
+                .ok_or_else(|| {
+                    MoFaError::InvalidArgument("ToolValue.string_value is required".to_string())
+                }),
+            ToolValueKind::List => {
+                let values = self.list_value.as_ref().ok_or_else(|| {
+                    MoFaError::InvalidArgument("ToolValue.list_value is required".to_string())
+                })?;
+                Ok(serde_json::Value::Array(
+                    values
+                        .iter()
+                        .map(|value| value.to_json_value())
+                        .collect::<Result<Vec<_>, _>>()?,
+                ))
+            }
+            ToolValueKind::Object => {
+                let entries = self.object_entries.as_ref().ok_or_else(|| {
+                    MoFaError::InvalidArgument("ToolValue.object_entries is required".to_string())
+                })?;
+                let mut map = serde_json::Map::with_capacity(entries.len());
+                for entry in entries {
+                    map.insert(entry.key.clone(), entry.value.to_json_value()?);
+                }
+                Ok(serde_json::Value::Object(map))
+            }
+        }
+    }
+}
+
+/// Typed schema format for tool descriptors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolSchemaFormat {
+    JsonSchema,
+}
+
+/// Typed schema descriptor for foreign-language tools.
+#[derive(Debug, Clone)]
+pub struct TypedToolSchema {
+    pub format: ToolSchemaFormat,
+    pub schema: ToolValue,
+}
+
+/// Typed tool input wrapper for foreign-language tools.
+#[derive(Debug, Clone)]
+pub struct TypedToolInput {
+    pub arguments: ToolValue,
+    pub raw_input: Option<String>,
+}
+
+/// Structured error kind for typed FFI tool execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiToolErrorKind {
+    Validation,
+    Execution,
+    Serialization,
+    Unknown,
+}
+
+/// Structured error payload for typed FFI tool execution.
+#[derive(Debug, Clone)]
+pub struct FfiToolError {
+    pub kind: FfiToolErrorKind,
+    pub message: String,
+}
+
+impl FfiToolError {
+    fn validation(message: impl Into<String>) -> Self {
+        Self {
+            kind: FfiToolErrorKind::Validation,
+            message: message.into(),
+        }
+    }
+
+    fn execution(message: impl Into<String>) -> Self {
+        Self {
+            kind: FfiToolErrorKind::Execution,
+            message: message.into(),
+        }
+    }
+}
+
+fn normalize_typed_tool_result(result: TypedFfiToolResult) -> TypedFfiToolResult {
+    if result.success && result.output.is_none() {
+        TypedFfiToolResult {
+            success: false,
+            output: None,
+            error: Some(FfiToolError {
+                kind: FfiToolErrorKind::Validation,
+                message: "Typed FFI tool reported success without an output payload".to_string(),
+            }),
+        }
+    } else if !result.success && result.error.is_none() {
+        TypedFfiToolResult {
+            success: false,
+            output: None,
+            error: Some(FfiToolError {
+                kind: FfiToolErrorKind::Unknown,
+                message: "Typed FFI tool failed without an error payload".to_string(),
+            }),
+        }
+    } else {
+        result
+    }
+}
+
+/// Tool description for listing through the legacy JSON-string contract.
 #[derive(Debug, Clone)]
 pub struct ToolInfo {
     pub name: String,
@@ -259,7 +527,15 @@ pub struct ToolInfo {
     pub parameters_schema_json: String,
 }
 
-/// FFI tool execution result
+/// Tool description for listing through the typed FFI contract.
+#[derive(Debug, Clone)]
+pub struct TypedToolInfo {
+    pub name: String,
+    pub description: String,
+    pub parameters_schema: TypedToolSchema,
+}
+
+/// FFI tool execution result for the legacy JSON-string contract.
 #[derive(Debug, Clone)]
 pub struct FfiToolResult {
     pub success: bool,
@@ -267,12 +543,29 @@ pub struct FfiToolResult {
     pub error: Option<String>,
 }
 
-/// Callback interface for foreign-language tool implementations
+/// Typed FFI tool execution result.
+#[derive(Debug, Clone)]
+pub struct TypedFfiToolResult {
+    pub success: bool,
+    pub output: Option<ToolValue>,
+    pub error: Option<FfiToolError>,
+}
+
+/// Callback interface for foreign-language tool implementations.
+/// This is the legacy JSON-string contract kept for backward compatibility.
 pub trait FfiToolCallback: Send + Sync {
     fn name(&self) -> String;
     fn description(&self) -> String;
     fn parameters_schema_json(&self) -> String;
     fn execute(&self, arguments_json: String) -> FfiToolResult;
+}
+
+/// Typed callback interface for foreign-language tool implementations.
+pub trait TypedFfiToolCallback: Send + Sync {
+    fn name(&self) -> String;
+    fn description(&self) -> String;
+    fn parameters_schema(&self) -> TypedToolSchema;
+    fn execute(&self, input: TypedToolInput) -> TypedFfiToolResult;
 }
 
 // =============================================================================
@@ -979,6 +1272,25 @@ impl CallbackToolAdapter {
     }
 }
 
+/// Adapter that wraps a typed foreign callback into the kernel Tool trait.
+struct TypedCallbackToolAdapter {
+    callback: Arc<dyn TypedFfiToolCallback>,
+    cached_name: String,
+    cached_description: String,
+}
+
+impl TypedCallbackToolAdapter {
+    fn new(callback: Arc<dyn TypedFfiToolCallback>) -> Self {
+        let cached_name = callback.name();
+        let cached_description = callback.description();
+        Self {
+            callback,
+            cached_name,
+            cached_description,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl mofa_kernel::agent::components::tool::Tool for CallbackToolAdapter {
     fn name(&self) -> &str {
@@ -1016,9 +1328,62 @@ impl mofa_kernel::agent::components::tool::Tool for CallbackToolAdapter {
     }
 }
 
+#[async_trait::async_trait]
+impl mofa_kernel::agent::components::tool::Tool for TypedCallbackToolAdapter {
+    fn name(&self) -> &str {
+        &self.cached_name
+    }
+
+    fn description(&self) -> &str {
+        &self.cached_description
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        let schema = self.callback.parameters_schema();
+        match schema.schema.to_json_value() {
+            Ok(value) => value,
+            Err(_) => serde_json::Value::Object(Default::default()),
+        }
+    }
+
+    async fn execute(
+        &self,
+        input: mofa_kernel::agent::components::tool::ToolInput,
+        _ctx: &mofa_kernel::agent::context::AgentContext,
+    ) -> mofa_kernel::agent::components::tool::ToolResult {
+        let typed_input = TypedToolInput {
+            arguments: ToolValue::from_json_value(input.arguments),
+            raw_input: input.raw_input,
+        };
+        let result = normalize_typed_tool_result(self.callback.execute(typed_input));
+
+        if result.success {
+            match result.output {
+                Some(output) => match output.to_json_value() {
+                    Ok(value) => mofa_kernel::agent::components::tool::ToolResult::success(value),
+                    Err(err) => {
+                        mofa_kernel::agent::components::tool::ToolResult::failure(err.to_string())
+                    }
+                },
+                None => mofa_kernel::agent::components::tool::ToolResult::failure(
+                    "Typed FFI tool reported success without an output payload",
+                ),
+            }
+        } else {
+            mofa_kernel::agent::components::tool::ToolResult::failure(
+                result
+                    .error
+                    .map(|err| err.message)
+                    .unwrap_or_else(|| "Unknown typed tool error".to_string()),
+            )
+        }
+    }
+}
+
 /// Registry for managing tools that agents can invoke
 pub struct ToolRegistry {
     inner: StdMutex<mofa_foundation::agent::components::tool::SimpleToolRegistry>,
+    typed_callbacks: StdMutex<HashMap<String, Arc<dyn TypedFfiToolCallback>>>,
 }
 
 impl Default for ToolRegistry {
@@ -1034,29 +1399,52 @@ impl ToolRegistry {
             inner: StdMutex::new(
                 mofa_foundation::agent::components::tool::SimpleToolRegistry::new(),
             ),
+            typed_callbacks: StdMutex::new(HashMap::new()),
         }
     }
 
-    /// Register a foreign-language tool via callback
+    /// Register a foreign-language tool via the legacy JSON-string callback contract.
     pub fn register_tool(&self, tool: Box<dyn FfiToolCallback>) -> Result<(), MoFaError> {
         use mofa_kernel::agent::components::tool::{ToolExt, ToolRegistry as _};
         let adapter = CallbackToolAdapter::new(tool);
+        let tool_name = adapter.cached_name.clone();
         let tool_arc = adapter.into_dynamic();
-        self.inner
+        self.inner.lock().unwrap().register(tool_arc).map_err(
+            |e: mofa_kernel::agent::error::AgentError| MoFaError::ToolError(e.to_string()),
+        )?;
+        self.typed_callbacks.lock().unwrap().remove(&tool_name);
+        Ok(())
+    }
+
+    /// Register a foreign-language tool via the typed callback contract.
+    pub fn register_typed_tool(
+        &self,
+        tool: Box<dyn TypedFfiToolCallback>,
+    ) -> Result<(), MoFaError> {
+        use mofa_kernel::agent::components::tool::{ToolExt, ToolRegistry as _};
+        let callback: Arc<dyn TypedFfiToolCallback> = Arc::from(tool);
+        let adapter = TypedCallbackToolAdapter::new(callback.clone());
+        let tool_arc = adapter.into_dynamic();
+        self.inner.lock().unwrap().register(tool_arc).map_err(
+            |e: mofa_kernel::agent::error::AgentError| MoFaError::ToolError(e.to_string()),
+        )?;
+        self.typed_callbacks
             .lock()
             .unwrap()
-            .register(tool_arc)
-            .map_err(|e: mofa_kernel::agent::error::AgentError| MoFaError::ToolError(e.to_string()))
+            .insert(callback.name(), callback);
+        Ok(())
     }
 
     /// Unregister a tool by name
     pub fn unregister_tool(&self, name: String) -> Result<bool, MoFaError> {
         use mofa_kernel::agent::components::tool::ToolRegistry as _;
-        self.inner
-            .lock()
-            .unwrap()
-            .unregister(&name)
-            .map_err(|e: mofa_kernel::agent::error::AgentError| MoFaError::ToolError(e.to_string()))
+        let removed = self.inner.lock().unwrap().unregister(&name).map_err(
+            |e: mofa_kernel::agent::error::AgentError| MoFaError::ToolError(e.to_string()),
+        )?;
+        if removed {
+            self.typed_callbacks.lock().unwrap().remove(&name);
+        }
+        Ok(removed)
     }
 
     /// List all registered tools
@@ -1071,6 +1459,25 @@ impl ToolRegistry {
                 name: desc.name,
                 description: desc.description,
                 parameters_schema_json: desc.parameters_schema.to_string(),
+            })
+            .collect()
+    }
+
+    /// List all registered tools through the typed FFI contract.
+    pub fn list_typed_tools(&self) -> Vec<TypedToolInfo> {
+        use mofa_kernel::agent::components::tool::ToolRegistry as _;
+        self.inner
+            .lock()
+            .unwrap()
+            .list()
+            .into_iter()
+            .map(|desc| TypedToolInfo {
+                name: desc.name,
+                description: desc.description,
+                parameters_schema: TypedToolSchema {
+                    format: ToolSchemaFormat::JsonSchema,
+                    schema: ToolValue::from_json_value(desc.parameters_schema),
+                },
             })
             .collect()
     }
@@ -1129,11 +1536,183 @@ impl ToolRegistry {
             }),
         }
     }
+
+    /// Execute a tool by name through the typed FFI contract.
+    pub fn execute_typed_tool(
+        &self,
+        name: String,
+        input: TypedToolInput,
+    ) -> Result<TypedFfiToolResult, MoFaError> {
+        if let Some(callback) = self.typed_callbacks.lock().unwrap().get(&name).cloned() {
+            return Ok(normalize_typed_tool_result(callback.execute(input)));
+        }
+
+        use mofa_kernel::agent::components::tool::ToolRegistry as _;
+
+        let registry = self.inner.lock().unwrap();
+        let tool = registry
+            .get(&name)
+            .ok_or_else(|| MoFaError::ToolError(format!("Tool not found: {}", name)))?;
+
+        let arguments = match input.arguments.to_json_value() {
+            Ok(value) => value,
+            Err(err) => {
+                return Ok(TypedFfiToolResult {
+                    success: false,
+                    output: None,
+                    error: Some(FfiToolError::validation(format!(
+                        "Invalid typed tool arguments: {}",
+                        err
+                    ))),
+                });
+            }
+        };
+
+        let runtime =
+            tokio::runtime::Runtime::new().map_err(|e| MoFaError::RuntimeError(e.to_string()))?;
+
+        let ctx = mofa_kernel::agent::context::AgentContext::new("ffi-execution");
+        let result = runtime.block_on(tool.execute_dynamic(arguments, &ctx));
+
+        match result {
+            Ok(output) => Ok(TypedFfiToolResult {
+                success: true,
+                output: Some(ToolValue::from_json_value(output)),
+                error: None,
+            }),
+            Err(e) => Ok(TypedFfiToolResult {
+                success: false,
+                output: None,
+                error: Some(FfiToolError::execution(e.to_string())),
+            }),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EchoTypedTool;
+
+    struct SuccessWithoutOutputTypedTool;
+
+    struct FailureWithoutErrorTypedTool;
+
+    struct EchoLegacyTool;
+
+    impl TypedFfiToolCallback for EchoTypedTool {
+        fn name(&self) -> String {
+            "echo_typed".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Echo typed payload".to_string()
+        }
+
+        fn parameters_schema(&self) -> TypedToolSchema {
+            TypedToolSchema {
+                format: ToolSchemaFormat::JsonSchema,
+                schema: ToolValue::from_json_value(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "message": { "type": "string" }
+                    },
+                    "required": ["message"]
+                })),
+            }
+        }
+
+        fn execute(&self, input: TypedToolInput) -> TypedFfiToolResult {
+            TypedFfiToolResult {
+                success: true,
+                output: Some(input.arguments),
+                error: None,
+            }
+        }
+    }
+
+    impl TypedFfiToolCallback for SuccessWithoutOutputTypedTool {
+        fn name(&self) -> String {
+            "success_without_output".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Returns success without output".to_string()
+        }
+
+        fn parameters_schema(&self) -> TypedToolSchema {
+            TypedToolSchema {
+                format: ToolSchemaFormat::JsonSchema,
+                schema: ToolValue::from_json_value(serde_json::json!({
+                    "type": "object"
+                })),
+            }
+        }
+
+        fn execute(&self, _input: TypedToolInput) -> TypedFfiToolResult {
+            TypedFfiToolResult {
+                success: true,
+                output: None,
+                error: None,
+            }
+        }
+    }
+
+    impl TypedFfiToolCallback for FailureWithoutErrorTypedTool {
+        fn name(&self) -> String {
+            "failure_without_error".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Returns failure without an error payload".to_string()
+        }
+
+        fn parameters_schema(&self) -> TypedToolSchema {
+            TypedToolSchema {
+                format: ToolSchemaFormat::JsonSchema,
+                schema: ToolValue::from_json_value(serde_json::json!({
+                    "type": "object"
+                })),
+            }
+        }
+
+        fn execute(&self, _input: TypedToolInput) -> TypedFfiToolResult {
+            TypedFfiToolResult {
+                success: false,
+                output: None,
+                error: None,
+            }
+        }
+    }
+
+    impl FfiToolCallback for EchoLegacyTool {
+        fn name(&self) -> String {
+            "echo_legacy".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Echo legacy JSON payload".to_string()
+        }
+
+        fn parameters_schema_json(&self) -> String {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "message": { "type": "string" }
+                }
+            })
+            .to_string()
+        }
+
+        fn execute(&self, arguments_json: String) -> FfiToolResult {
+            FfiToolResult {
+                success: true,
+                output_json: arguments_json,
+                error: None,
+            }
+        }
+    }
 
     #[test]
     fn get_last_output_returns_explicit_runtime_error() {
@@ -1175,11 +1754,175 @@ mod tests {
             "[Throws=MoFaError, Name=from_config_file]",
             "[Throws=MoFaError, Name=from_config]",
             "LLMAgentBuilder set_openai_provider(",
+            "dictionary ToolValue",
+            "callback interface TypedFfiToolCallback",
+            "void register_typed_tool(TypedFfiToolCallback tool);",
+            "sequence<TypedToolInfo> list_typed_tools();",
+            "TypedFfiToolResult execute_typed_tool(string name, TypedToolInput input);",
         ] {
             assert!(
                 udl.contains(required),
                 "missing required UDL contract marker: {required}"
             );
         }
+    }
+
+    #[test]
+    fn tool_value_roundtrip_preserves_nested_json() {
+        let json = serde_json::json!({
+            "message": "hello",
+            "count": 3,
+            "flags": [true, false],
+            "meta": {
+                "nested": "value"
+            }
+        });
+
+        let value = ToolValue::from_json_value(json.clone());
+        let roundtrip = value.to_json_value().expect("tool value should roundtrip");
+
+        assert_eq!(roundtrip, json);
+    }
+
+    #[test]
+    fn execute_typed_tool_uses_typed_contract_end_to_end() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_typed_tool(Box::new(EchoTypedTool))
+            .expect("typed tool should register");
+
+        let tools = registry.list_typed_tools();
+        assert!(tools.iter().any(|tool| tool.name == "echo_typed"));
+
+        let input = TypedToolInput {
+            arguments: ToolValue::from_json_value(serde_json::json!({
+                "message": "hello"
+            })),
+            raw_input: Some("hello".to_string()),
+        };
+
+        let result = registry
+            .execute_typed_tool("echo_typed".to_string(), input)
+            .expect("typed execution should succeed");
+
+        assert!(result.success);
+        let output = result
+            .output
+            .as_ref()
+            .expect("typed tool should return an output");
+        let output_json = output
+            .to_json_value()
+            .expect("output should convert to json");
+        assert_eq!(output_json, serde_json::json!({ "message": "hello" }));
+    }
+
+    #[test]
+    fn execute_typed_tool_normalizes_success_without_output() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_typed_tool(Box::new(SuccessWithoutOutputTypedTool))
+            .expect("typed tool should register");
+
+        let result = registry
+            .execute_typed_tool(
+                "success_without_output".to_string(),
+                TypedToolInput {
+                    arguments: ToolValue::from_json_value(serde_json::json!({})),
+                    raw_input: None,
+                },
+            )
+            .expect("typed execution should return a normalized result");
+
+        assert!(!result.success);
+        let error = result
+            .error
+            .expect("normalized result should contain error");
+        assert_eq!(error.kind, FfiToolErrorKind::Validation);
+        assert!(error.message.contains("without an output payload"));
+    }
+
+    #[test]
+    fn execute_typed_tool_normalizes_failure_without_error() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_typed_tool(Box::new(FailureWithoutErrorTypedTool))
+            .expect("typed tool should register");
+
+        let result = registry
+            .execute_typed_tool(
+                "failure_without_error".to_string(),
+                TypedToolInput {
+                    arguments: ToolValue::from_json_value(serde_json::json!({})),
+                    raw_input: None,
+                },
+            )
+            .expect("typed execution should return a normalized result");
+
+        assert!(!result.success);
+        let error = result
+            .error
+            .expect("normalized result should contain error");
+        assert_eq!(error.kind, FfiToolErrorKind::Unknown);
+        assert!(error.message.contains("without an error payload"));
+    }
+
+    #[test]
+    fn execute_typed_tool_rejects_invalid_typed_arguments() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_tool(Box::new(EchoLegacyTool))
+            .expect("legacy tool should register");
+
+        let result = registry
+            .execute_typed_tool(
+                "echo_legacy".to_string(),
+                TypedToolInput {
+                    arguments: ToolValue {
+                        kind: ToolValueKind::Object,
+                        bool_value: None,
+                        int_value: None,
+                        float_value: None,
+                        string_value: None,
+                        list_value: None,
+                        object_entries: None,
+                    },
+                    raw_input: None,
+                },
+            )
+            .expect("typed execution should return a validation result");
+
+        assert!(!result.success);
+        let error = result
+            .error
+            .expect("invalid typed args should report error");
+        assert_eq!(error.kind, FfiToolErrorKind::Validation);
+        assert!(error.message.contains("Invalid typed tool arguments"));
+    }
+
+    #[test]
+    fn unregister_tool_removes_typed_callback_execution_path() {
+        let registry = ToolRegistry::new();
+        registry
+            .register_typed_tool(Box::new(EchoTypedTool))
+            .expect("typed tool should register");
+
+        let removed = registry
+            .unregister_tool("echo_typed".to_string())
+            .expect("unregister should succeed");
+        assert!(removed);
+
+        let err = registry
+            .execute_typed_tool(
+                "echo_typed".to_string(),
+                TypedToolInput {
+                    arguments: ToolValue::from_json_value(serde_json::json!({
+                        "message": "hello"
+                    })),
+                    raw_input: None,
+                },
+            )
+            .expect_err("unregistered typed tool should not execute");
+
+        assert!(err.to_string().contains("Tool not found"));
     }
 }


### PR DESCRIPTION
## 📋 Summary

This PR introduces a typed UniFFI tool contract alongside the existing legacy JSON-string bridge.

It adds:

- typed FFI value records for schemas, arguments, and outputs
- structured typed tool result/error records
- a new `TypedFfiToolCallback` callback interface
- typed registry APIs for registering, listing, and executing tools
- migration/docs guidance that marks the JSON-string path as legacy

The existing `FfiToolCallback` / `execute_tool(string arguments_json)` path is preserved for backward compatibility.

Closes #ISSUE_NUMBER

---

## 🔗 Related Issues

Closes #1512 

Related to the broader FFI type-safety and binding-contract work.

---

## 🧠 Context

The current UniFFI tool bridge passes schemas, arguments, outputs, and failures as JSON strings:

- tool schemas are exposed as `parameters_schema_json: String`
- tool execution takes `arguments_json: String`
- tool results return `output_json: String`
- invalid output parsing can silently degrade into string output

This weakens one of MoFA's most important extension points:

- bindings depend on runtime JSON correctness
- malformed payloads are harder to diagnose safely
- the cross-language contract is harder to evolve
- invalid outputs can lose structure instead of producing typed failures

This PR moves the tool FFI surface toward typed contracts while keeping the old JSON path available during migration.

---

## 🛠️ Changes

- Added typed UniFFI records/enums for tool payloads:
  - `ToolValueKind`
  - `ToolObjectEntry`
  - `ToolValue`
  - `TypedToolSchema`
  - `TypedToolInput`
  - `TypedToolInfo`
  - `TypedFfiToolResult`
  - `FfiToolError`
  - `FfiToolErrorKind`
- Added a new typed callback interface:
  - `TypedFfiToolCallback`
- Added typed `ToolRegistry` APIs:
  - `register_typed_tool(...)`
  - `list_typed_tools()`
  - `execute_typed_tool(...)`
- Preserved the legacy JSON-string APIs for backward compatibility:
  - `register_tool(...)`
  - `list_tools()`
  - `execute_tool(...)`
- Added migration guidance in `crates/mofa-ffi/README.md`
- Added normalization/validation for edge cases such as:
  - typed success without output payload
  - typed failure without error payload
  - invalid typed arguments
  - unregister behavior for typed tools

---

## 🧪 How you Tested

1. Ran:
   - `rustfmt --edition 2021 --check crates/mofa-ffi/src/uniffi_bindings.rs`
2. Added Rust-side tests covering:
   - UDL contract markers for the typed FFI surface
   - `ToolValue` nested roundtrip behavior
   - typed tool registration/list/execution
   - typed success-without-output normalization
   - typed failure-without-error normalization
   - invalid typed argument handling
   - unregister removing the typed execution path
3. Attempted full Rust test/build verification, but local execution is currently blocked by missing MSVC linker tooling

---

## 📸 Screenshots / Logs (if applicable)

Local build/test blocker:

```text
error: linker `link.exe` not found
