### PR TITLE
test(runtime): add interrupt and fallback unit coverage

### DIFF
--- a/crates/mofa-runtime/src/fallback.rs
+++ b/crates/mofa-runtime/src/fallback.rs
@@ -36,3 +36,64 @@ impl FallbackStrategy for NoFallback {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{FallbackStrategy, NoFallback, StaticFallback};
+    use mofa_kernel::agent::{error::AgentError, types::AgentOutput};
+
+    #[tokio::test]
+    async fn test_static_fallback_returns_some_output() {
+        let strategy = StaticFallback {
+            output: AgentOutput::text("service unavailable"),
+        };
+
+        let result = strategy
+            .on_failure("agent-a", &AgentError::ExecutionFailed("boom".to_string()), 1)
+            .await;
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().to_text(), "service unavailable");
+    }
+
+    #[tokio::test]
+    async fn test_static_fallback_ignores_agent_id_and_attempt_count() {
+        let strategy = StaticFallback {
+            output: AgentOutput::text("fallback"),
+        };
+        let error = AgentError::Timeout { duration_ms: 5000 };
+
+        let first = strategy.on_failure("agent-a", &error, 1).await;
+        let second = strategy.on_failure("agent-b", &error, 999).await;
+
+        assert_eq!(first.unwrap().to_text(), "fallback");
+        assert_eq!(second.unwrap().to_text(), "fallback");
+    }
+
+    #[tokio::test]
+    async fn test_no_fallback_returns_none() {
+        let strategy = NoFallback;
+
+        let result = strategy
+            .on_failure(
+                "agent-a",
+                &AgentError::ResourceUnavailable("db".to_string()),
+                3,
+            )
+            .await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_no_fallback_always_none_for_any_attempt_count() {
+        let strategy = NoFallback;
+        let error = AgentError::ExecutionFailed("boom".to_string());
+
+        let first = strategy.on_failure("agent", &error, 1).await;
+        let second = strategy.on_failure("agent", &error, 1000).await;
+
+        assert!(first.is_none());
+        assert!(second.is_none());
+    }
+}

--- a/crates/mofa-runtime/src/interrupt.rs
+++ b/crates/mofa-runtime/src/interrupt.rs
@@ -45,3 +45,84 @@ impl AgentInterrupt {
             .store(false, std::sync::atomic::Ordering::SeqCst);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AgentInterrupt;
+    use std::time::Duration;
+
+    #[test]
+    fn test_new_starts_not_interrupted() {
+        let interrupt = AgentInterrupt::new();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn test_default_starts_not_interrupted() {
+        let interrupt = AgentInterrupt::default();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn test_trigger_sets_interrupted_state() {
+        let interrupt = AgentInterrupt::new();
+        interrupt.trigger();
+        assert!(interrupt.check());
+    }
+
+    #[test]
+    fn test_reset_clears_interrupted_state() {
+        let interrupt = AgentInterrupt::new();
+        interrupt.trigger();
+        interrupt.reset();
+        assert!(!interrupt.check());
+    }
+
+    #[test]
+    fn test_trigger_reset_trigger_cycle() {
+        let interrupt = AgentInterrupt::new();
+
+        interrupt.trigger();
+        assert!(interrupt.check());
+
+        interrupt.reset();
+        assert!(!interrupt.check());
+
+        interrupt.trigger();
+        assert!(interrupt.check());
+    }
+
+    #[test]
+    fn test_clone_shares_triggered_state() {
+        let interrupt = AgentInterrupt::new();
+        let cloned = interrupt.clone();
+
+        interrupt.trigger();
+        assert!(cloned.check());
+    }
+
+    #[test]
+    fn test_clone_reset_affects_both_instances() {
+        let interrupt = AgentInterrupt::new();
+        let cloned = interrupt.clone();
+
+        interrupt.trigger();
+        assert!(interrupt.check());
+        assert!(cloned.check());
+
+        cloned.reset();
+        assert!(!interrupt.check());
+        assert!(!cloned.check());
+    }
+
+    #[tokio::test]
+    async fn test_trigger_notifies_waiter() {
+        let interrupt = AgentInterrupt::new();
+        let notified = interrupt.notify.notified();
+
+        interrupt.trigger();
+
+        let result = tokio::time::timeout(Duration::from_millis(200), notified).await;
+        assert!(result.is_ok(), "notify waiter should be woken by trigger");
+    }
+}


### PR DESCRIPTION
Adds comprehensive unit tests for runtime interruption and fallback behavior. Includes 8 tests in interrupt.rs (new/default, trigger/reset lifecycle, clone shared state, notify wakeup) and 4 tests in fallback.rs (StaticFallback always Some, NoFallback always None across inputs). Test-only change; no production logic changes.\n\nCloses #986