### PR TITLE
ci: fix clippy gate and add rustfmt check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run clippy (fail fast on errors)
-        run: cargo clippy --workspace --all-features -- -D errors
+      - name: Check formatting (rustfmt)
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy (deny warnings)
+        run: cargo clippy --workspace --all-features -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})


### PR DESCRIPTION
Fixes lint gate correctness in CI by replacing invalid clippy flag -D errors with -D warnings, and adds an explicit cargo fmt --all -- --check step in the lint job to catch formatting drift.

This aligns with issue expectations for a reliable warning-deny clippy gate and formatting baseline enforcement.

Closes #1301