### PR TITLE
ci: add cargo-audit and cargo-deny security gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,24 @@ jobs:
       - name: Run clippy (fail fast on errors)
         run: cargo clippy --workspace --all-features -- -D errors
 
+  security:
+    name: Security and License Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Security audit (cargo-audit)
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dependency and license policy (cargo-deny)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          arguments: --all-features
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-DFS-2016",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"


### PR DESCRIPTION
Adds automated dependency security and license compliance checks to CI.

What changed:
- new Security and License Checks job in ci workflow
- rustsec/audit-check action for advisory scanning
- cargo-deny action for dependency/license policy checks
- new deny.toml policy config with allowed licenses and source constraints

This closes a major observability gap in dependency risk management and license compliance.

Closes #610