### PR TITLE
chore(llm): fix collapsible_if warnings in Gemini SSE parser

### DIFF
--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -447,21 +447,15 @@ fn parse_gemini_sse(resp: reqwest::Response, model: String) -> ChatStream {
                     }
                     Ok(None) => {
                         // End of stream. If there is leftover data, try to parse it.
-                        if !buf.trim().is_empty() {
-                            if let Some(json_str) = buf.trim().strip_prefix("data: ") {
-                                if json_str.trim() != "[DONE]" {
-                                    if let Ok(chunk) =
-                                        serde_json::from_str::<GeminiStreamChunk>(json_str)
-                                    {
-                                        let completion =
-                                            gemini_chunk_to_completion(&chunk, &model, is_first);
-                                        return Some((
-                                            Ok(completion),
-                                            (resp, String::new(), model, false),
-                                        ));
-                                    }
-                                }
-                            }
+                        if let Some(json_str) = buf.trim().strip_prefix("data: ")
+                            && json_str.trim() != "[DONE]"
+                            && let Ok(chunk) = serde_json::from_str::<GeminiStreamChunk>(json_str)
+                        {
+                            let completion = gemini_chunk_to_completion(&chunk, &model, is_first);
+                            return Some((
+                                Ok(completion),
+                                (resp, String::new(), model, false),
+                            ));
                         }
                         return None;
                     }


### PR DESCRIPTION
Refactors nested conditionals in parse_gemini_sse() into a single let-chain condition, preserving behavior while addressing clippy::collapsible_if warnings.

Scope:
- crates/mofa-foundation/src/llm/google.rs
- no functional behavior changes

Closes #1295