### PR TITLE
feat(cli): add mofa plugin repository remove command

### DIFF
--- a/crates/mofa-cli/src/cli.rs
+++ b/crates/mofa-cli/src/cli.rs
@@ -442,6 +442,12 @@ pub enum PluginRepositoryCommands {
         #[arg(short, long)]
         description: Option<String>,
     },
+
+    /// Remove a plugin repository
+    Remove {
+        /// Repository identifier
+        id: String,
+    },
 }
 
 /// Session management subcommands

--- a/crates/mofa-cli/src/commands/plugin/repository.rs
+++ b/crates/mofa-cli/src/commands/plugin/repository.rs
@@ -67,6 +67,21 @@ pub async fn add(
     Ok(())
 }
 
+/// Remove a plugin repository
+pub async fn remove(ctx: &CliContext, id: &str) -> Result<(), CliError> {
+    let removed = ctx.plugin_repo_store.delete(id)?;
+
+    if removed {
+        println!("{} Repository '{}' removed", "✓".green(), id);
+        Ok(())
+    } else {
+        Err(CliError::PluginError(format!(
+            "Repository '{}' not found",
+            id
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +113,37 @@ mod tests {
         let stored = ctx.plugin_repo_store.get("custom").unwrap().unwrap();
         assert_eq!(stored.url, "https://example.org/plugins");
         assert!(stored.last_synced.is_some());
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_existing_repository() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        add(
+            &ctx,
+            "custom",
+            "https://example.org/plugins",
+            Some("Example repo"),
+        )
+        .await
+        .unwrap();
+
+        remove(&ctx, "custom").await.unwrap();
+        assert!(ctx.plugin_repo_store.get("custom").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_returns_error_for_missing_repository() {
+        let temp = TempDir::new().unwrap();
+        let ctx = CliContext::with_temp_dir(temp.path()).await.unwrap();
+
+        let err = remove(&ctx, "missing").await.unwrap_err();
+        match err {
+            CliError::PluginError(message) => {
+                assert!(message.contains("not found"));
+            }
+            other => panic!("Unexpected error type: {}", other),
+        }
     }
 }

--- a/crates/mofa-cli/src/main.rs
+++ b/crates/mofa-cli/src/main.rs
@@ -289,6 +289,9 @@ async fn run_command(cli: Cli) -> CliResult<()> {
                         commands::plugin::repository::add(ctx, &id, &url, description.as_deref())
                             .await?;
                     }
+                    cli::PluginRepositoryCommands::Remove { id } => {
+                        commands::plugin::repository::remove(ctx, &id).await?;
+                    }
                 },
             }
         }


### PR DESCRIPTION
Implements a GSoC ideas-list Open Task #24 contribution (mofa-cli subcommand implementations / plugin repository integration).\n\nSource idea list: https://github.com/mofa-org/GSoC/blob/main/ideas-list.md\n\nChanges:\n- add mofa plugin repository remove <id>\n- wire remove subcommand in dispatcher\n- implement repository deletion logic\n- add tests for success and missing repo error\n\nNote: cargo is unavailable in this environment, so tests could not be executed locally.