### PR TITLE
docs: improve Discord invite fallback guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,7 @@ For more information on security best practices, see our [Security Guide](docs/s
 - **Questions, ideas, and general discussion** → [GitHub Discussions](https://github.com/mofa-org/mofa/discussions)
 - **Security vulnerabilities** → Do **not** open a public issue. Email the maintainers directly (see [SECURITY.md](SECURITY.md)).
 - **Community chat** → [Discord](https://discord.com/invite/hKJZzDMMm9)
+  - If the invite appears expired, ask in Discussions for the latest invite link.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ MoFA is participating in **Google Summer of Code 2026** as a first-time organiza
 
 - GitHub Discussions: [https://github.com/mofa-org/mofa/discussions](https://github.com/mofa-org/mofa/discussions)
 - Discord: [https://discord.com/invite/hKJZzDMMm9](https://discord.com/invite/hKJZzDMMm9)
+- If the Discord invite appears expired, open a thread in Discussions and maintainers will share a refreshed invite.
 
 ## Star History
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -378,8 +378,9 @@ export MOFA_BIN=/absolute/path/to/mofa
 
 ## 社区
 
-- GitHub Issues: [https://github.com/mofa-org/mofa/discussions](https://github.com/mofa-org/mofa/discussions)
+- GitHub Discussions: [https://github.com/mofa-org/mofa/discussions](https://github.com/mofa-org/mofa/discussions)
 - Discord: [https://discord.com/invite/hKJZzDMMm9](https://discord.com/invite/hKJZzDMMm9)
+- 若 Discord 邀请链接失效，请在 Discussions 发帖，维护者会提供最新邀请链接。
 
 ## 星标历史
 

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -263,7 +263,7 @@ For a full list see [examples/README.md](../examples/README.md).
 | Write a Rhai runtime plugin | `examples/rhai_scripting/` |
 | Build a WASM plugin | `examples/wasm_plugin/` |
 | Contribute a fix or feature | [CONTRIBUTING.md](../CONTRIBUTING.md) |
-| Ask a question | [GitHub Discussions](https://github.com/mofa-org/mofa/discussions) · [Discord](https://discord.com/invite/hKJZzDMMm9) |
+| Ask a question | [GitHub Discussions](https://github.com/mofa-org/mofa/discussions) · [Discord](https://discord.com/invite/hKJZzDMMm9) (if invite fails, ask in Discussions) |
 
 ---
 


### PR DESCRIPTION
## Summary\n- address community onboarding friction when invite links intermittently fail\n- add explicit fallback instructions to use GitHub Discussions in key entry docs\n- fix a mislabeled Chinese README community link label\n\n## Files updated\n- README.md\n- README_cn.md\n- CONTRIBUTING.md\n- docs/QuickStart.md\n\n## Issue\nFixes #1265