### PR TITLE
fix(foundation): replace unwrap() with proper error handling in cron schedule parsing

### DIFF
--- a/crates/mofa-foundation/src/scheduler/cron.rs
+++ b/crates/mofa-foundation/src/scheduler/cron.rs
@@ -398,7 +398,18 @@ impl CronScheduler {
 
         tokio::spawn(async move {
             let mut timing = if let Some(cron_expr) = &cron_expression {
-                ScheduleTiming::Cron(Box::new(cron_expr.parse().unwrap()))
+                match cron_expr.parse::<Schedule>() {
+                    Ok(schedule) => ScheduleTiming::Cron(Box::new(schedule)),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to parse cron expression '{}' for schedule {}: {}",
+                            cron_expr,
+                            schedule_id,
+                            e
+                        );
+                        return;
+                    }
+                }
             } else if let Some(ms) = interval_ms {
                 ScheduleTiming::Interval(interval(Duration::from_millis(ms)))
             } else {


### PR DESCRIPTION
## Summary

Fixes #1476 - Cron schedule parsing can panic due to an unwrap() in the schedule task spawn code, even though validation happens in register().

## Problem

In `crates/mofa-foundation/src/scheduler/cron.rs` line 401:

```rust
ScheduleTiming::Cron(Box::new(cron_expr.parse().unwrap()))
```

While the `register()` method validates cron expressions upfront, having a bare `.unwrap()` in spawned tasks is dangerous:
- Bypassing validation layers could still cause panics
- It's not defensive coding
- Production systems should never panic on invalid input

## Solution

Replace `.unwrap()` with proper error handling:
```rust
match cron_expr.parse::<Schedule>() {
    Ok(schedule) => ScheduleTiming::Cron(Box::new(schedule)),
    Err(e) => {
        tracing::error!(
            "Failed to parse cron expression '{}' for schedule {}: {}",
            cron_expr, schedule_id, e
        );
        return;
    }
}
```

The task exits gracefully with a logged error instead of panicking.

## Testing

Existing cron tests verify happy path. This change adds defensive error handling for edge cases.

## GSOC2026 Contribution

Demonstrates commitment to production-grade error handling and robustness. Fixes P1 issue #1476.

Cc: @Mustafa11300 @rahulkr182