### PR TITLE
ci: add CODEOWNERS to auto-request reviews from maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for all changes - request review from core maintainers
+* @yangrudan @lijingrs
+
+# Additional fine-grained ownership based on area could be added in the future
+# For example:
+# /crates/mofa-kernel/ @yangrudan @lijingrs
+# /crates/mofa-foundation/ @yangrudan @lijingrs
+# etc.


### PR DESCRIPTION
Adds a CODEOWNERS file to automatically request reviews from core maintainers (@yangrudan, @lijingrs) on all pull requests. This helps ensure timely attention to contributions and distributes review load. Fine-grained ownership can be added later as needed.