### PR TITLE
feat(testing): add async parallel test runner with concurrency + timeout

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod report;
+pub mod runner;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
@@ -17,5 +18,9 @@ pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
+};
+pub use runner::{
+    AsyncTestCase, AsyncTestOutcome, AsyncTestRunner, AsyncTestRunnerConfig, TestProgressEvent,
+    TestProgressState,
 };
 pub use tools::MockTool;

--- a/tests/src/runner.rs
+++ b/tests/src/runner.rs
@@ -1,0 +1,315 @@
+//! Async test execution engine with configurable concurrency and timeouts.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use crate::clock::Clock;
+use crate::report::{TestCaseResult, TestReport, TestReportBuilder, TestStatus};
+
+/// Boxed future returned by a single async test case.
+pub type BoxedAsyncTestFuture = Pin<Box<dyn Future<Output = AsyncTestOutcome> + Send>>;
+
+/// Normalized outcome produced by a single async test case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AsyncTestOutcome {
+    Passed,
+    Failed(String),
+    Skipped(Option<String>),
+}
+
+impl AsyncTestOutcome {
+    pub fn passed() -> Self {
+        Self::Passed
+    }
+
+    pub fn failed(message: impl Into<String>) -> Self {
+        Self::Failed(message.into())
+    }
+
+    pub fn skipped(reason: impl Into<String>) -> Self {
+        Self::Skipped(Some(reason.into()))
+    }
+}
+
+impl From<Result<(), String>> for AsyncTestOutcome {
+    fn from(value: Result<(), String>) -> Self {
+        match value {
+            Ok(()) => Self::Passed,
+            Err(msg) => Self::Failed(msg),
+        }
+    }
+}
+
+/// A single test case executable by [`AsyncTestRunner`].
+pub struct AsyncTestCase {
+    pub name: String,
+    task: BoxedAsyncTestFuture,
+}
+
+impl AsyncTestCase {
+    /// Create a case whose future returns [`AsyncTestOutcome`].
+    pub fn new(
+        name: impl Into<String>,
+        task: impl Future<Output = AsyncTestOutcome> + Send + 'static,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            task: Box::pin(task),
+        }
+    }
+
+    /// Create a case from a future that returns `Result<(), String>`.
+    pub fn from_result(
+        name: impl Into<String>,
+        task: impl Future<Output = Result<(), String>> + Send + 'static,
+    ) -> Self {
+        Self::new(name, async move { AsyncTestOutcome::from(task.await) })
+    }
+}
+
+/// Lifecycle states emitted as progress events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TestProgressState {
+    Started,
+    Passed,
+    Failed,
+    Skipped,
+}
+
+/// Structured progress event emitted as each test starts and finishes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestProgressEvent {
+    pub test_name: String,
+    pub state: TestProgressState,
+    pub detail: Option<String>,
+}
+
+type EventCallback = Arc<dyn Fn(TestProgressEvent) + Send + Sync>;
+
+/// Runtime configuration for [`AsyncTestRunner`].
+#[derive(Clone)]
+pub struct AsyncTestRunnerConfig {
+    pub concurrency_limit: usize,
+    pub per_test_timeout: Option<Duration>,
+    pub clock: Option<Arc<dyn Clock>>,
+    pub(crate) event_callback: Option<EventCallback>,
+}
+
+impl Default for AsyncTestRunnerConfig {
+    fn default() -> Self {
+        Self {
+            concurrency_limit: 1,
+            per_test_timeout: None,
+            clock: None,
+            event_callback: None,
+        }
+    }
+}
+
+impl AsyncTestRunnerConfig {
+    pub fn with_concurrency_limit(mut self, limit: usize) -> Self {
+        self.concurrency_limit = limit.max(1);
+        self
+    }
+
+    pub fn with_per_test_timeout(mut self, timeout: Duration) -> Self {
+        self.per_test_timeout = Some(timeout);
+        self
+    }
+
+    pub fn without_timeout(mut self) -> Self {
+        self.per_test_timeout = None;
+        self
+    }
+
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
+    pub fn with_event_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(TestProgressEvent) + Send + Sync + 'static,
+    {
+        self.event_callback = Some(Arc::new(callback));
+        self
+    }
+}
+
+/// Async test runner that executes tests with bounded concurrency.
+pub struct AsyncTestRunner {
+    config: AsyncTestRunnerConfig,
+}
+
+impl Default for AsyncTestRunner {
+    fn default() -> Self {
+        Self {
+            config: AsyncTestRunnerConfig::default(),
+        }
+    }
+}
+
+impl AsyncTestRunner {
+    pub fn new(config: AsyncTestRunnerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Execute all test cases and produce a consolidated [`TestReport`].
+    pub async fn run_suite(
+        &self,
+        suite_name: impl Into<String>,
+        test_cases: Vec<AsyncTestCase>,
+    ) -> TestReport {
+        let total = test_cases.len();
+        let mut join_set: JoinSet<(usize, TestCaseResult)> = JoinSet::new();
+        let semaphore = Arc::new(Semaphore::new(self.config.concurrency_limit.max(1)));
+
+        for (index, test_case) in test_cases.into_iter().enumerate() {
+            let timeout = self.config.per_test_timeout;
+            let callback = self.config.event_callback.clone();
+            let gate = Arc::clone(&semaphore);
+
+            join_set.spawn(async move {
+                let _permit = gate
+                    .acquire_owned()
+                    .await
+                    .expect("test runner semaphore closed unexpectedly");
+                let result = run_single_test_case(test_case, timeout, callback).await;
+                (index, result)
+            });
+        }
+
+        let mut ordered_results: Vec<Option<TestCaseResult>> = vec![None; total];
+        while let Some(joined) = join_set.join_next().await {
+            match joined {
+                Ok((index, result)) => {
+                    if let Some(slot) = ordered_results.get_mut(index) {
+                        *slot = Some(result);
+                    }
+                }
+                Err(err) => {
+                    let result = TestCaseResult {
+                        name: "unknown_test_case".to_string(),
+                        status: TestStatus::Failed,
+                        duration: Duration::from_secs(0),
+                        error: Some(format!("runner task join error: {err}")),
+                        metadata: vec![],
+                    };
+                    if let Some(slot) = ordered_results.iter_mut().find(|slot| slot.is_none()) {
+                        *slot = Some(result);
+                    }
+                }
+            }
+        }
+
+        let mut builder = TestReportBuilder::new(suite_name);
+        if let Some(clock) = &self.config.clock {
+            builder = builder.with_clock(Arc::clone(clock));
+        }
+
+        for result in ordered_results.into_iter().flatten() {
+            builder = builder.add_result(result);
+        }
+
+        builder.build()
+    }
+}
+
+async fn run_single_test_case(
+    test_case: AsyncTestCase,
+    timeout: Option<Duration>,
+    callback: Option<EventCallback>,
+) -> TestCaseResult {
+    emit_event(
+        &callback,
+        TestProgressEvent {
+            test_name: test_case.name.clone(),
+            state: TestProgressState::Started,
+            detail: None,
+        },
+    );
+
+    let start = Instant::now();
+    let outcome = match timeout {
+        Some(limit) => match tokio::time::timeout(limit, test_case.task).await {
+            Ok(outcome) => outcome,
+            Err(_) => AsyncTestOutcome::Failed(format!(
+                "test exceeded timeout of {} ms",
+                limit.as_millis()
+            )),
+        },
+        None => test_case.task.await,
+    };
+    let duration = start.elapsed();
+
+    match outcome {
+        AsyncTestOutcome::Passed => {
+            emit_event(
+                &callback,
+                TestProgressEvent {
+                    test_name: test_case.name.clone(),
+                    state: TestProgressState::Passed,
+                    detail: None,
+                },
+            );
+            TestCaseResult {
+                name: test_case.name,
+                status: TestStatus::Passed,
+                duration,
+                error: None,
+                metadata: vec![],
+            }
+        }
+        AsyncTestOutcome::Failed(message) => {
+            emit_event(
+                &callback,
+                TestProgressEvent {
+                    test_name: test_case.name.clone(),
+                    state: TestProgressState::Failed,
+                    detail: Some(message.clone()),
+                },
+            );
+            TestCaseResult {
+                name: test_case.name,
+                status: TestStatus::Failed,
+                duration,
+                error: Some(message),
+                metadata: vec![],
+            }
+        }
+        AsyncTestOutcome::Skipped(reason) => {
+            emit_event(
+                &callback,
+                TestProgressEvent {
+                    test_name: test_case.name.clone(),
+                    state: TestProgressState::Skipped,
+                    detail: reason.clone(),
+                },
+            );
+            let mut metadata = vec![];
+            if let Some(reason) = reason {
+                metadata.push(("skip_reason".to_string(), reason));
+            }
+            TestCaseResult {
+                name: test_case.name,
+                status: TestStatus::Skipped,
+                duration,
+                error: None,
+                metadata,
+            }
+        }
+    }
+}
+
+fn emit_event(callback: &Option<EventCallback>, event: TestProgressEvent) {
+    if let Some(cb) = callback {
+        cb(event);
+    }
+}

--- a/tests/tests/async_runner_tests.rs
+++ b/tests/tests/async_runner_tests.rs
@@ -1,0 +1,168 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use mofa_testing::{
+    AsyncTestCase, AsyncTestOutcome, AsyncTestRunner, AsyncTestRunnerConfig, MockClock,
+    TestProgressState, TestStatus,
+};
+
+#[tokio::test]
+async fn async_runner_collects_pass_fail_and_skipped() {
+    let runner = AsyncTestRunner::default();
+    let cases = vec![
+        AsyncTestCase::from_result("passes", async { Ok(()) }),
+        AsyncTestCase::from_result("fails", async { Err("boom".to_string()) }),
+        AsyncTestCase::new("skips", async {
+            AsyncTestOutcome::skipped("feature disabled")
+        }),
+    ];
+
+    let report = runner.run_suite("suite", cases).await;
+
+    assert_eq!(report.total(), 3);
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 1);
+    assert_eq!(report.skipped(), 1);
+
+    let skip = report
+        .results
+        .iter()
+        .find(|r| r.name == "skips")
+        .expect("missing skip result");
+    assert_eq!(skip.status, TestStatus::Skipped);
+    assert!(skip.error.is_none());
+    assert!(
+        skip.metadata
+            .iter()
+            .any(|(k, v)| k == "skip_reason" && v == "feature disabled")
+    );
+}
+
+#[tokio::test]
+async fn async_runner_respects_concurrency_limit() {
+    let running = Arc::new(AtomicUsize::new(0));
+    let max_running = Arc::new(AtomicUsize::new(0));
+
+    let mut cases = Vec::new();
+    for idx in 0..8 {
+        let running = Arc::clone(&running);
+        let max_running = Arc::clone(&max_running);
+        cases.push(AsyncTestCase::new(format!("case-{idx}"), async move {
+            let now_running = running.fetch_add(1, Ordering::SeqCst) + 1;
+            update_max(&max_running, now_running);
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            running.fetch_sub(1, Ordering::SeqCst);
+            AsyncTestOutcome::passed()
+        }));
+    }
+
+    let runner = AsyncTestRunner::new(AsyncTestRunnerConfig::default().with_concurrency_limit(2));
+    let report = runner.run_suite("parallel", cases).await;
+
+    assert_eq!(report.failed(), 0);
+    assert_eq!(report.passed(), 8);
+    assert!(
+        max_running.load(Ordering::SeqCst) <= 2,
+        "expected max running <= 2, got {}",
+        max_running.load(Ordering::SeqCst)
+    );
+}
+
+#[tokio::test]
+async fn async_runner_marks_timeout_as_failed() {
+    let runner = AsyncTestRunner::new(
+        AsyncTestRunnerConfig::default().with_per_test_timeout(Duration::from_millis(20)),
+    );
+
+    let report = runner
+        .run_suite(
+            "timeouts",
+            vec![AsyncTestCase::new("slow", async {
+                tokio::time::sleep(Duration::from_millis(80)).await;
+                AsyncTestOutcome::passed()
+            })],
+        )
+        .await;
+
+    assert_eq!(report.total(), 1);
+    assert_eq!(report.failed(), 1);
+    assert!(
+        report.results[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("timeout")
+    );
+}
+
+#[tokio::test]
+async fn async_runner_emits_progress_events() {
+    let events: Arc<Mutex<Vec<(String, TestProgressState)>>> = Arc::new(Mutex::new(Vec::new()));
+    let event_sink = Arc::clone(&events);
+
+    let runner = AsyncTestRunner::new(AsyncTestRunnerConfig::default().with_event_callback(
+        move |event| {
+            event_sink
+                .lock()
+                .expect("event lock poisoned")
+                .push((event.test_name, event.state));
+        },
+    ));
+
+    let cases = vec![
+        AsyncTestCase::from_result("p", async { Ok(()) }),
+        AsyncTestCase::from_result("f", async { Err("failed".to_string()) }),
+    ];
+
+    let report = runner.run_suite("events", cases).await;
+    assert_eq!(report.total(), 2);
+
+    let snapshot = events.lock().expect("event lock poisoned").clone();
+    assert!(
+        snapshot
+            .iter()
+            .any(|(name, state)| name == "p" && *state == TestProgressState::Started)
+    );
+    assert!(
+        snapshot
+            .iter()
+            .any(|(name, state)| name == "p" && *state == TestProgressState::Passed)
+    );
+    assert!(
+        snapshot
+            .iter()
+            .any(|(name, state)| name == "f" && *state == TestProgressState::Started)
+    );
+    assert!(
+        snapshot
+            .iter()
+            .any(|(name, state)| name == "f" && *state == TestProgressState::Failed)
+    );
+}
+
+#[tokio::test]
+async fn async_runner_uses_injected_clock_for_report() {
+    let clock = Arc::new(MockClock::starting_at(Duration::from_millis(1234)));
+    let config = AsyncTestRunnerConfig::default().with_clock(clock);
+    let runner = AsyncTestRunner::new(config);
+
+    let report = runner.run_suite("clocked", vec![]).await;
+
+    assert_eq!(report.timestamp, 1234);
+}
+
+fn update_max(max_running: &AtomicUsize, now_running: usize) {
+    let mut current_max = max_running.load(Ordering::SeqCst);
+    while now_running > current_max {
+        match max_running.compare_exchange(
+            current_max,
+            now_running,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            Ok(_) => return,
+            Err(observed) => current_max = observed,
+        }
+    }
+}


### PR DESCRIPTION
## Feat: add async parallel test runner for mofa-testing #1598 

### Problem

The testing crate did not have a dedicated async test execution engine with configurable parallelism and per-test timeout control.  
Tests were primarily run through cargo test, and the existing suite runner in runner.rs executes sequentially without configurable concurrency, timeout enforcement, or progress event emission.

### Fix

Implemented a new async runner foundation in runner.rs, and exported it from lib.rs.

Key additions:

- AsyncTestRunner with configurable bounded concurrency
- Semaphore-based parallel execution
- Per-test timeout support using Tokio timeout
- Structured progress events:
  - Started
  - Passed
  - Failed
  - Skipped
- Deterministic result collation in input order
- Native integration with existing TestReport and TestReportBuilder
- Support for skipped tests with structured skip metadata

### Tests added

Added targeted coverage in async_runner_tests.rs:

- async_runner_collects_pass_fail_and_skipped
- async_runner_respects_concurrency_limit
- async_runner_marks_timeout_as_failed
- async_runner_emits_progress_events
- async_runner_uses_injected_clock_for_report

### Verification

Ran:

- cargo test -p mofa-testing

All relevant tests pass.