### PR TITLE
 feat(testing): Add Semantic Assertion Matchers for Intent-Level Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6168,7 +6168,9 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/examples/agent_test_dsl/README.md
+++ b/examples/agent_test_dsl/README.md
@@ -1,0 +1,49 @@
+# Agent Test DSL Examples
+
+This folder provides practical, copy-paste scenarios for the `mofa-testing` Agent Test DSL.
+
+## Included Scenarios
+
+- `scenario_weather.yaml`: Multi-turn support flow with tool call + follow-up acknowledgment
+- `scenario_follow_up.toml`: TOML scenario with tool expectation and summary follow-up
+
+## Minimal Usage
+
+```rust
+use mofa_testing::{
+    AgentTestScenario, MockLLMBackend, MockScenarioAgent, MockTool,
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let yaml = std::fs::read_to_string("examples/agent_test_dsl/scenario_weather.yaml")?;
+    let scenario = AgentTestScenario::from_yaml_str(&yaml)?;
+
+    let backend = MockLLMBackend::new();
+    backend.add_response("weather", "The temperature in Berlin is 22C.");
+
+    let weather_tool = MockTool::new(
+        "weather_search",
+        "Lookup weather",
+        json!({
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"]
+        }),
+    );
+
+    let mut agent = MockScenarioAgent::new("mock-model", backend)
+        .with_mock_tool(weather_tool)
+        .add_tool_rule("weather", "weather_search", json!({"city": "Berlin"}));
+
+    let report = scenario.run_with_agent(&mut agent).await;
+    println!("total={}, passed={}, failed={}", report.total(), report.passed(), report.failed());
+
+    Ok(())
+}
+```
+
+## Why these examples exist
+
+The DSL introduces structural testing capabilities. These example scenarios are included so new users can quickly understand practical usage without reverse-engineering test internals.

--- a/examples/agent_test_dsl/scenario_follow_up.toml
+++ b/examples/agent_test_dsl/scenario_follow_up.toml
@@ -1,0 +1,24 @@
+agent_id = "support_agent"
+system_prompt = "You are a practical support assistant"
+tools = ["ticket_lookup"]
+
+[[turns]]
+user = "Check ticket #123"
+
+[[turns.expect]]
+kind = "call_tool"
+name = "ticket_lookup"
+
+[[turns.expect]]
+kind = "respond_containing"
+text = "ticket"
+
+[[turns]]
+user = "Great, summarize it"
+
+[[turns.expect]]
+kind = "not_call_any_tool"
+
+[[turns.expect]]
+kind = "respond_matching_regex"
+pattern = "(?i)summary|status"

--- a/examples/agent_test_dsl/scenario_weather.yaml
+++ b/examples/agent_test_dsl/scenario_weather.yaml
@@ -1,0 +1,18 @@
+agent_id: customer_support_agent
+system_prompt: You are a helpful assistant
+tools:
+  - weather_search
+turns:
+  - user: What's the weather in Berlin?
+    expect:
+      - kind: call_tool_with
+        name: weather_search
+        arguments:
+          city: Berlin
+      - kind: respond_containing
+        text: temperature
+  - user: Thanks!
+    expect:
+      - kind: not_call_any_tool
+      - kind: respond_matching_regex
+        pattern: "(?i)welcome|happy to help"

--- a/examples/golden_response_test/README.md
+++ b/examples/golden_response_test/README.md
@@ -1,0 +1,101 @@
+# Golden Response Testing Examples
+
+This folder demonstrates the **golden response (snapshot) testing** capabilities of `mofa-testing`.
+
+Golden tests record agent outputs as baselines, then compare future runs against them to detect regressions automatically.
+
+## Included Files
+
+| File | Description |
+|------|-------------|
+| `goldens/weather_agent.golden.json` | Pre-recorded golden snapshot for a weather agent scenario |
+| `goldens/support_agent.golden.json` | Pre-recorded golden snapshot for a support agent scenario |
+
+## Quick Usage
+
+### 1. Record a golden baseline (update mode)
+
+```rust
+use mofa_testing::{
+    AgentTest, GoldenStore, GoldenTestConfig, MockLLMBackend,
+    MockScenarioAgent, MockTool, run_golden_test,
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = AgentTest::new("weather_agent")
+        .given_tool("weather_search")
+        .when_user_says("What's the weather in Berlin?")
+        .then_agent_should()
+        .call_tool("weather_search")
+        .respond_containing("Berlin")
+        .build()?;
+
+    let backend = MockLLMBackend::new();
+    backend.add_response("weather", "The temperature in Berlin is 22C.");
+
+    let tool = MockTool::new(
+        "weather_search", "Lookup weather",
+        json!({"type":"object","properties":{"city":{"type":"string"}}}),
+    );
+
+    let mut agent = MockScenarioAgent::new("mock-model", backend)
+        .with_mock_tool(tool)
+        .add_tool_rule("weather", "weather_search", json!({"city": "Berlin"}));
+
+    // Update mode: saves actual outputs as the golden baseline
+    let store = GoldenStore::new("examples/golden_response_test/goldens");
+    let config = GoldenTestConfig::update(store);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    println!("Baseline recorded: passed={}", report.passed());
+    Ok(())
+}
+```
+
+### 2. Validate against golden (strict mode)
+
+```rust
+    // Strict mode: compares actual outputs against stored golden
+    let store = GoldenStore::new("examples/golden_response_test/goldens");
+    let config = GoldenTestConfig::strict(store);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    if report.failed() > 0 {
+        println!("REGRESSION DETECTED:");
+        for result in &report.results {
+            if let Some(err) = &result.error {
+                println!("  {}: {}", result.name, err);
+            }
+        }
+    }
+```
+
+### 3. Use normalizers to ignore non-deterministic content
+
+```rust
+use mofa_testing::{NormalizerChain, RegexNormalizer};
+
+    let config = GoldenTestConfig::strict(store)
+        .with_normalizer(
+            NormalizerChain::default_chain()? // whitespace + UUID + timestamps
+        );
+```
+
+## How It Works
+
+1. **Update mode**: Run the scenario, capture all turn outputs, save them as `{test_name}.golden.json`.
+2. **Strict mode**: Run the scenario, load the saved golden, compare field-by-field (response text, tool call names, tool call arguments).
+3. **Normalizers**: Before comparison, strip non-deterministic content (UUIDs, timestamps, whitespace) so they don't cause false failures.
+4. **Reports**: Results integrate into the standard `TestReport` with clear diff messages for each mismatch.
+
+## CI Workflow
+
+```
+# In CI: run in strict mode to catch regressions
+GOLDEN_MODE=strict cargo test --test golden_tests
+
+# Locally: update baselines when behavior intentionally changes
+GOLDEN_MODE=update cargo test --test golden_tests
+```

--- a/examples/golden_response_test/goldens/support_agent.golden.json
+++ b/examples/golden_response_test/goldens/support_agent.golden.json
@@ -1,0 +1,27 @@
+{
+  "test_name": "support_agent",
+  "turns": [
+    {
+      "user_input": "Check my billing ticket #456",
+      "response": "I found ticket #456. It's a billing inquiry about your March invoice, currently in 'open' status.",
+      "tool_calls": [
+        {
+          "name": "ticket_lookup",
+          "arguments": {
+            "ticket_id": "456"
+          }
+        }
+      ]
+    },
+    {
+      "user_input": "Can you summarize the issue?",
+      "response": "Summary: Your March invoice shows a discrepancy of $15.00. The team is reviewing the charges and will update the ticket within 24 hours.",
+      "tool_calls": []
+    }
+  ],
+  "metadata": {
+    "created": "2026-04-09",
+    "model": "mock-model-v1",
+    "department": "billing"
+  }
+}

--- a/examples/golden_response_test/goldens/weather_agent.golden.json
+++ b/examples/golden_response_test/goldens/weather_agent.golden.json
@@ -1,0 +1,26 @@
+{
+  "test_name": "weather_agent",
+  "turns": [
+    {
+      "user_input": "What's the weather in Berlin?",
+      "response": "The temperature in Berlin is 22C.",
+      "tool_calls": [
+        {
+          "name": "weather_search",
+          "arguments": {
+            "city": "Berlin"
+          }
+        }
+      ]
+    },
+    {
+      "user_input": "Is it warm?",
+      "response": "Yes, 22C is considered warm for this time of year.",
+      "tool_calls": []
+    }
+  ],
+  "metadata": {
+    "created": "2026-04-09",
+    "model": "mock-model-v1"
+  }
+}

--- a/examples/parameterized_test/README.md
+++ b/examples/parameterized_test/README.md
@@ -1,0 +1,82 @@
+# Parameterized Agent Test Examples
+
+This folder demonstrates the **parameterized test** capabilities of `mofa-testing`.
+
+A parameterized test allows one scenario template to expand into multiple concrete test cases by substituting `{{variable}}` placeholders with values from parameter sets.
+
+## Included Files
+
+| File | Description |
+|------|-------------|
+| `scenario_weather_parameterized.yaml` | Explicit parameter list: tests the same weather lookup across multiple cities |
+| `scenario_greetings_matrix.yaml` | Matrix expansion: generates Cartesian product of languages × tones |
+| `scenario_support_parameterized.toml` | TOML format: parameterized support ticket lookup |
+
+## Quick Usage
+
+```rust
+use mofa_testing::{
+    ParameterizedScenarioFile, MockLLMBackend, MockScenarioAgent, MockTool,
+};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Load the parameterized scenario
+    let yaml = std::fs::read_to_string(
+        "examples/parameterized_test/scenario_weather_parameterized.yaml",
+    )?;
+    let parameterized = ParameterizedScenarioFile::from_yaml_str(&yaml)?;
+
+    println!("Expanding {} test variants...", parameterized.case_count());
+
+    let expanded = parameterized.expand()?;
+
+    for scenario in &expanded {
+        // Set up a fresh mock agent per variant
+        let backend = MockLLMBackend::new();
+        // The response includes the city name from the scenario
+        backend.add_response("weather", "The temperature is 22C.");
+
+        let tool = MockTool::new(
+            "weather_search",
+            "Lookup weather",
+            json!({"type": "object", "properties": {"city": {"type": "string"}}}),
+        );
+
+        let mut agent = MockScenarioAgent::new("mock-model", backend)
+            .with_mock_tool(tool)
+            .add_tool_rule("weather", "weather_search", json!({"city": "any"}));
+
+        let report = scenario.run_with_agent(&mut agent).await;
+        println!(
+            "[{}] total={} passed={} failed={}",
+            scenario.agent_id,
+            report.total(),
+            report.passed(),
+            report.failed()
+        );
+    }
+
+    Ok(())
+}
+```
+
+## How It Works
+
+1. **Template**: Write a scenario with `{{variable}}` placeholders in user prompts, expected responses, and tool arguments.
+
+2. **Parameters**: Provide either:
+   - **Explicit list**: Named parameter sets with variable bindings
+   - **Matrix**: Dimensions with values; the Cartesian product is computed automatically
+   - **Both**: Explicit sets + matrix sets are combined
+
+3. **Expansion**: Each parameter set produces one concrete scenario with all `{{variable}}` placeholders replaced.
+
+4. **Execution**: Each expanded scenario runs independently with isolated mock agents.
+
+## Placeholder Syntax
+
+- Placeholders use `{{variable_name}}` (double curly braces).
+- They are supported in: `user` input, `text` expectations, `pattern` (regex), tool `name`, tool `arguments`, and `system_prompt`.
+- The same variable can be used in multiple places and will be substituted everywhere.

--- a/examples/parameterized_test/scenario_greetings_matrix.yaml
+++ b/examples/parameterized_test/scenario_greetings_matrix.yaml
@@ -1,0 +1,21 @@
+# Matrix expansion: Cartesian product of languages × tones.
+# Produces 2 × 3 = 6 test variants automatically.
+
+template:
+  agent_id: greeting_agent
+  system_prompt: "You are a {{tone}} assistant who speaks {{language}}"
+  turns:
+    - user: "Greet me in {{language}} with a {{tone}} tone"
+      expect:
+        - kind: respond_containing
+          text: "{{language}}"
+
+matrix:
+  dimensions:
+    language:
+      - English
+      - German
+    tone:
+      - formal
+      - casual
+      - enthusiastic

--- a/examples/parameterized_test/scenario_support_parameterized.toml
+++ b/examples/parameterized_test/scenario_support_parameterized.toml
@@ -1,0 +1,35 @@
+# Parameterized support ticket lookup in TOML format.
+
+[template]
+agent_id = "support_agent"
+system_prompt = "You help customers with {{department}} issues"
+tools = ["ticket_lookup"]
+
+[[template.turns]]
+user = "Check my {{department}} ticket"
+
+[[template.turns.expect]]
+kind = "call_tool"
+name = "ticket_lookup"
+
+[[template.turns.expect]]
+kind = "respond_containing"
+text = "{{department}}"
+
+[[parameters]]
+name = "billing"
+
+[parameters.vars]
+department = "billing"
+
+[[parameters]]
+name = "shipping"
+
+[parameters.vars]
+department = "shipping"
+
+[[parameters]]
+name = "returns"
+
+[parameters.vars]
+department = "returns"

--- a/examples/parameterized_test/scenario_weather_parameterized.yaml
+++ b/examples/parameterized_test/scenario_weather_parameterized.yaml
@@ -1,0 +1,31 @@
+# Parameterized weather lookup: test the same flow across multiple cities.
+# Each parameter set produces one concrete test variant.
+
+template:
+  agent_id: weather_agent
+  system_prompt: You are a helpful weather assistant
+  tools:
+    - weather_search
+  turns:
+    - user: "What's the weather in {{city}}?"
+      expect:
+        - kind: call_tool
+          name: weather_search
+        - kind: respond_containing
+          text: "{{city}}"
+    - user: "Is it warm in {{city}}?"
+      expect:
+        - kind: not_call_any_tool
+        - kind: respond_matching_regex
+          pattern: "(?i)warm|cold|temperature"
+
+parameters:
+  - name: berlin
+    vars:
+      city: Berlin
+  - name: tokyo
+    vars:
+      city: Tokyo
+  - name: new_york
+    vars:
+      city: New York

--- a/examples/semantic_assertions/README.md
+++ b/examples/semantic_assertions/README.md
@@ -1,0 +1,81 @@
+# Semantic Assertion Matcher Examples
+
+This folder demonstrates the **semantic assertion** capabilities of `mofa-testing`.
+
+Semantic assertions validate **meaning and intent** rather than exact text, making tests resilient to harmless wording changes while maintaining strict policy checks.
+
+## Included Files
+
+| File | Description |
+|------|-------------|
+| `weather_assertions.yaml` | Weather agent assertions: facts, intents, similarity, and policy |
+| `safety_assertions.yaml` | Safety-focused assertions: prohibited content and policy compliance |
+
+## Quick Usage
+
+### Rust Builder API
+
+```rust
+use mofa_testing::{
+    ContainsAllFactsMatcher, ExcludesContentMatcher, IntentMatcher,
+    SemanticAssertionSet, SimilarityMatcher,
+};
+
+let assertions = SemanticAssertionSet::new()
+    // Required facts must be present
+    .add(ContainsAllFactsMatcher::new(vec!["Berlin", "temperature"]))
+    // Prohibited content must be absent
+    .add(ExcludesContentMatcher::new(vec!["password", "error"]))
+    // Expected intent via keyword indicators
+    .add(IntentMatcher::new()
+        .expect_intent("weather", vec!["weather", "forecast", "temperature"]))
+    // Token-overlap similarity to reference
+    .add(SimilarityMatcher::new(
+        "The temperature in Berlin is around 22 degrees", 0.3
+    ).unwrap());
+
+let report = assertions.evaluate(
+    "The current temperature in Berlin is 22 degrees Celsius."
+).unwrap();
+
+println!("passed={} ({}/{})", report.passed, report.passed_count, report.total_count);
+for result in &report.results {
+    println!("  [{}] {} (confidence: {:.2}): {}",
+        if result.passed { "PASS" } else { "FAIL" },
+        result.matcher_name, result.confidence, result.explanation
+    );
+}
+```
+
+### File-backed (YAML)
+
+```rust
+use mofa_testing::SemanticExpectation;
+
+let yaml = std::fs::read_to_string(
+    "examples/semantic_assertions/weather_assertions.yaml"
+)?;
+let expectations = SemanticExpectation::from_yaml_str(&yaml)?;
+let set = SemanticExpectation::into_assertion_set(expectations)?;
+
+let report = set.evaluate("Berlin is 22 degrees and sunny.")?;
+assert!(report.passed);
+```
+
+## Available Matcher Types
+
+| Matcher | Purpose | Confidence Score |
+|---------|---------|-----------------|
+| `ContainsAllFactsMatcher` | All required facts must be present | Fraction of facts found |
+| `ExcludesContentMatcher` | No prohibited content may appear | Fraction of clean terms |
+| `IntentMatcher` | Intent via keyword indicators | Fraction of intents matched |
+| `SimilarityMatcher` | Token-overlap (Jaccard) similarity | Similarity coefficient |
+| `RegexIntentMatcher` | Structural pattern via regex | 1.0 or 0.0 |
+
+## Design Decisions
+
+1. **All matchers are deterministic** — no external API calls required, safe for CI.
+2. **Case-insensitive by default** — reduces brittle failures from capitalization differences.
+3. **Confidence scores** — every result includes a [0.0, 1.0] confidence score for nuanced analysis.
+4. **Composable** — combine any number of matchers into a `SemanticAssertionSet` for comprehensive validation.
+5. **File-backed** — YAML/JSON definitions enable non-Rust contributors to author assertions.

--- a/examples/semantic_assertions/safety_assertions.yaml
+++ b/examples/semantic_assertions/safety_assertions.yaml
@@ -1,0 +1,32 @@
+# Safety-focused semantic assertions.
+# Validates that agent responses comply with data protection policies
+# and do not leak sensitive information.
+
+# No PII or credentials should appear in any response.
+- kind: excludes_content
+  banned:
+    - password
+    - SSN
+    - social security
+    - credit card number
+    - date of birth
+    - secret key
+    - API key
+    - bearer token
+
+# Response should acknowledge the user's request.
+- kind: matches_intent
+  intents:
+    - name: acknowledgment
+      indicators: [here, found, your, account, summary, result, information]
+  require_all: false
+
+# Response should not contain error-like language.
+- kind: excludes_content
+  banned:
+    - internal error
+    - stack trace
+    - exception
+    - panic
+    - undefined
+    - "null pointer"

--- a/examples/semantic_assertions/weather_assertions.yaml
+++ b/examples/semantic_assertions/weather_assertions.yaml
@@ -1,0 +1,37 @@
+# Weather agent semantic assertions.
+# Tests that the response conveys weather information about Berlin
+# with correct intent and without policy violations.
+
+# Required facts: Berlin and a temperature indication must appear.
+- kind: contains_all_facts
+  facts:
+    - Berlin
+    - temperature
+
+# Safety: response must not contain error or uncertainty phrases.
+- kind: excludes_content
+  banned:
+    - "I don't know"
+    - error
+    - unable
+    - "I cannot"
+
+# Intent: the response should convey weather information.
+- kind: matches_intent
+  intents:
+    - name: weather_info
+      indicators: [weather, temperature, forecast, degrees, celsius, fahrenheit]
+    - name: location_aware
+      indicators: [Berlin]
+  require_all: true
+
+# Similarity: response should overlap with the expected reference.
+- kind: similar_to
+  reference: "The temperature in Berlin is around 22 degrees Celsius"
+  threshold: 0.3
+
+# Structure: response should include a numeric value (temperature).
+- kind: matches_pattern
+  name: has_numeric_value
+  pattern: '\d+'
+  description: "response includes at least one numeric value"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,5 +14,7 @@ async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
+toml = "0.8"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,3 +18,6 @@ serde_yaml = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
 toml = "0.8"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/tests/src/dsl.rs
+++ b/tests/src/dsl.rs
@@ -1,0 +1,727 @@
+//! Declarative agent testing DSL and scenario runner.
+//!
+//! This module provides:
+//! - A fluent builder (`AgentTest`) for multi-turn scenarios
+//! - YAML/TOML scenario loading
+//! - Expectation evaluation for responses and tool calls
+//! - A mock harness (`MockScenarioAgent`) that integrates with `MockLLMBackend`
+//!   and `MockTool`
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::time::Instant;
+
+use async_trait::async_trait;
+use mofa_foundation::agent::components::tool::SimpleTool;
+use mofa_foundation::orchestrator::ModelOrchestrator;
+use mofa_kernel::agent::components::tool::ToolInput;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::backend::MockLLMBackend;
+use crate::report::{TestCaseResult, TestReport, TestReportBuilder, TestStatus};
+use crate::tools::MockTool;
+
+/// Builder-level validation error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScenarioBuildError {
+    pub errors: Vec<String>,
+}
+
+impl ScenarioBuildError {
+    pub fn new(errors: Vec<String>) -> Self {
+        Self { errors }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+impl Display for ScenarioBuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "scenario build failed: {}", self.errors.join("; "))
+    }
+}
+
+impl Error for ScenarioBuildError {}
+
+/// Scenario loading error (JSON/YAML/TOML parse + validation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScenarioLoadError {
+    Json(String),
+    Yaml(String),
+    Toml(String),
+    Validation(Vec<String>),
+}
+
+impl Display for ScenarioLoadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json(msg) => write!(f, "json parse error: {msg}"),
+            Self::Yaml(msg) => write!(f, "yaml parse error: {msg}"),
+            Self::Toml(msg) => write!(f, "toml parse error: {msg}"),
+            Self::Validation(errors) => {
+                write!(f, "scenario validation error: {}", errors.join("; "))
+            }
+        }
+    }
+}
+
+impl Error for ScenarioLoadError {}
+
+/// Single tool call record observed in a turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCallRecord {
+    pub name: String,
+    pub arguments: Value,
+}
+
+/// Agent output observed for one scenario turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScenarioTurnOutput {
+    pub response: String,
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+
+impl ScenarioTurnOutput {
+    pub fn new(response: impl Into<String>) -> Self {
+        Self {
+            response: response.into(),
+            tool_calls: Vec::new(),
+        }
+    }
+
+    pub fn with_tool_call(mut self, name: impl Into<String>, arguments: Value) -> Self {
+        self.tool_calls.push(ToolCallRecord {
+            name: name.into(),
+            arguments,
+        });
+        self
+    }
+}
+
+/// Agent adapter trait used by the scenario runner.
+#[async_trait]
+pub trait ScenarioAgent: Send {
+    async fn execute_turn(
+        &mut self,
+        system_prompt: Option<&str>,
+        user_input: &str,
+    ) -> Result<ScenarioTurnOutput, String>;
+}
+
+/// Turn expectation primitives.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnExpectation {
+    CallTool { name: String },
+    CallToolWith { name: String, arguments: Value },
+    NotCallAnyTool,
+    RespondContaining { text: String },
+    RespondExact { text: String },
+    RespondMatchingRegex { pattern: String },
+}
+
+/// One conversational turn in a scenario.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScenarioTurn {
+    pub user_input: String,
+    pub expectations: Vec<TurnExpectation>,
+}
+
+/// Declarative scenario for testing an agent's behavior.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentTestScenario {
+    pub agent_id: String,
+    pub system_prompt: Option<String>,
+    pub tools: Vec<String>,
+    pub turns: Vec<ScenarioTurn>,
+}
+
+impl AgentTestScenario {
+    /// Parse a scenario from JSON.
+    pub fn from_json_str(input: &str) -> Result<Self, ScenarioLoadError> {
+        let parsed: ScenarioFile =
+            serde_json::from_str(input).map_err(|err| ScenarioLoadError::Json(err.to_string()))?;
+        let scenario = Self::from(parsed);
+        scenario
+            .validate()
+            .map_err(|err| ScenarioLoadError::Validation(err.errors))?;
+        Ok(scenario)
+    }
+
+    /// Parse a scenario from YAML.
+    pub fn from_yaml_str(input: &str) -> Result<Self, ScenarioLoadError> {
+        let parsed: ScenarioFile =
+            serde_yaml::from_str(input).map_err(|err| ScenarioLoadError::Yaml(err.to_string()))?;
+        let scenario = Self::from(parsed);
+        scenario
+            .validate()
+            .map_err(|err| ScenarioLoadError::Validation(err.errors))?;
+        Ok(scenario)
+    }
+
+    /// Parse a scenario from TOML.
+    pub fn from_toml_str(input: &str) -> Result<Self, ScenarioLoadError> {
+        let parsed: ScenarioFile =
+            toml::from_str(input).map_err(|err| ScenarioLoadError::Toml(err.to_string()))?;
+        let scenario = Self::from(parsed);
+        scenario
+            .validate()
+            .map_err(|err| ScenarioLoadError::Validation(err.errors))?;
+        Ok(scenario)
+    }
+
+    /// Validate scenario shape and expectation payloads.
+    pub fn validate(&self) -> Result<(), ScenarioBuildError> {
+        let mut errors = Vec::new();
+
+        if self.agent_id.trim().is_empty() {
+            errors.push("agent_id must not be empty".to_string());
+        }
+
+        if self.turns.is_empty() {
+            errors.push("scenario must include at least one turn".to_string());
+        }
+
+        for (idx, turn) in self.turns.iter().enumerate() {
+            if turn.user_input.trim().is_empty() {
+                errors.push(format!("turn {} has empty user_input", idx + 1));
+            }
+
+            for expectation in &turn.expectations {
+                match expectation {
+                    TurnExpectation::CallTool { name }
+                    | TurnExpectation::CallToolWith { name, .. } => {
+                        if name.trim().is_empty() {
+                            errors.push(format!(
+                                "turn {} contains a tool expectation with empty tool name",
+                                idx + 1
+                            ));
+                        }
+                    }
+                    TurnExpectation::RespondContaining { text }
+                    | TurnExpectation::RespondExact { text } => {
+                        if text.is_empty() {
+                            errors.push(format!(
+                                "turn {} contains an empty response text expectation",
+                                idx + 1
+                            ));
+                        }
+                    }
+                    TurnExpectation::RespondMatchingRegex { pattern } => {
+                        if let Err(err) = Regex::new(pattern) {
+                            errors.push(format!(
+                                "turn {} has invalid regex '{}': {}",
+                                idx + 1,
+                                pattern,
+                                err
+                            ));
+                        }
+                    }
+                    TurnExpectation::NotCallAnyTool => {}
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ScenarioBuildError::new(errors))
+        }
+    }
+
+    /// Execute the scenario and produce a `TestReport`.
+    ///
+    /// If scenario validation fails, the report contains one failed test case
+    /// with the validation details.
+    pub async fn run_with_agent<A: ScenarioAgent>(&self, agent: &mut A) -> TestReport {
+        match self.run_with_agent_checked(agent).await {
+            Ok(report) => report,
+            Err(err) => TestReportBuilder::new(format!("scenario:{}", self.agent_id))
+                .add_result(TestCaseResult {
+                    name: "scenario_validation".to_string(),
+                    status: TestStatus::Failed,
+                    duration: std::time::Duration::from_secs(0),
+                    error: Some(err.to_string()),
+                    metadata: vec![],
+                })
+                .build(),
+        }
+    }
+
+    /// Execute the scenario and return a validated report.
+    pub async fn run_with_agent_checked<A: ScenarioAgent>(
+        &self,
+        agent: &mut A,
+    ) -> Result<TestReport, ScenarioBuildError> {
+        self.validate()?;
+
+        let mut builder = TestReportBuilder::new(format!("scenario:{}", self.agent_id));
+
+        for (idx, turn) in self.turns.iter().enumerate() {
+            let test_name = format!("turn_{}_{}", idx + 1, sanitize_name(&turn.user_input));
+            let start = Instant::now();
+
+            let result = agent
+                .execute_turn(self.system_prompt.as_deref(), &turn.user_input)
+                .await;
+
+            let (status, error, metadata) = match result {
+                Ok(output) => {
+                    let failures = evaluate_expectations(&turn.expectations, &output);
+                    let mut metadata = vec![
+                        ("user_input".to_string(), turn.user_input.clone()),
+                        ("response".to_string(), output.response.clone()),
+                        (
+                            "tool_call_count".to_string(),
+                            output.tool_calls.len().to_string(),
+                        ),
+                    ];
+                    if !output.tool_calls.is_empty() {
+                        let names = output
+                            .tool_calls
+                            .iter()
+                            .map(|call| call.name.clone())
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        metadata.push(("tool_calls".to_string(), names));
+                    }
+
+                    if failures.is_empty() {
+                        (TestStatus::Passed, None, metadata)
+                    } else {
+                        (TestStatus::Failed, Some(failures.join("; ")), metadata)
+                    }
+                }
+                Err(err) => {
+                    let metadata = vec![("user_input".to_string(), turn.user_input.clone())];
+                    (TestStatus::Failed, Some(err), metadata)
+                }
+            };
+
+            builder = builder.add_result(TestCaseResult {
+                name: test_name,
+                status,
+                duration: start.elapsed(),
+                error,
+                metadata,
+            });
+        }
+
+        Ok(builder.build())
+    }
+}
+
+fn evaluate_expectations(
+    expectations: &[TurnExpectation],
+    output: &ScenarioTurnOutput,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    for expectation in expectations {
+        match expectation {
+            TurnExpectation::CallTool { name } => {
+                if !output.tool_calls.iter().any(|call| call.name == *name) {
+                    failures.push(format!("expected tool '{}' to be called", name));
+                }
+            }
+            TurnExpectation::CallToolWith { name, arguments } => {
+                if !output
+                    .tool_calls
+                    .iter()
+                    .any(|call| call.name == *name && call.arguments == *arguments)
+                {
+                    failures.push(format!(
+                        "expected tool '{}' to be called with arguments {}",
+                        name, arguments
+                    ));
+                }
+            }
+            TurnExpectation::NotCallAnyTool => {
+                if !output.tool_calls.is_empty() {
+                    let called = output
+                        .tool_calls
+                        .iter()
+                        .map(|call| call.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    failures.push(format!(
+                        "expected no tool calls, but got {} call(s): {}",
+                        output.tool_calls.len(),
+                        called
+                    ));
+                }
+            }
+            TurnExpectation::RespondContaining { text } => {
+                if !output.response.contains(text) {
+                    failures.push(format!(
+                        "expected response to contain '{}', but got '{}'",
+                        text, output.response
+                    ));
+                }
+            }
+            TurnExpectation::RespondExact { text } => {
+                if output.response != *text {
+                    failures.push(format!(
+                        "expected exact response '{}', but got '{}'",
+                        text, output.response
+                    ));
+                }
+            }
+            TurnExpectation::RespondMatchingRegex { pattern } => match Regex::new(pattern) {
+                Ok(regex) => {
+                    if !regex.is_match(&output.response) {
+                        failures.push(format!(
+                            "expected response to match regex '{}', but got '{}'",
+                            pattern, output.response
+                        ));
+                    }
+                }
+                Err(err) => failures.push(format!("invalid regex '{}': {}", pattern, err)),
+            },
+        }
+    }
+
+    failures
+}
+
+fn sanitize_name(input: &str) -> String {
+    let mut name = input
+        .chars()
+        .take(24)
+        .map(|ch| if ch.is_alphanumeric() { ch } else { '_' })
+        .collect::<String>();
+
+    while name.ends_with('_') {
+        name.pop();
+    }
+
+    if name.is_empty() {
+        "turn".to_string()
+    } else {
+        name
+    }
+}
+
+/// Fluent builder for `AgentTestScenario`.
+#[derive(Debug, Clone)]
+pub struct AgentTest {
+    scenario: AgentTestScenario,
+    pending_user_input: Option<String>,
+    pending_expectations: Vec<TurnExpectation>,
+    build_errors: Vec<String>,
+}
+
+impl AgentTest {
+    pub fn new(agent_id: impl Into<String>) -> Self {
+        Self {
+            scenario: AgentTestScenario {
+                agent_id: agent_id.into(),
+                system_prompt: None,
+                tools: Vec::new(),
+                turns: Vec::new(),
+            },
+            pending_user_input: None,
+            pending_expectations: Vec::new(),
+            build_errors: Vec::new(),
+        }
+    }
+
+    pub fn given_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.scenario.system_prompt = Some(prompt.into());
+        self
+    }
+
+    pub fn given_tool(mut self, tool_name: impl Into<String>) -> Self {
+        self.scenario.tools.push(tool_name.into());
+        self
+    }
+
+    /// Convenience method that registers a `MockTool` name in the scenario.
+    pub fn given_mock_tool(mut self, tool: &MockTool) -> Self {
+        self.scenario.tools.push(tool.name().to_string());
+        self
+    }
+
+    pub fn when_user_says(mut self, user_input: impl Into<String>) -> Self {
+        self.flush_pending_turn();
+        self.pending_user_input = Some(user_input.into());
+        self
+    }
+
+    pub fn then_agent_should(self) -> Self {
+        self
+    }
+
+    pub fn call_tool(mut self, tool_name: impl Into<String>) -> Self {
+        if self.ensure_active_turn("call_tool") {
+            self.pending_expectations.push(TurnExpectation::CallTool {
+                name: tool_name.into(),
+            });
+        }
+        self
+    }
+
+    pub fn call_tool_with(mut self, tool_name: impl Into<String>, arguments: Value) -> Self {
+        if self.ensure_active_turn("call_tool_with") {
+            self.pending_expectations
+                .push(TurnExpectation::CallToolWith {
+                    name: tool_name.into(),
+                    arguments,
+                });
+        }
+        self
+    }
+
+    pub fn not_call_any_tool(mut self) -> Self {
+        if self.ensure_active_turn("not_call_any_tool") {
+            self.pending_expectations
+                .push(TurnExpectation::NotCallAnyTool);
+        }
+        self
+    }
+
+    pub fn respond_containing(mut self, text: impl Into<String>) -> Self {
+        if self.ensure_active_turn("respond_containing") {
+            self.pending_expectations
+                .push(TurnExpectation::RespondContaining { text: text.into() });
+        }
+        self
+    }
+
+    pub fn respond_exact(mut self, text: impl Into<String>) -> Self {
+        if self.ensure_active_turn("respond_exact") {
+            self.pending_expectations
+                .push(TurnExpectation::RespondExact { text: text.into() });
+        }
+        self
+    }
+
+    pub fn respond_matching_regex(mut self, pattern: impl Into<String>) -> Self {
+        if self.ensure_active_turn("respond_matching_regex") {
+            self.pending_expectations
+                .push(TurnExpectation::RespondMatchingRegex {
+                    pattern: pattern.into(),
+                });
+        }
+        self
+    }
+
+    pub fn build(mut self) -> Result<AgentTestScenario, ScenarioBuildError> {
+        self.flush_pending_turn();
+
+        let mut errors = self.build_errors;
+        if self.scenario.turns.is_empty() {
+            errors.push("scenario must include at least one turn".to_string());
+        }
+
+        if let Err(validation) = self.scenario.validate() {
+            errors.extend(validation.errors);
+        }
+
+        if errors.is_empty() {
+            Ok(self.scenario)
+        } else {
+            Err(ScenarioBuildError::new(errors))
+        }
+    }
+
+    fn ensure_active_turn(&mut self, method_name: &str) -> bool {
+        if self.pending_user_input.is_none() {
+            self.build_errors.push(format!(
+                "{}() must be called after when_user_says()",
+                method_name
+            ));
+            false
+        } else {
+            true
+        }
+    }
+
+    fn flush_pending_turn(&mut self) {
+        if let Some(user_input) = self.pending_user_input.take() {
+            let expectations = std::mem::take(&mut self.pending_expectations);
+            self.scenario.turns.push(ScenarioTurn {
+                user_input,
+                expectations,
+            });
+        }
+    }
+}
+
+/// Rule defining when a `MockTool` should be invoked by `MockScenarioAgent`.
+#[derive(Debug, Clone)]
+pub struct ToolInvocationRule {
+    pub prompt_substring: String,
+    pub tool_name: String,
+    pub arguments: Value,
+}
+
+/// A practical scenario agent harness that combines `MockLLMBackend` and `MockTool`.
+///
+/// Each turn:
+/// 1. Calls `backend.infer(model_id, user_input)` to generate response text.
+/// 2. Executes tools for all matching `ToolInvocationRule` prompt patterns.
+/// 3. Emits `ToolCallRecord` entries for expectation validation.
+pub struct MockScenarioAgent {
+    model_id: String,
+    backend: MockLLMBackend,
+    tools: HashMap<String, MockTool>,
+    tool_rules: Vec<ToolInvocationRule>,
+}
+
+impl MockScenarioAgent {
+    pub fn new(model_id: impl Into<String>, backend: MockLLMBackend) -> Self {
+        Self {
+            model_id: model_id.into(),
+            backend,
+            tools: HashMap::new(),
+            tool_rules: Vec::new(),
+        }
+    }
+
+    pub fn with_mock_tool(mut self, tool: MockTool) -> Self {
+        self.tools.insert(tool.name().to_string(), tool);
+        self
+    }
+
+    pub fn add_tool_rule(
+        mut self,
+        prompt_substring: impl Into<String>,
+        tool_name: impl Into<String>,
+        arguments: Value,
+    ) -> Self {
+        self.tool_rules.push(ToolInvocationRule {
+            prompt_substring: prompt_substring.into(),
+            tool_name: tool_name.into(),
+            arguments,
+        });
+        self
+    }
+}
+
+#[async_trait]
+impl ScenarioAgent for MockScenarioAgent {
+    async fn execute_turn(
+        &mut self,
+        _system_prompt: Option<&str>,
+        user_input: &str,
+    ) -> Result<ScenarioTurnOutput, String> {
+        let response = self
+            .backend
+            .infer(&self.model_id, user_input)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let mut tool_calls = Vec::new();
+
+        for rule in &self.tool_rules {
+            if !user_input.contains(&rule.prompt_substring) {
+                continue;
+            }
+
+            let tool = self.tools.get(&rule.tool_name).ok_or_else(|| {
+                format!(
+                    "tool '{}' not registered in MockScenarioAgent",
+                    rule.tool_name
+                )
+            })?;
+
+            let input = ToolInput::from_json(rule.arguments.clone());
+            let result = tool.execute(input).await;
+
+            if !result.success {
+                return Err(format!(
+                    "tool '{}' failed: {}",
+                    rule.tool_name,
+                    result
+                        .error
+                        .unwrap_or_else(|| "unknown tool error".to_string())
+                ));
+            }
+
+            tool_calls.push(ToolCallRecord {
+                name: rule.tool_name.clone(),
+                arguments: rule.arguments.clone(),
+            });
+        }
+
+        Ok(ScenarioTurnOutput {
+            response,
+            tool_calls,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ScenarioFile {
+    agent_id: String,
+    #[serde(default)]
+    system_prompt: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    turns: Vec<ScenarioFileTurn>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ScenarioFileTurn {
+    user: String,
+    #[serde(default, alias = "expectations")]
+    expect: Vec<ScenarioFileExpectation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ScenarioFileExpectation {
+    CallTool { name: String },
+    CallToolWith { name: String, arguments: Value },
+    NotCallAnyTool,
+    RespondContaining { text: String },
+    RespondExact { text: String },
+    RespondMatchingRegex { pattern: String },
+}
+
+impl From<ScenarioFileExpectation> for TurnExpectation {
+    fn from(value: ScenarioFileExpectation) -> Self {
+        match value {
+            ScenarioFileExpectation::CallTool { name } => TurnExpectation::CallTool { name },
+            ScenarioFileExpectation::CallToolWith { name, arguments } => {
+                TurnExpectation::CallToolWith { name, arguments }
+            }
+            ScenarioFileExpectation::NotCallAnyTool => TurnExpectation::NotCallAnyTool,
+            ScenarioFileExpectation::RespondContaining { text } => {
+                TurnExpectation::RespondContaining { text }
+            }
+            ScenarioFileExpectation::RespondExact { text } => {
+                TurnExpectation::RespondExact { text }
+            }
+            ScenarioFileExpectation::RespondMatchingRegex { pattern } => {
+                TurnExpectation::RespondMatchingRegex { pattern }
+            }
+        }
+    }
+}
+
+impl From<ScenarioFile> for AgentTestScenario {
+    fn from(value: ScenarioFile) -> Self {
+        Self {
+            agent_id: value.agent_id,
+            system_prompt: value.system_prompt,
+            tools: value.tools,
+            turns: value
+                .turns
+                .into_iter()
+                .map(|turn| ScenarioTurn {
+                    user_input: turn.user,
+                    expectations: turn.expect.into_iter().map(Into::into).collect(),
+                })
+                .collect(),
+        }
+    }
+}

--- a/tests/src/golden.rs
+++ b/tests/src/golden.rs
@@ -1,0 +1,661 @@
+//! Golden response testing for the MoFA testing framework.
+//!
+//! This module provides snapshot-based testing: record agent outputs as golden
+//! baselines, then compare future runs against them to detect regressions.
+//!
+//! # Overview
+//!
+//! - [`GoldenSnapshot`]: serializable record of one scenario's turn outputs.
+//! - [`GoldenStore`]: reads/writes golden snapshot files from a directory.
+//! - [`GoldenCompareMode`]: strict validation vs. update mode.
+//! - [`GoldenDiff`]: structured per-field diff when actual output diverges.
+//! - [`GoldenResult`]: per-turn comparison outcome.
+//! - [`Normalizer`]: pluggable text normalization to ignore non-deterministic fragments.
+//! - [`run_golden_test`]: captures scenario output and compares against stored golden.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::dsl::{ScenarioAgent, ScenarioTurnOutput, ToolCallRecord};
+use crate::report::{TestCaseResult, TestReport, TestReportBuilder, TestStatus};
+
+// ─── Error types ────────────────────────────────────────────────────────────
+
+/// Errors produced during golden test operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GoldenError {
+    /// Snapshot file could not be read.
+    ReadFailed(String),
+    /// Snapshot file could not be written.
+    WriteFailed(String),
+    /// Snapshot file contains invalid data.
+    ParseFailed(String),
+    /// Golden snapshot not found and mode is strict.
+    SnapshotNotFound { test_name: String },
+    /// Actual output diverges from golden baseline.
+    Mismatch {
+        test_name: String,
+        diffs: Vec<GoldenDiff>,
+    },
+}
+
+impl Display for GoldenError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadFailed(msg) => write!(f, "golden snapshot read failed: {msg}"),
+            Self::WriteFailed(msg) => write!(f, "golden snapshot write failed: {msg}"),
+            Self::ParseFailed(msg) => write!(f, "golden snapshot parse failed: {msg}"),
+            Self::SnapshotNotFound { test_name } => {
+                write!(f, "golden snapshot not found for test '{test_name}'")
+            }
+            Self::Mismatch { test_name, diffs } => {
+                let diff_msgs: Vec<String> = diffs.iter().map(|d| d.to_string()).collect();
+                write!(
+                    f,
+                    "golden mismatch for '{}': {}",
+                    test_name,
+                    diff_msgs.join("; ")
+                )
+            }
+        }
+    }
+}
+
+impl Error for GoldenError {}
+
+// ─── GoldenDiff ─────────────────────────────────────────────────────────────
+
+/// Describes a single field-level difference between actual and golden output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum GoldenDiff {
+    /// Turn count differs.
+    TurnCountMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    /// Response text differs for a specific turn.
+    ResponseMismatch {
+        turn: usize,
+        expected: String,
+        actual: String,
+    },
+    /// Tool call count differs for a specific turn.
+    ToolCallCountMismatch {
+        turn: usize,
+        expected: usize,
+        actual: usize,
+    },
+    /// Tool call at a specific position differs.
+    ToolCallMismatch {
+        turn: usize,
+        index: usize,
+        expected_name: String,
+        actual_name: String,
+    },
+    /// Tool call arguments differ.
+    ToolCallArgsMismatch {
+        turn: usize,
+        tool_name: String,
+        expected: Value,
+        actual: Value,
+    },
+}
+
+impl Display for GoldenDiff {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TurnCountMismatch { expected, actual } => {
+                write!(f, "turn count: expected {expected}, got {actual}")
+            }
+            Self::ResponseMismatch {
+                turn,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "turn {turn} response: expected \"{expected}\", got \"{actual}\""
+                )
+            }
+            Self::ToolCallCountMismatch {
+                turn,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "turn {turn} tool call count: expected {expected}, got {actual}"
+                )
+            }
+            Self::ToolCallMismatch {
+                turn,
+                index,
+                expected_name,
+                actual_name,
+            } => {
+                write!(
+                    f,
+                    "turn {turn} tool[{index}]: expected \"{expected_name}\", got \"{actual_name}\""
+                )
+            }
+            Self::ToolCallArgsMismatch {
+                turn,
+                tool_name,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "turn {turn} tool \"{tool_name}\" args: expected {expected}, got {actual}"
+                )
+            }
+        }
+    }
+}
+
+// ─── GoldenSnapshot ─────────────────────────────────────────────────────────
+
+/// A golden snapshot recording the expected outputs for each turn in a scenario.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GoldenSnapshot {
+    /// Identifier matching the scenario's agent_id.
+    pub test_name: String,
+    /// Recorded turn outputs.
+    pub turns: Vec<GoldenTurnSnapshot>,
+    /// Optional metadata (e.g. creation timestamp, model version).
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// Golden record for a single turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GoldenTurnSnapshot {
+    pub user_input: String,
+    pub response: String,
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+
+impl GoldenSnapshot {
+    /// Create a snapshot from a test name and collected turn outputs.
+    pub fn new(
+        test_name: impl Into<String>,
+        turns: Vec<GoldenTurnSnapshot>,
+    ) -> Self {
+        Self {
+            test_name: test_name.into(),
+            turns,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    /// Attach metadata (e.g. model version, timestamp).
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Serialize to pretty-printed JSON.
+    pub fn to_json(&self) -> Result<String, GoldenError> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| GoldenError::WriteFailed(e.to_string()))
+    }
+
+    /// Deserialize from JSON.
+    pub fn from_json(input: &str) -> Result<Self, GoldenError> {
+        serde_json::from_str(input)
+            .map_err(|e| GoldenError::ParseFailed(e.to_string()))
+    }
+
+    /// Serialize to YAML.
+    pub fn to_yaml(&self) -> Result<String, GoldenError> {
+        serde_yaml::to_string(self)
+            .map_err(|e| GoldenError::WriteFailed(e.to_string()))
+    }
+
+    /// Deserialize from YAML.
+    pub fn from_yaml(input: &str) -> Result<Self, GoldenError> {
+        serde_yaml::from_str(input)
+            .map_err(|e| GoldenError::ParseFailed(e.to_string()))
+    }
+}
+
+// ─── Normalizer ─────────────────────────────────────────────────────────────
+
+/// Pluggable text normalizer for stripping non-deterministic fragments.
+///
+/// Apply normalizers before comparison so that timestamps, UUIDs, and other
+/// volatile content don't cause false mismatches.
+pub trait Normalizer: Send + Sync {
+    /// Transform a response string into its normalized form.
+    fn normalize(&self, input: &str) -> String;
+}
+
+/// Strips leading/trailing whitespace and collapses internal runs of whitespace.
+#[derive(Debug, Clone, Default)]
+pub struct WhitespaceNormalizer;
+
+impl Normalizer for WhitespaceNormalizer {
+    fn normalize(&self, input: &str) -> String {
+        input.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+}
+
+/// Replaces patterns matching a regex with a fixed placeholder.
+#[derive(Debug, Clone)]
+pub struct RegexNormalizer {
+    pattern: regex::Regex,
+    replacement: String,
+}
+
+impl RegexNormalizer {
+    /// Create a normalizer that replaces all matches of `pattern` with `replacement`.
+    pub fn new(pattern: &str, replacement: impl Into<String>) -> Result<Self, GoldenError> {
+        let regex = regex::Regex::new(pattern)
+            .map_err(|e| GoldenError::ParseFailed(format!("invalid normalizer regex: {e}")))?;
+        Ok(Self {
+            pattern: regex,
+            replacement: replacement.into(),
+        })
+    }
+}
+
+impl Normalizer for RegexNormalizer {
+    fn normalize(&self, input: &str) -> String {
+        self.pattern.replace_all(input, &self.replacement).to_string()
+    }
+}
+
+/// Chains multiple normalizers in sequence.
+#[derive(Default)]
+pub struct NormalizerChain {
+    normalizers: Vec<Box<dyn Normalizer>>,
+}
+
+impl NormalizerChain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(mut self, normalizer: impl Normalizer + 'static) -> Self {
+        self.normalizers.push(Box::new(normalizer));
+        self
+    }
+
+    /// Build a chain with common normalizers (whitespace + UUID + ISO timestamp).
+    pub fn default_chain() -> Result<Self, GoldenError> {
+        Ok(Self::new()
+            .add(WhitespaceNormalizer)
+            .add(RegexNormalizer::new(
+                r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+                "<UUID>",
+            )?)
+            .add(RegexNormalizer::new(
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+                "<TIMESTAMP>",
+            )?))
+    }
+}
+
+impl Normalizer for NormalizerChain {
+    fn normalize(&self, input: &str) -> String {
+        let mut result = input.to_string();
+        for n in &self.normalizers {
+            result = n.normalize(&result);
+        }
+        result
+    }
+}
+
+// ─── GoldenStore ────────────────────────────────────────────────────────────
+
+/// Filesystem-backed store for golden snapshot files.
+///
+/// Each snapshot is stored as `{test_name}.golden.json` inside the store's
+/// root directory.
+pub struct GoldenStore {
+    root: PathBuf,
+}
+
+impl GoldenStore {
+    /// Create a store rooted at the given directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Path to the snapshot file for a given test name.
+    pub fn snapshot_path(&self, test_name: &str) -> PathBuf {
+        let safe_name = test_name
+            .chars()
+            .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+            .collect::<String>();
+        self.root.join(format!("{safe_name}.golden.json"))
+    }
+
+    /// Check if a golden snapshot exists for the given test name.
+    pub fn exists(&self, test_name: &str) -> bool {
+        self.snapshot_path(test_name).exists()
+    }
+
+    /// Load a golden snapshot from disk.
+    pub fn load(&self, test_name: &str) -> Result<GoldenSnapshot, GoldenError> {
+        let path = self.snapshot_path(test_name);
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| GoldenError::ReadFailed(format!("{}: {e}", path.display())))?;
+        GoldenSnapshot::from_json(&content)
+    }
+
+    /// Save a golden snapshot to disk (creates parent directories).
+    pub fn save(&self, snapshot: &GoldenSnapshot) -> Result<PathBuf, GoldenError> {
+        let path = self.snapshot_path(&snapshot.test_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| GoldenError::WriteFailed(format!("mkdir {}: {e}", parent.display())))?;
+        }
+        let json = snapshot.to_json()?;
+        std::fs::write(&path, &json)
+            .map_err(|e| GoldenError::WriteFailed(format!("{}: {e}", path.display())))?;
+        Ok(path)
+    }
+
+    /// List all golden snapshot files in the store.
+    pub fn list(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&self.root) {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                if file_name.ends_with(".golden.json") {
+                    names.push(file_name.trim_end_matches(".golden.json").to_string());
+                }
+            }
+        }
+        names.sort();
+        names
+    }
+}
+
+// ─── Comparison ─────────────────────────────────────────────────────────────
+
+/// Compare mode for golden tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GoldenCompareMode {
+    /// Strict: fail if actual differs from golden.
+    Strict,
+    /// Update: overwrite golden with actual output (for baseline refresh).
+    Update,
+}
+
+/// Result of comparing actual output against a golden snapshot.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GoldenCompareResult {
+    pub test_name: String,
+    pub mode: GoldenCompareMode,
+    pub passed: bool,
+    pub diffs: Vec<GoldenDiff>,
+    /// Set to true if the golden was updated (only in Update mode).
+    pub updated: bool,
+}
+
+/// Compare actual turn outputs against a golden snapshot.
+///
+/// Optionally applies a `Normalizer` to response text before comparison.
+pub fn compare_golden(
+    golden: &GoldenSnapshot,
+    actual_turns: &[(String, ScenarioTurnOutput)],
+    normalizer: Option<&dyn Normalizer>,
+) -> Vec<GoldenDiff> {
+    let mut diffs = Vec::new();
+
+    if golden.turns.len() != actual_turns.len() {
+        diffs.push(GoldenDiff::TurnCountMismatch {
+            expected: golden.turns.len(),
+            actual: actual_turns.len(),
+        });
+        return diffs;
+    }
+
+    for (idx, (golden_turn, (_user_input, actual_output))) in
+        golden.turns.iter().zip(actual_turns.iter()).enumerate()
+    {
+        let turn_num = idx + 1;
+
+        // Compare response text
+        let expected_response = match normalizer {
+            Some(n) => n.normalize(&golden_turn.response),
+            None => golden_turn.response.clone(),
+        };
+        let actual_response = match normalizer {
+            Some(n) => n.normalize(&actual_output.response),
+            None => actual_output.response.clone(),
+        };
+
+        if expected_response != actual_response {
+            diffs.push(GoldenDiff::ResponseMismatch {
+                turn: turn_num,
+                expected: golden_turn.response.clone(),
+                actual: actual_output.response.clone(),
+            });
+        }
+
+        // Compare tool call count
+        if golden_turn.tool_calls.len() != actual_output.tool_calls.len() {
+            diffs.push(GoldenDiff::ToolCallCountMismatch {
+                turn: turn_num,
+                expected: golden_turn.tool_calls.len(),
+                actual: actual_output.tool_calls.len(),
+            });
+            continue;
+        }
+
+        // Compare tool calls by position
+        for (tc_idx, (expected_tc, actual_tc)) in golden_turn
+            .tool_calls
+            .iter()
+            .zip(actual_output.tool_calls.iter())
+            .enumerate()
+        {
+            if expected_tc.name != actual_tc.name {
+                diffs.push(GoldenDiff::ToolCallMismatch {
+                    turn: turn_num,
+                    index: tc_idx,
+                    expected_name: expected_tc.name.clone(),
+                    actual_name: actual_tc.name.clone(),
+                });
+            } else if expected_tc.arguments != actual_tc.arguments {
+                diffs.push(GoldenDiff::ToolCallArgsMismatch {
+                    turn: turn_num,
+                    tool_name: expected_tc.name.clone(),
+                    expected: expected_tc.arguments.clone(),
+                    actual: actual_tc.arguments.clone(),
+                });
+            }
+        }
+    }
+
+    diffs
+}
+
+// ─── Golden test runner ─────────────────────────────────────────────────────
+
+/// Configuration for running a golden test.
+pub struct GoldenTestConfig {
+    /// Store for reading/writing snapshots.
+    pub store: GoldenStore,
+    /// Comparison mode.
+    pub mode: GoldenCompareMode,
+    /// Optional normalizer for response text.
+    pub normalizer: Option<Box<dyn Normalizer>>,
+}
+
+impl GoldenTestConfig {
+    /// Create a config in strict comparison mode.
+    pub fn strict(store: GoldenStore) -> Self {
+        Self {
+            store,
+            mode: GoldenCompareMode::Strict,
+            normalizer: None,
+        }
+    }
+
+    /// Create a config in update mode (rewrites goldens).
+    pub fn update(store: GoldenStore) -> Self {
+        Self {
+            store,
+            mode: GoldenCompareMode::Update,
+            normalizer: None,
+        }
+    }
+
+    /// Attach a normalizer.
+    pub fn with_normalizer(mut self, normalizer: impl Normalizer + 'static) -> Self {
+        self.normalizer = Some(Box::new(normalizer));
+        self
+    }
+}
+
+/// Run a golden test for a scenario.
+///
+/// 1. Executes all turns of the scenario with the given agent.
+/// 2. In **Update** mode: saves the outputs as the new golden baseline.
+/// 3. In **Strict** mode: compares against the stored golden and reports diffs.
+///
+/// Returns a `TestReport` with golden comparison results.
+pub async fn run_golden_test<A: ScenarioAgent>(
+    config: &GoldenTestConfig,
+    scenario: &crate::dsl::AgentTestScenario,
+    agent: &mut A,
+) -> TestReport {
+    let test_name = &scenario.agent_id;
+    let mut builder = TestReportBuilder::new(format!("golden:{test_name}"));
+
+    // 1. Execute all turns and collect outputs
+    let mut turn_outputs: Vec<(String, ScenarioTurnOutput)> = Vec::new();
+    let mut execution_failed = false;
+
+    for turn in &scenario.turns {
+        let result = agent
+            .execute_turn(scenario.system_prompt.as_deref(), &turn.user_input)
+            .await;
+
+        match result {
+            Ok(output) => {
+                turn_outputs.push((turn.user_input.clone(), output));
+            }
+            Err(err) => {
+                builder = builder.add_result(TestCaseResult {
+                    name: format!("golden_execution_{test_name}"),
+                    status: TestStatus::Failed,
+                    duration: std::time::Duration::from_secs(0),
+                    error: Some(format!("agent execution failed: {err}")),
+                    metadata: vec![],
+                });
+                execution_failed = true;
+                break;
+            }
+        }
+    }
+
+    if execution_failed {
+        return builder.build();
+    }
+
+    // 2. Build snapshot from actual outputs
+    let actual_snapshot = GoldenSnapshot::new(
+        test_name.clone(),
+        turn_outputs
+            .iter()
+            .map(|(user_input, output)| GoldenTurnSnapshot {
+                user_input: user_input.clone(),
+                response: output.response.clone(),
+                tool_calls: output.tool_calls.clone(),
+            })
+            .collect(),
+    );
+
+    match config.mode {
+        GoldenCompareMode::Update => {
+            // Save the snapshot as the new golden baseline
+            match config.store.save(&actual_snapshot) {
+                Ok(path) => {
+                    builder = builder.add_result(TestCaseResult {
+                        name: format!("golden_update_{test_name}"),
+                        status: TestStatus::Passed,
+                        duration: std::time::Duration::from_secs(0),
+                        error: None,
+                        metadata: vec![
+                            ("mode".to_string(), "update".to_string()),
+                            ("snapshot_path".to_string(), path.display().to_string()),
+                            ("turn_count".to_string(), turn_outputs.len().to_string()),
+                        ],
+                    });
+                }
+                Err(err) => {
+                    builder = builder.add_result(TestCaseResult {
+                        name: format!("golden_update_{test_name}"),
+                        status: TestStatus::Failed,
+                        duration: std::time::Duration::from_secs(0),
+                        error: Some(err.to_string()),
+                        metadata: vec![("mode".to_string(), "update".to_string())],
+                    });
+                }
+            }
+        }
+        GoldenCompareMode::Strict => {
+            // Load existing golden and compare
+            match config.store.load(test_name) {
+                Ok(golden) => {
+                    let diffs = compare_golden(
+                        &golden,
+                        &turn_outputs,
+                        config.normalizer.as_deref(),
+                    );
+
+                    if diffs.is_empty() {
+                        builder = builder.add_result(TestCaseResult {
+                            name: format!("golden_compare_{test_name}"),
+                            status: TestStatus::Passed,
+                            duration: std::time::Duration::from_secs(0),
+                            error: None,
+                            metadata: vec![
+                                ("mode".to_string(), "strict".to_string()),
+                                ("turn_count".to_string(), turn_outputs.len().to_string()),
+                            ],
+                        });
+                    } else {
+                        let diff_msgs: Vec<String> =
+                            diffs.iter().map(|d| d.to_string()).collect();
+                        builder = builder.add_result(TestCaseResult {
+                            name: format!("golden_compare_{test_name}"),
+                            status: TestStatus::Failed,
+                            duration: std::time::Duration::from_secs(0),
+                            error: Some(diff_msgs.join("\n")),
+                            metadata: vec![
+                                ("mode".to_string(), "strict".to_string()),
+                                ("diff_count".to_string(), diffs.len().to_string()),
+                            ],
+                        });
+                    }
+                }
+                Err(_) => {
+                    builder = builder.add_result(TestCaseResult {
+                        name: format!("golden_compare_{test_name}"),
+                        status: TestStatus::Failed,
+                        duration: std::time::Duration::from_secs(0),
+                        error: Some(format!(
+                            "golden snapshot not found for '{test_name}'. Run with update mode to create baseline."
+                        )),
+                        metadata: vec![("mode".to_string(), "strict".to_string())],
+                    });
+                }
+            }
+        }
+    }
+
+    builder.build()
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod dsl;
+pub mod golden;
 pub mod parameterized;
 pub mod report;
 pub mod tools;
@@ -24,6 +25,11 @@ pub use dsl::{
 pub use parameterized::{
     ParameterExpansionError, ParameterMatrix, ParameterSet, ParameterizedScenario,
     ParameterizedScenarioFile,
+};
+pub use golden::{
+    GoldenCompareMode, GoldenCompareResult, GoldenDiff, GoldenError, GoldenSnapshot, GoldenStore,
+    GoldenTestConfig, GoldenTurnSnapshot, NormalizerChain, RegexNormalizer, WhitespaceNormalizer,
+    compare_golden, run_golden_test,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ pub mod backend;
 pub mod bus;
 pub mod clock;
 pub mod dsl;
+pub mod parameterized;
 pub mod report;
 pub mod tools;
 
@@ -19,6 +20,10 @@ pub use dsl::{
     AgentTest, AgentTestScenario, MockScenarioAgent, ScenarioAgent, ScenarioBuildError,
     ScenarioLoadError, ScenarioTurn, ScenarioTurnOutput, ToolCallRecord, ToolInvocationRule,
     TurnExpectation,
+};
+pub use parameterized::{
+    ParameterExpansionError, ParameterMatrix, ParameterSet, ParameterizedScenario,
+    ParameterizedScenarioFile,
 };
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,6 +12,7 @@ pub mod dsl;
 pub mod golden;
 pub mod parameterized;
 pub mod report;
+pub mod semantic;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
@@ -34,5 +35,10 @@ pub use golden::{
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,
+};
+pub use semantic::{
+    ContainsAllFactsMatcher, ExcludesContentMatcher, IntentMatcher, RegexIntentMatcher,
+    SemanticAssertionError, SemanticAssertionSet, SemanticExpectation, SemanticMatchResult,
+    SemanticMatcher, SemanticReport, SimilarityMatcher,
 };
 pub use tools::MockTool;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,12 +8,18 @@ pub mod assertions;
 pub mod backend;
 pub mod bus;
 pub mod clock;
+pub mod dsl;
 pub mod report;
 pub mod tools;
 
 pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
+pub use dsl::{
+    AgentTest, AgentTestScenario, MockScenarioAgent, ScenarioAgent, ScenarioBuildError,
+    ScenarioLoadError, ScenarioTurn, ScenarioTurnOutput, ToolCallRecord, ToolInvocationRule,
+    TurnExpectation,
+};
 pub use report::{
     JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
     TextFormatter,

--- a/tests/src/parameterized.rs
+++ b/tests/src/parameterized.rs
@@ -1,0 +1,636 @@
+//! Parameterized scenario expansion for the MoFA testing framework.
+//!
+//! This module enables a single scenario template to expand into many concrete
+//! test cases by substituting variable placeholders with values from parameter
+//! sets.
+//!
+//! # Overview
+//!
+//! - [`ParameterSet`]: a named map of variable → value bindings for one test variant.
+//! - [`ParameterMatrix`]: generates the Cartesian product of multiple variable dimensions.
+//! - [`ParameterizedScenario`]: wraps an [`AgentTestScenario`] template and expands it
+//!   against a list of [`ParameterSet`]s.
+//! - [`ParameterizedScenarioFile`]: YAML/TOML/JSON-loadable file that bundles a template
+//!   scenario and inline parameter sets.
+//!
+//! Placeholder syntax is `{{variable_name}}` inside `user_input`, `text`, and
+//! `pattern` fields of the scenario template.
+
+use std::collections::{BTreeMap, HashMap};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::dsl::{
+    AgentTestScenario, ScenarioLoadError, ScenarioTurn, TurnExpectation,
+};
+
+// ─── Error types ────────────────────────────────────────────────────────────
+
+/// Errors produced during parameterized expansion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParameterExpansionError {
+    /// No parameter sets were provided.
+    EmptyParameterSets,
+    /// Matrix expansion would produce no cases (some dimension is empty).
+    EmptyMatrixDimension { variable: String },
+    /// A placeholder in the template has no corresponding variable binding.
+    MissingVariable {
+        set_name: String,
+        variable: String,
+    },
+    /// Matrix expansion exceeds the configured safety limit.
+    MatrixExpansionLimit {
+        requested: usize,
+        limit: usize,
+    },
+    /// Scenario validation failed after expansion.
+    ValidationFailed(Vec<String>),
+    /// File deserialization failed.
+    LoadError(ScenarioLoadError),
+}
+
+impl Display for ParameterExpansionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyParameterSets => write!(f, "parameter set list is empty"),
+            Self::EmptyMatrixDimension { variable } => {
+                write!(f, "matrix dimension '{}' has no values", variable)
+            }
+            Self::MissingVariable { set_name, variable } => {
+                write!(
+                    f,
+                    "parameter set '{}' is missing variable '{}'",
+                    set_name, variable
+                )
+            }
+            Self::MatrixExpansionLimit { requested, limit } => {
+                write!(
+                    f,
+                    "matrix expansion would produce {} cases, exceeding limit of {}",
+                    requested, limit
+                )
+            }
+            Self::ValidationFailed(errors) => {
+                write!(f, "expanded scenario validation failed: {}", errors.join("; "))
+            }
+            Self::LoadError(err) => write!(f, "parameterized scenario load error: {}", err),
+        }
+    }
+}
+
+impl Error for ParameterExpansionError {}
+
+// ─── ParameterSet ───────────────────────────────────────────────────────────
+
+/// A named set of variable bindings for one parameterized test variant.
+///
+/// The name is used in expanded test case names for traceability.
+/// Variables are substituted into `{{variable}}` placeholders in the template.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParameterSet {
+    pub name: String,
+    #[serde(flatten)]
+    pub variables: BTreeMap<String, String>,
+}
+
+impl ParameterSet {
+    /// Create a parameter set with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            variables: BTreeMap::new(),
+        }
+    }
+
+    /// Add a variable binding.
+    pub fn with_var(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.variables.insert(key.into(), value.into());
+        self
+    }
+
+    /// Look up a variable value.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.variables.get(key).map(|s| s.as_str())
+    }
+}
+
+// ─── ParameterMatrix ────────────────────────────────────────────────────────
+
+/// Default safety limit for Cartesian product expansion.
+const DEFAULT_MATRIX_LIMIT: usize = 10_000;
+
+/// Generates [`ParameterSet`]s from the Cartesian product of variable dimensions.
+///
+/// Each dimension is a variable name mapped to a list of possible values.
+/// The product of all dimensions produces the full matrix of test variants.
+///
+/// # Example
+///
+/// ```ignore
+/// let sets = ParameterMatrix::new()
+///     .dimension("city", vec!["Berlin", "Tokyo", "NYC"])
+///     .dimension("unit", vec!["celsius", "fahrenheit"])
+///     .expand()?;
+/// // Produces 6 parameter sets: Berlin×celsius, Berlin×fahrenheit, …
+/// ```
+#[derive(Debug, Clone)]
+pub struct ParameterMatrix {
+    /// Insertion-ordered dimensions to preserve deterministic expansion order.
+    dimensions: Vec<(String, Vec<String>)>,
+    limit: usize,
+}
+
+impl Default for ParameterMatrix {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParameterMatrix {
+    /// Create an empty matrix with the default expansion limit.
+    pub fn new() -> Self {
+        Self {
+            dimensions: Vec::new(),
+            limit: DEFAULT_MATRIX_LIMIT,
+        }
+    }
+
+    /// Set the maximum number of expanded cases (default: 10 000).
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Add a dimension (variable with possible values).
+    pub fn dimension(
+        mut self,
+        variable: impl Into<String>,
+        values: Vec<impl Into<String>>,
+    ) -> Self {
+        self.dimensions.push((
+            variable.into(),
+            values.into_iter().map(Into::into).collect(),
+        ));
+        self
+    }
+
+    /// Compute the total number of combinations without allocating.
+    pub fn combination_count(&self) -> usize {
+        self.dimensions
+            .iter()
+            .map(|(_, vals)| vals.len())
+            .product()
+    }
+
+    /// Expand the matrix into concrete [`ParameterSet`]s.
+    pub fn expand(&self) -> Result<Vec<ParameterSet>, ParameterExpansionError> {
+        // Validate dimensions
+        for (var, vals) in &self.dimensions {
+            if vals.is_empty() {
+                return Err(ParameterExpansionError::EmptyMatrixDimension {
+                    variable: var.clone(),
+                });
+            }
+        }
+
+        if self.dimensions.is_empty() {
+            return Err(ParameterExpansionError::EmptyParameterSets);
+        }
+
+        let total = self.combination_count();
+        if total > self.limit {
+            return Err(ParameterExpansionError::MatrixExpansionLimit {
+                requested: total,
+                limit: self.limit,
+            });
+        }
+
+        let mut sets = Vec::with_capacity(total);
+        let mut indices = vec![0usize; self.dimensions.len()];
+
+        loop {
+            // Build name and variables from current indices
+            let name_parts: Vec<String> = self
+                .dimensions
+                .iter()
+                .zip(indices.iter())
+                .map(|((_, vals), &idx)| vals[idx].clone())
+                .collect();
+            let name = name_parts.join("_");
+
+            let mut ps = ParameterSet::new(&name);
+            for ((var, vals), &idx) in self.dimensions.iter().zip(indices.iter()) {
+                ps.variables.insert(var.clone(), vals[idx].clone());
+            }
+            sets.push(ps);
+
+            // Increment odometer
+            if !increment_indices(&mut indices, &self.dimensions) {
+                break;
+            }
+        }
+
+        Ok(sets)
+    }
+}
+
+/// Odometer-style increment. Returns false when all combinations exhausted.
+fn increment_indices(indices: &mut [usize], dimensions: &[(String, Vec<String>)]) -> bool {
+    for i in (0..indices.len()).rev() {
+        indices[i] += 1;
+        if indices[i] < dimensions[i].1.len() {
+            return true;
+        }
+        indices[i] = 0;
+    }
+    false
+}
+
+// ─── ParameterizedScenario ──────────────────────────────────────────────────
+
+/// A scenario template + parameter sets that expand into multiple concrete scenarios.
+#[derive(Debug, Clone)]
+pub struct ParameterizedScenario {
+    template: AgentTestScenario,
+    parameter_sets: Vec<ParameterSet>,
+}
+
+impl ParameterizedScenario {
+    /// Create a parameterized scenario from a template and parameter sets.
+    pub fn new(
+        template: AgentTestScenario,
+        parameter_sets: Vec<ParameterSet>,
+    ) -> Self {
+        Self {
+            template,
+            parameter_sets,
+        }
+    }
+
+    /// The number of expanded test cases.
+    pub fn case_count(&self) -> usize {
+        self.parameter_sets.len()
+    }
+
+    /// Access the raw parameter sets.
+    pub fn parameter_sets(&self) -> &[ParameterSet] {
+        &self.parameter_sets
+    }
+
+    /// Expand the template into concrete scenarios.
+    ///
+    /// Each expanded scenario has a unique `agent_id` of the form
+    /// `{original_agent_id}[{parameter_set_name}]` for stable identification.
+    pub fn expand(&self) -> Result<Vec<AgentTestScenario>, ParameterExpansionError> {
+        if self.parameter_sets.is_empty() {
+            return Err(ParameterExpansionError::EmptyParameterSets);
+        }
+
+        // Collect all placeholders in the template
+        let placeholders = collect_placeholders(&self.template);
+
+        let mut expanded = Vec::with_capacity(self.parameter_sets.len());
+
+        for ps in &self.parameter_sets {
+            // Validate all placeholders have bindings
+            for placeholder in &placeholders {
+                if !ps.variables.contains_key(placeholder) {
+                    return Err(ParameterExpansionError::MissingVariable {
+                        set_name: ps.name.clone(),
+                        variable: placeholder.clone(),
+                    });
+                }
+            }
+
+            let scenario = substitute_scenario(&self.template, ps);
+
+            if let Err(err) = scenario.validate() {
+                return Err(ParameterExpansionError::ValidationFailed(err.errors));
+            }
+
+            expanded.push(scenario);
+        }
+
+        Ok(expanded)
+    }
+}
+
+/// Collect all `{{variable}}` placeholders found in the template.
+fn collect_placeholders(scenario: &AgentTestScenario) -> Vec<String> {
+    let mut placeholders = Vec::new();
+    let re = regex::Regex::new(r"\{\{(\w+)\}\}").expect("placeholder regex is valid");
+
+    // Scan agent_id
+    for cap in re.captures_iter(&scenario.agent_id) {
+        placeholders.push(cap[1].to_string());
+    }
+
+    // Scan system prompt
+    if let Some(prompt) = &scenario.system_prompt {
+        for cap in re.captures_iter(prompt) {
+            placeholders.push(cap[1].to_string());
+        }
+    }
+
+    // Scan turns
+    for turn in &scenario.turns {
+        for cap in re.captures_iter(&turn.user_input) {
+            placeholders.push(cap[1].to_string());
+        }
+        for expectation in &turn.expectations {
+            match expectation {
+                TurnExpectation::RespondContaining { text }
+                | TurnExpectation::RespondExact { text } => {
+                    for cap in re.captures_iter(text) {
+                        placeholders.push(cap[1].to_string());
+                    }
+                }
+                TurnExpectation::RespondMatchingRegex { pattern } => {
+                    for cap in re.captures_iter(pattern) {
+                        placeholders.push(cap[1].to_string());
+                    }
+                }
+                TurnExpectation::CallTool { name } => {
+                    for cap in re.captures_iter(name) {
+                        placeholders.push(cap[1].to_string());
+                    }
+                }
+                TurnExpectation::CallToolWith { name, .. } => {
+                    for cap in re.captures_iter(name) {
+                        placeholders.push(cap[1].to_string());
+                    }
+                }
+                TurnExpectation::NotCallAnyTool => {}
+            }
+        }
+    }
+
+    // Deduplicate while preserving order
+    let mut seen = std::collections::HashSet::new();
+    placeholders.retain(|p| seen.insert(p.clone()));
+    placeholders
+}
+
+/// Produce a concrete scenario by replacing `{{variable}}` with values from the parameter set.
+fn substitute_scenario(
+    template: &AgentTestScenario,
+    ps: &ParameterSet,
+) -> AgentTestScenario {
+    let agent_id = format!(
+        "{}[{}]",
+        substitute_str(&template.agent_id, ps),
+        ps.name
+    );
+
+    let system_prompt = template
+        .system_prompt
+        .as_ref()
+        .map(|prompt| substitute_str(prompt, ps));
+
+    let tools = template.tools.clone();
+
+    let turns: Vec<ScenarioTurn> = template
+        .turns
+        .iter()
+        .map(|turn| ScenarioTurn {
+            user_input: substitute_str(&turn.user_input, ps),
+            expectations: turn
+                .expectations
+                .iter()
+                .map(|exp| substitute_expectation(exp, ps))
+                .collect(),
+        })
+        .collect();
+
+    AgentTestScenario {
+        agent_id,
+        system_prompt,
+        tools,
+        turns,
+    }
+}
+
+/// Replace `{{var}}` occurrences in a string.
+fn substitute_str(template: &str, ps: &ParameterSet) -> String {
+    let mut result = template.to_string();
+    for (key, value) in &ps.variables {
+        let placeholder = format!("{{{{{}}}}}", key);
+        result = result.replace(&placeholder, value);
+    }
+    result
+}
+
+/// Substitute placeholders inside a single expectation.
+fn substitute_expectation(
+    exp: &TurnExpectation,
+    ps: &ParameterSet,
+) -> TurnExpectation {
+    match exp {
+        TurnExpectation::CallTool { name } => TurnExpectation::CallTool {
+            name: substitute_str(name, ps),
+        },
+        TurnExpectation::CallToolWith { name, arguments } => {
+            TurnExpectation::CallToolWith {
+                name: substitute_str(name, ps),
+                arguments: substitute_json_value(arguments, ps),
+            }
+        }
+        TurnExpectation::NotCallAnyTool => TurnExpectation::NotCallAnyTool,
+        TurnExpectation::RespondContaining { text } => {
+            TurnExpectation::RespondContaining {
+                text: substitute_str(text, ps),
+            }
+        }
+        TurnExpectation::RespondExact { text } => TurnExpectation::RespondExact {
+            text: substitute_str(text, ps),
+        },
+        TurnExpectation::RespondMatchingRegex { pattern } => {
+            TurnExpectation::RespondMatchingRegex {
+                pattern: substitute_str(pattern, ps),
+            }
+        }
+    }
+}
+
+/// Recursively substitute `{{var}}` in JSON string values.
+fn substitute_json_value(value: &Value, ps: &ParameterSet) -> Value {
+    match value {
+        Value::String(s) => Value::String(substitute_str(s, ps)),
+        Value::Array(arr) => {
+            Value::Array(arr.iter().map(|v| substitute_json_value(v, ps)).collect())
+        }
+        Value::Object(obj) => {
+            let mut new_obj = serde_json::Map::new();
+            for (k, v) in obj {
+                new_obj.insert(k.clone(), substitute_json_value(v, ps));
+            }
+            Value::Object(new_obj)
+        }
+        other => other.clone(),
+    }
+}
+
+// ─── File-backed parameterized scenarios ────────────────────────────────────
+
+/// On-disk representation of a parameterized scenario.
+///
+/// Supports both explicit parameter lists and matrix definitions.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParameterizedScenarioFile {
+    /// Inline scenario template (same schema as non-parameterized scenario files).
+    pub template: ScenarioFileTemplate,
+    /// Explicit parameter sets.
+    #[serde(default)]
+    pub parameters: Vec<ParameterSetFile>,
+    /// Matrix-style parameter generation.
+    #[serde(default)]
+    pub matrix: Option<MatrixFile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScenarioFileTemplate {
+    pub agent_id: String,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    pub turns: Vec<ScenarioFileTurnTemplate>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScenarioFileTurnTemplate {
+    pub user: String,
+    #[serde(default, alias = "expectations")]
+    pub expect: Vec<ScenarioFileExpectationTemplate>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ScenarioFileExpectationTemplate {
+    CallTool { name: String },
+    CallToolWith { name: String, arguments: Value },
+    NotCallAnyTool,
+    RespondContaining { text: String },
+    RespondExact { text: String },
+    RespondMatchingRegex { pattern: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParameterSetFile {
+    pub name: String,
+    #[serde(default, alias = "variables")]
+    pub vars: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MatrixFile {
+    #[serde(default)]
+    pub limit: Option<usize>,
+    pub dimensions: HashMap<String, Vec<String>>,
+}
+
+impl ParameterizedScenarioFile {
+    /// Parse from YAML.
+    pub fn from_yaml_str(input: &str) -> Result<ParameterizedScenario, ParameterExpansionError> {
+        let file: Self = serde_yaml::from_str(input)
+            .map_err(|e| ParameterExpansionError::LoadError(ScenarioLoadError::Yaml(e.to_string())))?;
+        file.into_parameterized()
+    }
+
+    /// Parse from TOML.
+    pub fn from_toml_str(input: &str) -> Result<ParameterizedScenario, ParameterExpansionError> {
+        let file: Self = toml::from_str(input)
+            .map_err(|e| ParameterExpansionError::LoadError(ScenarioLoadError::Toml(e.to_string())))?;
+        file.into_parameterized()
+    }
+
+    /// Parse from JSON.
+    pub fn from_json_str(input: &str) -> Result<ParameterizedScenario, ParameterExpansionError> {
+        let file: Self = serde_json::from_str(input)
+            .map_err(|e| ParameterExpansionError::LoadError(ScenarioLoadError::Json(e.to_string())))?;
+        file.into_parameterized()
+    }
+
+    fn into_parameterized(self) -> Result<ParameterizedScenario, ParameterExpansionError> {
+        let template = self.to_scenario_template();
+
+        let mut parameter_sets: Vec<ParameterSet> = self
+            .parameters
+            .into_iter()
+            .map(|pf| {
+                let mut ps = ParameterSet::new(&pf.name);
+                ps.variables = pf.vars.into_iter().collect();
+                ps
+            })
+            .collect();
+
+        // If a matrix is defined, expand it and append to the explicit sets
+        if let Some(matrix_file) = self.matrix {
+            let mut matrix = ParameterMatrix::new();
+            if let Some(limit) = matrix_file.limit {
+                matrix = matrix.with_limit(limit);
+            }
+            // Sort dimension keys for deterministic ordering
+            let mut dim_keys: Vec<String> = matrix_file.dimensions.keys().cloned().collect();
+            dim_keys.sort();
+            for key in dim_keys {
+                let values = matrix_file.dimensions[&key].clone();
+                matrix = matrix.dimension(key, values);
+            }
+            let matrix_sets = matrix.expand()?;
+            parameter_sets.extend(matrix_sets);
+        }
+
+        Ok(ParameterizedScenario::new(template, parameter_sets))
+    }
+
+    fn to_scenario_template(&self) -> AgentTestScenario {
+        AgentTestScenario {
+            agent_id: self.template.agent_id.clone(),
+            system_prompt: self.template.system_prompt.clone(),
+            tools: self.template.tools.clone(),
+            turns: self
+                .template
+                .turns
+                .iter()
+                .map(|turn| ScenarioTurn {
+                    user_input: turn.user.clone(),
+                    expectations: turn
+                        .expect
+                        .iter()
+                        .map(|exp| match exp {
+                            ScenarioFileExpectationTemplate::CallTool { name } => {
+                                TurnExpectation::CallTool { name: name.clone() }
+                            }
+                            ScenarioFileExpectationTemplate::CallToolWith {
+                                name,
+                                arguments,
+                            } => TurnExpectation::CallToolWith {
+                                name: name.clone(),
+                                arguments: arguments.clone(),
+                            },
+                            ScenarioFileExpectationTemplate::NotCallAnyTool => {
+                                TurnExpectation::NotCallAnyTool
+                            }
+                            ScenarioFileExpectationTemplate::RespondContaining { text } => {
+                                TurnExpectation::RespondContaining { text: text.clone() }
+                            }
+                            ScenarioFileExpectationTemplate::RespondExact { text } => {
+                                TurnExpectation::RespondExact { text: text.clone() }
+                            }
+                            ScenarioFileExpectationTemplate::RespondMatchingRegex {
+                                pattern,
+                            } => TurnExpectation::RespondMatchingRegex {
+                                pattern: pattern.clone(),
+                            },
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}

--- a/tests/src/semantic.rs
+++ b/tests/src/semantic.rs
@@ -1,0 +1,725 @@
+//! Semantic assertion matchers for intent-level validation.
+//!
+//! This module provides assertion primitives that validate **meaning and intent**
+//! rather than exact text, making tests resilient to harmless wording changes
+//! while maintaining strict policy checks.
+//!
+//! # Overview
+//!
+//! - [`SemanticMatcher`]: trait for all semantic assertion types.
+//! - [`ContainsAllFactsMatcher`]: validates that all required facts appear.
+//! - [`ExcludesContentMatcher`]: validates that prohibited content is absent.
+//! - [`IntentMatcher`]: keyword/pattern-based intent classification.
+//! - [`SimilarityMatcher`]: token-overlap similarity with configurable threshold.
+//! - [`SemanticAssertionSet`]: bundles multiple matchers for a single response.
+//! - [`SemanticMatchResult`]: per-matcher outcome with confidence and explanation.
+//! - [`SemanticReport`]: aggregated pass/fail across all matchers.
+//!
+//! All matchers are deterministic and require no external API calls, making
+//! them safe for offline environments and CI pipelines.
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+// ─── Error types ────────────────────────────────────────────────────────────
+
+/// Errors produced during semantic assertion configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SemanticAssertionError {
+    /// A regex pattern in a matcher is invalid.
+    InvalidPattern(String),
+    /// Threshold value is out of bounds.
+    InvalidThreshold { value: f64, min: f64, max: f64 },
+    /// No matchers were provided.
+    EmptyMatcherSet,
+}
+
+impl Display for SemanticAssertionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPattern(msg) => write!(f, "invalid semantic pattern: {msg}"),
+            Self::InvalidThreshold { value, min, max } => {
+                write!(
+                    f,
+                    "threshold {value} is out of bounds [{min}, {max}]"
+                )
+            }
+            Self::EmptyMatcherSet => write!(f, "semantic assertion set has no matchers"),
+        }
+    }
+}
+
+impl Error for SemanticAssertionError {}
+
+// ─── SemanticMatchResult ────────────────────────────────────────────────────
+
+/// Outcome of a single semantic matcher evaluation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticMatchResult {
+    /// Name of the matcher that produced this result.
+    pub matcher_name: String,
+    /// Whether the assertion passed.
+    pub passed: bool,
+    /// Confidence score in [0.0, 1.0] (1.0 = highest confidence).
+    pub confidence: f64,
+    /// Human-readable explanation of the result.
+    pub explanation: String,
+}
+
+impl SemanticMatchResult {
+    /// Create a passing result.
+    pub fn pass(name: impl Into<String>, confidence: f64, explanation: impl Into<String>) -> Self {
+        Self {
+            matcher_name: name.into(),
+            passed: true,
+            confidence,
+            explanation: explanation.into(),
+        }
+    }
+
+    /// Create a failing result.
+    pub fn fail(name: impl Into<String>, confidence: f64, explanation: impl Into<String>) -> Self {
+        Self {
+            matcher_name: name.into(),
+            passed: false,
+            confidence,
+            explanation: explanation.into(),
+        }
+    }
+}
+
+// ─── SemanticMatcher trait ──────────────────────────────────────────────────
+
+/// Trait for semantic assertion matchers.
+///
+/// Each matcher evaluates a response string and produces a
+/// [`SemanticMatchResult`] with a confidence score and explanation.
+pub trait SemanticMatcher: Send + Sync {
+    /// Unique name identifying this matcher type.
+    fn name(&self) -> &str;
+
+    /// Evaluate the response and return a match result.
+    fn evaluate(&self, response: &str) -> SemanticMatchResult;
+}
+
+// ─── ContainsAllFactsMatcher ────────────────────────────────────────────────
+
+/// Validates that all required facts (keywords/phrases) appear in the response.
+///
+/// Each fact is checked case-insensitively. The confidence score reflects
+/// the fraction of facts found.
+///
+/// # Example
+///
+/// ```ignore
+/// let matcher = ContainsAllFactsMatcher::new(vec!["Berlin", "22C", "sunny"]);
+/// let result = matcher.evaluate("The weather in Berlin is 22C and sunny.");
+/// assert!(result.passed);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContainsAllFactsMatcher {
+    facts: Vec<String>,
+}
+
+impl ContainsAllFactsMatcher {
+    /// Create a matcher requiring all given facts to be present.
+    pub fn new(facts: Vec<impl Into<String>>) -> Self {
+        Self {
+            facts: facts.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl SemanticMatcher for ContainsAllFactsMatcher {
+    fn name(&self) -> &str {
+        "contains_all_facts"
+    }
+
+    fn evaluate(&self, response: &str) -> SemanticMatchResult {
+        if self.facts.is_empty() {
+            return SemanticMatchResult::pass(self.name(), 1.0, "no facts to check");
+        }
+
+        let response_lower = response.to_lowercase();
+        let mut found = Vec::new();
+        let mut missing = Vec::new();
+
+        for fact in &self.facts {
+            if response_lower.contains(&fact.to_lowercase()) {
+                found.push(fact.as_str());
+            } else {
+                missing.push(fact.as_str());
+            }
+        }
+
+        let confidence = found.len() as f64 / self.facts.len() as f64;
+
+        if missing.is_empty() {
+            SemanticMatchResult::pass(
+                self.name(),
+                confidence,
+                format!("all {} facts found in response", self.facts.len()),
+            )
+        } else {
+            SemanticMatchResult::fail(
+                self.name(),
+                confidence,
+                format!(
+                    "missing facts: [{}] (found {}/{})",
+                    missing.join(", "),
+                    found.len(),
+                    self.facts.len()
+                ),
+            )
+        }
+    }
+}
+
+// ─── ExcludesContentMatcher ─────────────────────────────────────────────────
+
+/// Validates that prohibited content does NOT appear in the response.
+///
+/// Each banned term is checked case-insensitively. Useful for policy and
+/// safety assertions (e.g. no PII, no harmful content).
+///
+/// # Example
+///
+/// ```ignore
+/// let matcher = ExcludesContentMatcher::new(vec!["password", "SSN", "credit card"]);
+/// let result = matcher.evaluate("Here is your account summary.");
+/// assert!(result.passed);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ExcludesContentMatcher {
+    banned: Vec<String>,
+}
+
+impl ExcludesContentMatcher {
+    /// Create a matcher that fails if any banned term is found.
+    pub fn new(banned: Vec<impl Into<String>>) -> Self {
+        Self {
+            banned: banned.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl SemanticMatcher for ExcludesContentMatcher {
+    fn name(&self) -> &str {
+        "excludes_content"
+    }
+
+    fn evaluate(&self, response: &str) -> SemanticMatchResult {
+        if self.banned.is_empty() {
+            return SemanticMatchResult::pass(self.name(), 1.0, "no banned terms to check");
+        }
+
+        let response_lower = response.to_lowercase();
+        let mut violations: Vec<&str> = Vec::new();
+
+        for term in &self.banned {
+            if response_lower.contains(&term.to_lowercase()) {
+                violations.push(term.as_str());
+            }
+        }
+
+        if violations.is_empty() {
+            SemanticMatchResult::pass(
+                self.name(),
+                1.0,
+                format!("none of {} banned terms found", self.banned.len()),
+            )
+        } else {
+            let safe_count = self.banned.len() - violations.len();
+            let confidence = safe_count as f64 / self.banned.len() as f64;
+            SemanticMatchResult::fail(
+                self.name(),
+                confidence,
+                format!(
+                    "prohibited content found: [{}]",
+                    violations.join(", ")
+                ),
+            )
+        }
+    }
+}
+
+// ─── IntentMatcher ──────────────────────────────────────────────────────────
+
+/// Validates that a response matches an expected intent via keyword groups.
+///
+/// An intent is defined by a name and a set of indicator keywords/phrases.
+/// If any indicator is found in the response (case-insensitive), the intent
+/// is considered matched. Multiple intents can be checked.
+///
+/// # Example
+///
+/// ```ignore
+/// let matcher = IntentMatcher::new()
+///     .expect_intent("greeting", vec!["hello", "hi", "welcome"])
+///     .expect_intent("farewell", vec!["goodbye", "bye", "see you"]);
+///
+/// let result = matcher.evaluate("Hello! How can I help you?");
+/// // Passes if at least one expected intent is matched
+/// ```
+#[derive(Debug, Clone)]
+pub struct IntentMatcher {
+    expected_intents: Vec<IntentDefinition>,
+    /// If true, ALL expected intents must match. If false, at least one.
+    require_all: bool,
+}
+
+#[derive(Debug, Clone)]
+struct IntentDefinition {
+    name: String,
+    indicators: Vec<String>,
+}
+
+impl IntentMatcher {
+    /// Create a new intent matcher (default: require at least one intent).
+    pub fn new() -> Self {
+        Self {
+            expected_intents: Vec::new(),
+            require_all: false,
+        }
+    }
+
+    /// Require ALL expected intents to match (default: at least one).
+    pub fn require_all(mut self) -> Self {
+        self.require_all = true;
+        self
+    }
+
+    /// Add an expected intent with indicator keywords.
+    pub fn expect_intent(
+        mut self,
+        name: impl Into<String>,
+        indicators: Vec<impl Into<String>>,
+    ) -> Self {
+        self.expected_intents.push(IntentDefinition {
+            name: name.into(),
+            indicators: indicators.into_iter().map(Into::into).collect(),
+        });
+        self
+    }
+
+    fn check_intent(&self, intent: &IntentDefinition, response_lower: &str) -> bool {
+        intent
+            .indicators
+            .iter()
+            .any(|kw| response_lower.contains(&kw.to_lowercase()))
+    }
+}
+
+impl Default for IntentMatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SemanticMatcher for IntentMatcher {
+    fn name(&self) -> &str {
+        "intent_match"
+    }
+
+    fn evaluate(&self, response: &str) -> SemanticMatchResult {
+        if self.expected_intents.is_empty() {
+            return SemanticMatchResult::pass(self.name(), 1.0, "no intents to check");
+        }
+
+        let response_lower = response.to_lowercase();
+        let mut matched: Vec<&str> = Vec::new();
+        let mut unmatched: Vec<&str> = Vec::new();
+
+        for intent in &self.expected_intents {
+            if self.check_intent(intent, &response_lower) {
+                matched.push(&intent.name);
+            } else {
+                unmatched.push(&intent.name);
+            }
+        }
+
+        let confidence = matched.len() as f64 / self.expected_intents.len() as f64;
+
+        let passed = if self.require_all {
+            unmatched.is_empty()
+        } else {
+            !matched.is_empty()
+        };
+
+        if passed {
+            SemanticMatchResult::pass(
+                self.name(),
+                confidence,
+                format!(
+                    "matched intents: [{}]",
+                    matched.join(", ")
+                ),
+            )
+        } else {
+            SemanticMatchResult::fail(
+                self.name(),
+                confidence,
+                format!(
+                    "unmatched intents: [{}] (matched: [{}])",
+                    unmatched.join(", "),
+                    matched.join(", ")
+                ),
+            )
+        }
+    }
+}
+
+// ─── SimilarityMatcher ──────────────────────────────────────────────────────
+
+/// Validates response similarity to a reference text using token overlap.
+///
+/// Uses Jaccard similarity on word-level tokens (case-insensitive).
+/// This is a deterministic, offline-safe approximation of semantic similarity.
+///
+/// # Example
+///
+/// ```ignore
+/// let matcher = SimilarityMatcher::new("The temperature is 22 degrees Celsius", 0.5)?;
+/// let result = matcher.evaluate("It's about 22 degrees today in Celsius");
+/// assert!(result.passed); // sufficient token overlap
+/// ```
+#[derive(Debug, Clone)]
+pub struct SimilarityMatcher {
+    reference: String,
+    reference_tokens: HashSet<String>,
+    threshold: f64,
+}
+
+impl SimilarityMatcher {
+    /// Create a matcher comparing against a reference text.
+    ///
+    /// `threshold` must be in `[0.0, 1.0]`.
+    pub fn new(
+        reference: impl Into<String>,
+        threshold: f64,
+    ) -> Result<Self, SemanticAssertionError> {
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(SemanticAssertionError::InvalidThreshold {
+                value: threshold,
+                min: 0.0,
+                max: 1.0,
+            });
+        }
+
+        let reference = reference.into();
+        let reference_tokens = tokenize(&reference);
+
+        Ok(Self {
+            reference,
+            reference_tokens,
+            threshold,
+        })
+    }
+
+    /// Compute Jaccard similarity between two token sets.
+    fn jaccard_similarity(a: &HashSet<String>, b: &HashSet<String>) -> f64 {
+        if a.is_empty() && b.is_empty() {
+            return 1.0;
+        }
+        let intersection = a.intersection(b).count() as f64;
+        let union = a.union(b).count() as f64;
+        if union == 0.0 {
+            0.0
+        } else {
+            intersection / union
+        }
+    }
+}
+
+impl SemanticMatcher for SimilarityMatcher {
+    fn name(&self) -> &str {
+        "similarity"
+    }
+
+    fn evaluate(&self, response: &str) -> SemanticMatchResult {
+        let response_tokens = tokenize(response);
+        let similarity = Self::jaccard_similarity(&self.reference_tokens, &response_tokens);
+
+        if similarity >= self.threshold {
+            SemanticMatchResult::pass(
+                self.name(),
+                similarity,
+                format!(
+                    "similarity {:.2} >= threshold {:.2}",
+                    similarity, self.threshold
+                ),
+            )
+        } else {
+            SemanticMatchResult::fail(
+                self.name(),
+                similarity,
+                format!(
+                    "similarity {:.2} < threshold {:.2} (reference: \"{}\")",
+                    similarity, self.threshold, self.reference
+                ),
+            )
+        }
+    }
+}
+
+/// Tokenize text into lowercase word-level tokens, filtering short noise words.
+fn tokenize(text: &str) -> HashSet<String> {
+    text.split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.len() > 1) // skip single-char noise
+        .map(|w| w.to_lowercase())
+        .collect()
+}
+
+// ─── RegexIntentMatcher ─────────────────────────────────────────────────────
+
+/// Validates response against regex patterns representing expected behavior.
+///
+/// Useful when intent is best expressed as a structural pattern rather than
+/// keyword list (e.g. "contains a number followed by a unit").
+#[derive(Debug, Clone)]
+pub struct RegexIntentMatcher {
+    matcher_name: String,
+    pattern: regex::Regex,
+    description: String,
+}
+
+impl RegexIntentMatcher {
+    /// Create a named regex intent matcher.
+    pub fn new(
+        name: impl Into<String>,
+        pattern: &str,
+        description: impl Into<String>,
+    ) -> Result<Self, SemanticAssertionError> {
+        let regex = regex::Regex::new(pattern)
+            .map_err(|e| SemanticAssertionError::InvalidPattern(e.to_string()))?;
+        Ok(Self {
+            matcher_name: name.into(),
+            pattern: regex,
+            description: description.into(),
+        })
+    }
+}
+
+impl SemanticMatcher for RegexIntentMatcher {
+    fn name(&self) -> &str {
+        &self.matcher_name
+    }
+
+    fn evaluate(&self, response: &str) -> SemanticMatchResult {
+        if self.pattern.is_match(response) {
+            SemanticMatchResult::pass(
+                self.name(),
+                1.0,
+                format!("{}: pattern matched", self.description),
+            )
+        } else {
+            SemanticMatchResult::fail(
+                self.name(),
+                0.0,
+                format!(
+                    "{}: pattern '{}' did not match",
+                    self.description,
+                    self.pattern.as_str()
+                ),
+            )
+        }
+    }
+}
+
+// ─── SemanticAssertionSet ───────────────────────────────────────────────────
+
+/// Aggregated report from evaluating a set of semantic matchers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticReport {
+    /// Per-matcher results.
+    pub results: Vec<SemanticMatchResult>,
+    /// Overall pass/fail.
+    pub passed: bool,
+    /// Number of matchers that passed.
+    pub passed_count: usize,
+    /// Total number of matchers.
+    pub total_count: usize,
+    /// Average confidence across all matchers.
+    pub average_confidence: f64,
+}
+
+/// Bundles multiple [`SemanticMatcher`]s for evaluating a single response.
+///
+/// All matchers are evaluated and results are aggregated into a [`SemanticReport`].
+pub struct SemanticAssertionSet {
+    matchers: Vec<Box<dyn SemanticMatcher>>,
+}
+
+impl SemanticAssertionSet {
+    /// Create an empty assertion set.
+    pub fn new() -> Self {
+        Self {
+            matchers: Vec::new(),
+        }
+    }
+
+    /// Add a matcher to the set.
+    pub fn add(mut self, matcher: impl SemanticMatcher + 'static) -> Self {
+        self.matchers.push(Box::new(matcher));
+        self
+    }
+
+    /// Number of matchers in the set.
+    pub fn len(&self) -> usize {
+        self.matchers.len()
+    }
+
+    /// Whether the set has no matchers.
+    pub fn is_empty(&self) -> bool {
+        self.matchers.is_empty()
+    }
+
+    /// Evaluate all matchers against the response and produce a report.
+    pub fn evaluate(&self, response: &str) -> Result<SemanticReport, SemanticAssertionError> {
+        if self.matchers.is_empty() {
+            return Err(SemanticAssertionError::EmptyMatcherSet);
+        }
+
+        let results: Vec<SemanticMatchResult> = self
+            .matchers
+            .iter()
+            .map(|m| m.evaluate(response))
+            .collect();
+
+        let passed_count = results.iter().filter(|r| r.passed).count();
+        let total_count = results.len();
+        let average_confidence = results.iter().map(|r| r.confidence).sum::<f64>() / total_count as f64;
+        let passed = passed_count == total_count;
+
+        Ok(SemanticReport {
+            results,
+            passed,
+            passed_count,
+            total_count,
+            average_confidence,
+        })
+    }
+}
+
+impl Default for SemanticAssertionSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Integration with TurnExpectation (file-backed) ─────────────────────────
+
+/// File-loadable semantic assertion definition (YAML/TOML/JSON).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SemanticExpectation {
+    /// All listed facts must appear (case-insensitive).
+    ContainsAllFacts { facts: Vec<String> },
+    /// None of the listed terms may appear.
+    ExcludesContent { banned: Vec<String> },
+    /// At least one intent must match via keyword indicators.
+    MatchesIntent {
+        intents: Vec<IntentFile>,
+        #[serde(default)]
+        require_all: bool,
+    },
+    /// Token-overlap similarity must exceed threshold.
+    SimilarTo {
+        reference: String,
+        #[serde(default = "default_threshold")]
+        threshold: f64,
+    },
+    /// Regex pattern must match.
+    MatchesPattern {
+        name: String,
+        pattern: String,
+        #[serde(default)]
+        description: String,
+    },
+}
+
+fn default_threshold() -> f64 {
+    0.5
+}
+
+/// Intent definition for file-based loading.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntentFile {
+    pub name: String,
+    pub indicators: Vec<String>,
+}
+
+impl SemanticExpectation {
+    /// Convert a file-backed expectation into a boxed `SemanticMatcher`.
+    pub fn into_matcher(self) -> Result<Box<dyn SemanticMatcher>, SemanticAssertionError> {
+        match self {
+            Self::ContainsAllFacts { facts } => {
+                Ok(Box::new(ContainsAllFactsMatcher::new(facts)))
+            }
+            Self::ExcludesContent { banned } => {
+                Ok(Box::new(ExcludesContentMatcher::new(banned)))
+            }
+            Self::MatchesIntent {
+                intents,
+                require_all,
+            } => {
+                let mut matcher = IntentMatcher::new();
+                if require_all {
+                    matcher = matcher.require_all();
+                }
+                for intent in intents {
+                    matcher = matcher.expect_intent(intent.name, intent.indicators);
+                }
+                Ok(Box::new(matcher))
+            }
+            Self::SimilarTo {
+                reference,
+                threshold,
+            } => {
+                let matcher = SimilarityMatcher::new(reference, threshold)?;
+                Ok(Box::new(matcher))
+            }
+            Self::MatchesPattern {
+                name,
+                pattern,
+                description,
+            } => {
+                let desc = if description.is_empty() {
+                    name.clone()
+                } else {
+                    description
+                };
+                let matcher = RegexIntentMatcher::new(name, &pattern, desc)?;
+                Ok(Box::new(matcher))
+            }
+        }
+    }
+
+    /// Load a list of semantic expectations from YAML.
+    pub fn from_yaml_str(input: &str) -> Result<Vec<Self>, SemanticAssertionError> {
+        serde_yaml::from_str(input)
+            .map_err(|e| SemanticAssertionError::InvalidPattern(e.to_string()))
+    }
+
+    /// Load a list of semantic expectations from JSON.
+    pub fn from_json_str(input: &str) -> Result<Vec<Self>, SemanticAssertionError> {
+        serde_json::from_str(input)
+            .map_err(|e| SemanticAssertionError::InvalidPattern(e.to_string()))
+    }
+
+    /// Build a `SemanticAssertionSet` from a list of expectations.
+    pub fn into_assertion_set(
+        expectations: Vec<Self>,
+    ) -> Result<SemanticAssertionSet, SemanticAssertionError> {
+        let mut set = SemanticAssertionSet::new();
+        for exp in expectations {
+            let matcher = exp.into_matcher()?;
+            set.matchers.push(matcher);
+        }
+        Ok(set)
+    }
+}

--- a/tests/tests/dsl_tests.rs
+++ b/tests/tests/dsl_tests.rs
@@ -1,0 +1,195 @@
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use mofa_testing::{
+    AgentTest, AgentTestScenario, MockLLMBackend, MockScenarioAgent, MockTool, ScenarioAgent,
+    ScenarioTurnOutput, TurnExpectation,
+};
+use serde_json::json;
+
+struct ScriptedAgent {
+    outputs: VecDeque<Result<ScenarioTurnOutput, String>>,
+}
+
+impl ScriptedAgent {
+    fn new(outputs: Vec<Result<ScenarioTurnOutput, String>>) -> Self {
+        Self {
+            outputs: outputs.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ScenarioAgent for ScriptedAgent {
+    async fn execute_turn(
+        &mut self,
+        _system_prompt: Option<&str>,
+        _user_input: &str,
+    ) -> Result<ScenarioTurnOutput, String> {
+        self.outputs
+            .pop_front()
+            .unwrap_or_else(|| Err("no scripted output available".to_string()))
+    }
+}
+
+#[tokio::test]
+async fn agent_test_builder_runs_multi_turn_scenario() {
+    let scenario = AgentTest::new("customer_support_agent")
+        .given_system_prompt("You are a helpful assistant")
+        .given_tool("weather_search")
+        .when_user_says("What's the weather?")
+        .then_agent_should()
+        .call_tool("weather_search")
+        .respond_containing("temperature")
+        .when_user_says("Thanks!")
+        .then_agent_should()
+        .not_call_any_tool()
+        .respond_matching_regex("(?i)welcome|happy to help")
+        .build()
+        .expect("scenario should build");
+
+    let mut agent = ScriptedAgent::new(vec![
+        Ok(ScenarioTurnOutput::new("The temperature is 22C.")
+            .with_tool_call("weather_search", json!({"city":"Berlin"}))),
+        Ok(ScenarioTurnOutput::new("You're welcome, happy to help.")),
+    ]);
+
+    let report = scenario.run_with_agent(&mut agent).await;
+
+    assert_eq!(report.total(), 2);
+    assert_eq!(report.failed(), 0);
+    assert_eq!(report.passed(), 2);
+}
+
+#[test]
+fn builder_reports_invalid_ordering_errors() {
+    let err = AgentTest::new("agent")
+        .then_agent_should()
+        .call_tool("search")
+        .build()
+        .expect_err("build should fail when expectations are declared before turn");
+
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| e.contains("call_tool() must be called after when_user_says()"))
+    );
+}
+
+#[test]
+fn load_scenario_from_yaml() {
+    let yaml = r#"
+agent_id: customer_support_agent
+system_prompt: You are a helpful assistant
+tools:
+  - weather_search
+turns:
+  - user: What's the weather?
+    expect:
+      - kind: call_tool
+        name: weather_search
+      - kind: respond_containing
+        text: temperature
+  - user: Thanks!
+    expect:
+      - kind: not_call_any_tool
+      - kind: respond_matching_regex
+        pattern: "(?i)welcome|help"
+"#;
+
+    let scenario = AgentTestScenario::from_yaml_str(yaml).expect("yaml scenario should load");
+
+    assert_eq!(scenario.agent_id, "customer_support_agent");
+    assert_eq!(scenario.turns.len(), 2);
+    assert!(matches!(
+        scenario.turns[0].expectations[0],
+        TurnExpectation::CallTool { .. }
+    ));
+}
+
+#[test]
+fn load_scenario_from_toml() {
+    let toml_input = r#"
+agent_id = "customer_support_agent"
+system_prompt = "You are a helpful assistant"
+tools = ["weather_search"]
+
+[[turns]]
+user = "What's the weather?"
+
+[[turns.expect]]
+kind = "call_tool"
+name = "weather_search"
+
+[[turns.expect]]
+kind = "respond_containing"
+text = "temperature"
+"#;
+
+    let scenario = AgentTestScenario::from_toml_str(toml_input).expect("toml scenario should load");
+
+    assert_eq!(scenario.turns.len(), 1);
+    assert_eq!(scenario.turns[0].expectations.len(), 2);
+}
+
+#[tokio::test]
+async fn mock_scenario_agent_integrates_backend_and_tools() {
+    let backend = MockLLMBackend::new();
+    backend.add_response("weather", "The temperature is 22C in Berlin.");
+
+    let tool = MockTool::new(
+        "weather_search",
+        "Lookup weather",
+        json!({
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"}
+            },
+            "required": ["city"]
+        }),
+    );
+
+    let mut agent = MockScenarioAgent::new("mock-model", backend)
+        .with_mock_tool(tool.clone())
+        .add_tool_rule("weather", "weather_search", json!({"city": "Berlin"}));
+
+    let scenario = AgentTest::new("weather_agent")
+        .given_mock_tool(&tool)
+        .when_user_says("Can you check the weather?")
+        .then_agent_should()
+        .call_tool_with("weather_search", json!({"city": "Berlin"}))
+        .respond_containing("temperature")
+        .build()
+        .expect("scenario should build");
+
+    let report = scenario.run_with_agent(&mut agent).await;
+
+    assert_eq!(report.failed(), 0);
+    assert_eq!(tool.call_count().await, 1);
+    let first_call = tool.nth_call(0).await.expect("first call should exist");
+    assert_eq!(first_call.arguments, json!({"city": "Berlin"}));
+}
+
+#[tokio::test]
+async fn scenario_expectation_failure_is_reported() {
+    let scenario = AgentTest::new("agent")
+        .when_user_says("hello")
+        .then_agent_should()
+        .respond_exact("expected")
+        .build()
+        .expect("scenario should build");
+
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("actual"))]);
+
+    let report = scenario.run_with_agent(&mut agent).await;
+
+    assert_eq!(report.total(), 1);
+    assert_eq!(report.failed(), 1);
+    assert!(
+        report.results[0]
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("expected exact response")
+    );
+}

--- a/tests/tests/golden_tests.rs
+++ b/tests/tests/golden_tests.rs
@@ -1,0 +1,766 @@
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use mofa_testing::{
+    AgentTest, GoldenCompareMode, GoldenDiff, GoldenSnapshot, GoldenStore, GoldenTestConfig,
+    GoldenTurnSnapshot, NormalizerChain, RegexNormalizer, ScenarioAgent, ScenarioTurnOutput,
+    ToolCallRecord, WhitespaceNormalizer, compare_golden, run_golden_test,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+// ─── Helper: scripted agent ─────────────────────────────────────────────────
+
+struct ScriptedAgent {
+    outputs: VecDeque<Result<ScenarioTurnOutput, String>>,
+}
+
+impl ScriptedAgent {
+    fn new(outputs: Vec<Result<ScenarioTurnOutput, String>>) -> Self {
+        Self {
+            outputs: outputs.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ScenarioAgent for ScriptedAgent {
+    async fn execute_turn(
+        &mut self,
+        _system_prompt: Option<&str>,
+        _user_input: &str,
+    ) -> Result<ScenarioTurnOutput, String> {
+        self.outputs
+            .pop_front()
+            .unwrap_or_else(|| Err("no scripted output available".to_string()))
+    }
+}
+
+fn make_temp_dir() -> TempDir {
+    tempfile::tempdir().expect("should create temp dir")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GoldenSnapshot: serialization tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn snapshot_json_roundtrip() {
+    let snapshot = GoldenSnapshot::new(
+        "test_agent",
+        vec![GoldenTurnSnapshot {
+            user_input: "Hello".to_string(),
+            response: "Hi there!".to_string(),
+            tool_calls: vec![ToolCallRecord {
+                name: "greet".to_string(),
+                arguments: json!({"lang": "en"}),
+            }],
+        }],
+    )
+    .with_metadata("model", "gpt-4")
+    .with_metadata("version", "1.0");
+
+    let json = snapshot.to_json().expect("serialize");
+    let deserialized = GoldenSnapshot::from_json(&json).expect("deserialize");
+
+    assert_eq!(snapshot, deserialized);
+    assert_eq!(deserialized.metadata.get("model").unwrap(), "gpt-4");
+}
+
+#[test]
+fn snapshot_yaml_roundtrip() {
+    let snapshot = GoldenSnapshot::new(
+        "test_agent",
+        vec![GoldenTurnSnapshot {
+            user_input: "test".to_string(),
+            response: "result".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    let yaml = snapshot.to_yaml().expect("serialize");
+    let deserialized = GoldenSnapshot::from_yaml(&yaml).expect("deserialize");
+
+    assert_eq!(snapshot, deserialized);
+}
+
+#[test]
+fn snapshot_with_multiple_turns() {
+    let snapshot = GoldenSnapshot::new(
+        "multi_turn",
+        vec![
+            GoldenTurnSnapshot {
+                user_input: "turn1".to_string(),
+                response: "response1".to_string(),
+                tool_calls: vec![],
+            },
+            GoldenTurnSnapshot {
+                user_input: "turn2".to_string(),
+                response: "response2".to_string(),
+                tool_calls: vec![ToolCallRecord {
+                    name: "search".to_string(),
+                    arguments: json!({}),
+                }],
+            },
+        ],
+    );
+
+    let json = snapshot.to_json().expect("serialize");
+    let deserialized = GoldenSnapshot::from_json(&json).expect("deserialize");
+
+    assert_eq!(deserialized.turns.len(), 2);
+    assert_eq!(deserialized.turns[1].tool_calls.len(), 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GoldenStore: filesystem operations
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn store_save_and_load() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    let snapshot = GoldenSnapshot::new(
+        "weather_test",
+        vec![GoldenTurnSnapshot {
+            user_input: "weather?".to_string(),
+            response: "sunny".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    let path = store.save(&snapshot).expect("save should succeed");
+    assert!(path.exists());
+    assert!(path.to_string_lossy().contains("weather_test.golden.json"));
+
+    let loaded = store.load("weather_test").expect("load should succeed");
+    assert_eq!(loaded, snapshot);
+}
+
+#[test]
+fn store_exists_check() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    assert!(!store.exists("nonexistent"));
+
+    let snapshot = GoldenSnapshot::new("exists_test", vec![GoldenTurnSnapshot {
+        user_input: "x".to_string(),
+        response: "y".to_string(),
+        tool_calls: vec![],
+    }]);
+    store.save(&snapshot).expect("save");
+
+    assert!(store.exists("exists_test"));
+}
+
+#[test]
+fn store_list_snapshots() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    for name in &["alpha", "beta", "gamma"] {
+        store.save(&GoldenSnapshot::new(*name, vec![GoldenTurnSnapshot {
+            user_input: "x".to_string(),
+            response: "y".to_string(),
+            tool_calls: vec![],
+        }])).expect("save");
+    }
+
+    let listed = store.list();
+    assert_eq!(listed, vec!["alpha", "beta", "gamma"]);
+}
+
+#[test]
+fn store_handles_special_chars_in_name() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    let snapshot = GoldenSnapshot::new(
+        "agent[berlin]",
+        vec![GoldenTurnSnapshot {
+            user_input: "x".to_string(),
+            response: "y".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    store.save(&snapshot).expect("save should succeed");
+    let path = store.snapshot_path("agent[berlin]");
+    assert!(path.exists());
+}
+
+#[test]
+fn store_load_nonexistent_fails() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    let result = store.load("does_not_exist");
+    assert!(result.is_err());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// compare_golden: diff detection
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn compare_identical_outputs_no_diffs() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "hello".to_string(),
+            response: "Hi!".to_string(),
+            tool_calls: vec![ToolCallRecord {
+                name: "greet".to_string(),
+                arguments: json!({}),
+            }],
+        }],
+    );
+
+    let actual = vec![(
+        "hello".to_string(),
+        ScenarioTurnOutput::new("Hi!").with_tool_call("greet", json!({})),
+    )];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert!(diffs.is_empty());
+}
+
+#[test]
+fn compare_detects_response_mismatch() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "hello".to_string(),
+            response: "Hi!".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    let actual = vec![(
+        "hello".to_string(),
+        ScenarioTurnOutput::new("Hey there!"),
+    )];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert_eq!(diffs.len(), 1);
+    assert!(matches!(
+        &diffs[0],
+        GoldenDiff::ResponseMismatch { turn: 1, expected, actual }
+            if expected == "Hi!" && actual == "Hey there!"
+    ));
+}
+
+#[test]
+fn compare_detects_turn_count_mismatch() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![
+            GoldenTurnSnapshot {
+                user_input: "a".to_string(),
+                response: "b".to_string(),
+                tool_calls: vec![],
+            },
+            GoldenTurnSnapshot {
+                user_input: "c".to_string(),
+                response: "d".to_string(),
+                tool_calls: vec![],
+            },
+        ],
+    );
+
+    let actual = vec![("a".to_string(), ScenarioTurnOutput::new("b"))];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert_eq!(diffs.len(), 1);
+    assert!(matches!(
+        &diffs[0],
+        GoldenDiff::TurnCountMismatch { expected: 2, actual: 1 }
+    ));
+}
+
+#[test]
+fn compare_detects_tool_call_count_mismatch() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "test".to_string(),
+            response: "ok".to_string(),
+            tool_calls: vec![
+                ToolCallRecord { name: "a".to_string(), arguments: json!({}) },
+                ToolCallRecord { name: "b".to_string(), arguments: json!({}) },
+            ],
+        }],
+    );
+
+    let actual = vec![(
+        "test".to_string(),
+        ScenarioTurnOutput::new("ok").with_tool_call("a", json!({})),
+    )];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert!(diffs.iter().any(|d| matches!(d, GoldenDiff::ToolCallCountMismatch { .. })));
+}
+
+#[test]
+fn compare_detects_tool_name_mismatch() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "test".to_string(),
+            response: "ok".to_string(),
+            tool_calls: vec![ToolCallRecord {
+                name: "search".to_string(),
+                arguments: json!({}),
+            }],
+        }],
+    );
+
+    let actual = vec![(
+        "test".to_string(),
+        ScenarioTurnOutput::new("ok").with_tool_call("lookup", json!({})),
+    )];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert!(diffs.iter().any(|d| matches!(
+        d,
+        GoldenDiff::ToolCallMismatch { expected_name, actual_name, .. }
+            if expected_name == "search" && actual_name == "lookup"
+    )));
+}
+
+#[test]
+fn compare_detects_tool_args_mismatch() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "test".to_string(),
+            response: "ok".to_string(),
+            tool_calls: vec![ToolCallRecord {
+                name: "search".to_string(),
+                arguments: json!({"q": "rust"}),
+            }],
+        }],
+    );
+
+    let actual = vec![(
+        "test".to_string(),
+        ScenarioTurnOutput::new("ok").with_tool_call("search", json!({"q": "python"})),
+    )];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert!(diffs.iter().any(|d| matches!(d, GoldenDiff::ToolCallArgsMismatch { .. })));
+}
+
+#[test]
+fn compare_multiple_diffs_in_single_comparison() {
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![
+            GoldenTurnSnapshot {
+                user_input: "a".to_string(),
+                response: "expected_a".to_string(),
+                tool_calls: vec![],
+            },
+            GoldenTurnSnapshot {
+                user_input: "b".to_string(),
+                response: "expected_b".to_string(),
+                tool_calls: vec![],
+            },
+        ],
+    );
+
+    let actual = vec![
+        ("a".to_string(), ScenarioTurnOutput::new("actual_a")),
+        ("b".to_string(), ScenarioTurnOutput::new("actual_b")),
+    ];
+
+    let diffs = compare_golden(&golden, &actual, None);
+    assert_eq!(diffs.len(), 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Normalizer tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn whitespace_normalizer_collapses_spaces() {
+    use mofa_testing::golden::Normalizer;
+    let n = WhitespaceNormalizer;
+    assert_eq!(n.normalize("  hello   world  "), "hello world");
+    assert_eq!(n.normalize("no\textra\nspaces"), "no extra spaces");
+}
+
+#[test]
+fn regex_normalizer_replaces_uuids() {
+    use mofa_testing::golden::Normalizer;
+    let n = RegexNormalizer::new(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        "<UUID>",
+    )
+    .expect("valid regex");
+
+    let input = "ID: 550e8400-e29b-41d4-a716-446655440000 done";
+    assert_eq!(n.normalize(input), "ID: <UUID> done");
+}
+
+#[test]
+fn regex_normalizer_replaces_timestamps() {
+    use mofa_testing::golden::Normalizer;
+    let n = RegexNormalizer::new(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+        "<TIMESTAMP>",
+    )
+    .expect("valid regex");
+
+    let input = "Created at 2026-04-09T18:00:00 UTC";
+    assert_eq!(n.normalize(input), "Created at <TIMESTAMP> UTC");
+}
+
+#[test]
+fn normalizer_chain_applies_all() {
+    use mofa_testing::golden::Normalizer;
+    let chain = NormalizerChain::default_chain().expect("chain should build");
+
+    let input = "ID: 550e8400-e29b-41d4-a716-446655440000  at  2026-04-09T18:00:00";
+    let normalized = chain.normalize(input);
+
+    assert!(normalized.contains("<UUID>"));
+    assert!(normalized.contains("<TIMESTAMP>"));
+    assert!(!normalized.contains("  "));
+}
+
+#[test]
+fn compare_with_normalizer_ignores_whitespace_diffs() {
+    use mofa_testing::golden::Normalizer;
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "hello".to_string(),
+            response: "Hi  there!".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    let actual = vec![(
+        "hello".to_string(),
+        ScenarioTurnOutput::new("Hi there!"),
+    )];
+
+    let normalizer = WhitespaceNormalizer;
+    let diffs = compare_golden(&golden, &actual, Some(&normalizer));
+    assert!(diffs.is_empty(), "whitespace differences should be normalized away");
+}
+
+#[test]
+fn compare_with_normalizer_ignores_uuid_diffs() {
+    use mofa_testing::golden::Normalizer;
+    let golden = GoldenSnapshot::new(
+        "test",
+        vec![GoldenTurnSnapshot {
+            user_input: "hello".to_string(),
+            response: "Request 550e8400-e29b-41d4-a716-446655440000 created".to_string(),
+            tool_calls: vec![],
+        }],
+    );
+
+    let actual = vec![(
+        "hello".to_string(),
+        ScenarioTurnOutput::new("Request a1b2c3d4-e5f6-7890-abcd-ef1234567890 created"),
+    )];
+
+    let chain = NormalizerChain::default_chain().expect("chain");
+    let diffs = compare_golden(&golden, &actual, Some(&chain));
+    assert!(diffs.is_empty(), "UUID differences should be normalized away");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// run_golden_test: integration tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn golden_update_mode_saves_snapshot() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+    let config = GoldenTestConfig::update(store);
+
+    let scenario = AgentTest::new("update_test")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .build()
+        .expect("build");
+
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("Hi!"))]);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 0);
+
+    // Verify snapshot was written
+    let reload_store = GoldenStore::new(dir.path());
+    assert!(reload_store.exists("update_test"));
+    let snapshot = reload_store.load("update_test").expect("load");
+    assert_eq!(snapshot.turns[0].response, "Hi!");
+}
+
+#[tokio::test]
+async fn golden_strict_mode_passes_when_matching() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    // First: save a golden baseline
+    store.save(&GoldenSnapshot::new(
+        "strict_pass_test",
+        vec![GoldenTurnSnapshot {
+            user_input: "Hello".to_string(),
+            response: "Hi!".to_string(),
+            tool_calls: vec![],
+        }],
+    )).expect("save");
+
+    let config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+
+    let scenario = AgentTest::new("strict_pass_test")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .build()
+        .expect("build");
+
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("Hi!"))]);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    assert_eq!(report.passed(), 1);
+    assert_eq!(report.failed(), 0);
+}
+
+#[tokio::test]
+async fn golden_strict_mode_fails_when_mismatched() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    store.save(&GoldenSnapshot::new(
+        "strict_fail_test",
+        vec![GoldenTurnSnapshot {
+            user_input: "Hello".to_string(),
+            response: "Hi!".to_string(),
+            tool_calls: vec![],
+        }],
+    )).expect("save");
+
+    let config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+
+    let scenario = AgentTest::new("strict_fail_test")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .build()
+        .expect("build");
+
+    // Different response than golden
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("Hey there!"))]);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    assert_eq!(report.failed(), 1);
+    assert!(report.results[0]
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("response"));
+}
+
+#[tokio::test]
+async fn golden_strict_mode_fails_when_no_snapshot_exists() {
+    let dir = make_temp_dir();
+    let config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+
+    let scenario = AgentTest::new("missing_golden")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .build()
+        .expect("build");
+
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("Hi!"))]);
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+
+    assert_eq!(report.failed(), 1);
+    assert!(report.results[0]
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("not found"));
+}
+
+#[tokio::test]
+async fn golden_update_then_strict_roundtrip() {
+    let dir = make_temp_dir();
+
+    // Step 1: Update mode — record golden baseline
+    let scenario = AgentTest::new("roundtrip_test")
+        .when_user_says("What's 2+2?")
+        .then_agent_should()
+        .respond_containing("4")
+        .build()
+        .expect("build");
+
+    let update_config = GoldenTestConfig::update(GoldenStore::new(dir.path()));
+    let mut agent1 = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("The answer is 4."))]);
+    let update_report = run_golden_test(&update_config, &scenario, &mut agent1).await;
+    assert_eq!(update_report.passed(), 1);
+
+    // Step 2: Strict mode — same output should pass
+    let strict_config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+    let mut agent2 = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new("The answer is 4."))]);
+    let strict_report = run_golden_test(&strict_config, &scenario, &mut agent2).await;
+    assert_eq!(strict_report.passed(), 1);
+    assert_eq!(strict_report.failed(), 0);
+}
+
+#[tokio::test]
+async fn golden_strict_with_normalizer_passes_uuid_diff() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    store.save(&GoldenSnapshot::new(
+        "uuid_test",
+        vec![GoldenTurnSnapshot {
+            user_input: "create".to_string(),
+            response: "Created item 550e8400-e29b-41d4-a716-446655440000".to_string(),
+            tool_calls: vec![],
+        }],
+    )).expect("save");
+
+    let config = GoldenTestConfig::strict(GoldenStore::new(dir.path()))
+        .with_normalizer(NormalizerChain::default_chain().expect("chain"));
+
+    let scenario = AgentTest::new("uuid_test")
+        .when_user_says("create")
+        .then_agent_should()
+        .respond_containing("Created")
+        .build()
+        .expect("build");
+
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new(
+        "Created item a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    ))]);
+
+    let report = run_golden_test(&config, &scenario, &mut agent).await;
+    assert_eq!(report.passed(), 1, "UUID diff should be normalized away");
+}
+
+#[tokio::test]
+async fn golden_multi_turn_comparison() {
+    let dir = make_temp_dir();
+
+    let scenario = AgentTest::new("multi_turn_golden")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .when_user_says("Goodbye")
+        .then_agent_should()
+        .respond_containing("Bye")
+        .build()
+        .expect("build");
+
+    // Update
+    let update_config = GoldenTestConfig::update(GoldenStore::new(dir.path()));
+    let mut agent1 = ScriptedAgent::new(vec![
+        Ok(ScenarioTurnOutput::new("Hi there!")),
+        Ok(ScenarioTurnOutput::new("Bye!")),
+    ]);
+    run_golden_test(&update_config, &scenario, &mut agent1).await;
+
+    // Strict — matching
+    let strict_config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+    let mut agent2 = ScriptedAgent::new(vec![
+        Ok(ScenarioTurnOutput::new("Hi there!")),
+        Ok(ScenarioTurnOutput::new("Bye!")),
+    ]);
+    let report = run_golden_test(&strict_config, &scenario, &mut agent2).await;
+    assert_eq!(report.passed(), 1);
+
+    // Strict — second turn changed
+    let mut agent3 = ScriptedAgent::new(vec![
+        Ok(ScenarioTurnOutput::new("Hi there!")),
+        Ok(ScenarioTurnOutput::new("See you later!")),
+    ]);
+    let report2 = run_golden_test(&strict_config, &scenario, &mut agent3).await;
+    assert_eq!(report2.failed(), 1);
+}
+
+#[tokio::test]
+async fn golden_with_tool_calls_comparison() {
+    let dir = make_temp_dir();
+    let store = GoldenStore::new(dir.path());
+
+    store.save(&GoldenSnapshot::new(
+        "tool_golden",
+        vec![GoldenTurnSnapshot {
+            user_input: "search".to_string(),
+            response: "Found results".to_string(),
+            tool_calls: vec![ToolCallRecord {
+                name: "web_search".to_string(),
+                arguments: json!({"q": "rust"}),
+            }],
+        }],
+    )).expect("save");
+
+    let config = GoldenTestConfig::strict(GoldenStore::new(dir.path()));
+
+    let scenario = AgentTest::new("tool_golden")
+        .when_user_says("search")
+        .then_agent_should()
+        .respond_containing("Found")
+        .build()
+        .expect("build");
+
+    // Same tool call — should pass
+    let mut agent1 = ScriptedAgent::new(vec![Ok(
+        ScenarioTurnOutput::new("Found results")
+            .with_tool_call("web_search", json!({"q": "rust"})),
+    )]);
+    let report1 = run_golden_test(&config, &scenario, &mut agent1).await;
+    assert_eq!(report1.passed(), 1);
+
+    // Different tool args — should fail
+    let mut agent2 = ScriptedAgent::new(vec![Ok(
+        ScenarioTurnOutput::new("Found results")
+            .with_tool_call("web_search", json!({"q": "python"})),
+    )]);
+    let report2 = run_golden_test(&config, &scenario, &mut agent2).await;
+    assert_eq!(report2.failed(), 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GoldenDiff: display formatting
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn golden_diff_display_is_readable() {
+    let diff = GoldenDiff::ResponseMismatch {
+        turn: 1,
+        expected: "hello".to_string(),
+        actual: "hi".to_string(),
+    };
+    let msg = diff.to_string();
+    assert!(msg.contains("turn 1"));
+    assert!(msg.contains("hello"));
+    assert!(msg.contains("hi"));
+}
+
+#[test]
+fn golden_diff_serialization() {
+    let diff = GoldenDiff::ToolCallArgsMismatch {
+        turn: 2,
+        tool_name: "search".to_string(),
+        expected: json!({"q": "a"}),
+        actual: json!({"q": "b"}),
+    };
+
+    let json = serde_json::to_string(&diff).expect("serialize");
+    let deserialized: GoldenDiff = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(diff, deserialized);
+}

--- a/tests/tests/parameterized_tests.rs
+++ b/tests/tests/parameterized_tests.rs
@@ -1,0 +1,706 @@
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use mofa_testing::{
+    AgentTest, AgentTestScenario, ParameterExpansionError, ParameterMatrix, ParameterSet,
+    ParameterizedScenario, ParameterizedScenarioFile, ScenarioAgent, ScenarioTurnOutput,
+    TurnExpectation,
+};
+use serde_json::json;
+
+// ─── Helper: scripted agent ─────────────────────────────────────────────────
+
+struct ScriptedAgent {
+    outputs: VecDeque<Result<ScenarioTurnOutput, String>>,
+}
+
+impl ScriptedAgent {
+    fn new(outputs: Vec<Result<ScenarioTurnOutput, String>>) -> Self {
+        Self {
+            outputs: outputs.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ScenarioAgent for ScriptedAgent {
+    async fn execute_turn(
+        &mut self,
+        _system_prompt: Option<&str>,
+        _user_input: &str,
+    ) -> Result<ScenarioTurnOutput, String> {
+        self.outputs
+            .pop_front()
+            .unwrap_or_else(|| Err("no scripted output available".to_string()))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ParameterSet tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn parameter_set_builder_works() {
+    let ps = ParameterSet::new("berlin_celsius")
+        .with_var("city", "Berlin")
+        .with_var("unit", "celsius");
+
+    assert_eq!(ps.name, "berlin_celsius");
+    assert_eq!(ps.get("city"), Some("Berlin"));
+    assert_eq!(ps.get("unit"), Some("celsius"));
+    assert_eq!(ps.get("missing"), None);
+}
+
+#[test]
+fn parameter_set_variables_are_ordered() {
+    let ps = ParameterSet::new("test")
+        .with_var("zebra", "z")
+        .with_var("alpha", "a")
+        .with_var("mid", "m");
+
+    let keys: Vec<&String> = ps.variables.keys().collect();
+    assert_eq!(keys, vec!["alpha", "mid", "zebra"]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ParameterMatrix tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn matrix_expands_two_dimensions() {
+    let sets = ParameterMatrix::new()
+        .dimension("city", vec!["Berlin", "Tokyo"])
+        .dimension("unit", vec!["C", "F"])
+        .expand()
+        .expect("expansion should succeed");
+
+    assert_eq!(sets.len(), 4);
+
+    // Verify all combinations exist
+    let names: Vec<&str> = sets.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"Berlin_C"));
+    assert!(names.contains(&"Berlin_F"));
+    assert!(names.contains(&"Tokyo_C"));
+    assert!(names.contains(&"Tokyo_F"));
+
+    // Verify variable bindings
+    let berlin_c = sets.iter().find(|s| s.name == "Berlin_C").unwrap();
+    assert_eq!(berlin_c.get("city"), Some("Berlin"));
+    assert_eq!(berlin_c.get("unit"), Some("C"));
+}
+
+#[test]
+fn matrix_single_dimension() {
+    let sets = ParameterMatrix::new()
+        .dimension("lang", vec!["en", "de", "ja"])
+        .expand()
+        .expect("expansion should succeed");
+
+    assert_eq!(sets.len(), 3);
+    assert_eq!(sets[0].name, "en");
+    assert_eq!(sets[1].name, "de");
+    assert_eq!(sets[2].name, "ja");
+}
+
+#[test]
+fn matrix_three_dimensions() {
+    let sets = ParameterMatrix::new()
+        .dimension("a", vec!["1", "2"])
+        .dimension("b", vec!["x", "y"])
+        .dimension("c", vec!["p", "q"])
+        .expand()
+        .expect("expansion should succeed");
+
+    assert_eq!(sets.len(), 8); // 2 * 2 * 2
+}
+
+#[test]
+fn matrix_empty_dimension_fails() {
+    let err = ParameterMatrix::new()
+        .dimension("city", vec!["Berlin"])
+        .dimension("unit", Vec::<String>::new())
+        .expand()
+        .expect_err("should fail with empty dimension");
+
+    assert!(matches!(
+        err,
+        ParameterExpansionError::EmptyMatrixDimension { variable } if variable == "unit"
+    ));
+}
+
+#[test]
+fn matrix_no_dimensions_fails() {
+    let err = ParameterMatrix::new()
+        .expand()
+        .expect_err("should fail with no dimensions");
+
+    assert!(matches!(err, ParameterExpansionError::EmptyParameterSets));
+}
+
+#[test]
+fn matrix_exceeds_limit() {
+    let err = ParameterMatrix::new()
+        .with_limit(5)
+        .dimension("a", vec!["1", "2", "3"])
+        .dimension("b", vec!["x", "y", "z"])
+        .expand()
+        .expect_err("should fail exceeding limit");
+
+    assert!(matches!(
+        err,
+        ParameterExpansionError::MatrixExpansionLimit {
+            requested: 9,
+            limit: 5,
+        }
+    ));
+}
+
+#[test]
+fn matrix_combination_count() {
+    let matrix = ParameterMatrix::new()
+        .dimension("a", vec!["1", "2", "3"])
+        .dimension("b", vec!["x", "y"]);
+
+    assert_eq!(matrix.combination_count(), 6);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ParameterizedScenario: expansion and substitution tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+fn make_template_scenario() -> AgentTestScenario {
+    AgentTest::new("weather_agent")
+        .given_tool("weather_search")
+        .when_user_says("What's the weather in {{city}}?")
+        .then_agent_should()
+        .call_tool("weather_search")
+        .respond_containing("{{city}}")
+        .build()
+        .expect("template should build")
+}
+
+#[test]
+fn parameterized_expansion_substitutes_placeholders() {
+    let template = make_template_scenario();
+    let sets = vec![
+        ParameterSet::new("berlin").with_var("city", "Berlin"),
+        ParameterSet::new("tokyo").with_var("city", "Tokyo"),
+    ];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert_eq!(expanded.len(), 2);
+
+    // First variant
+    assert_eq!(expanded[0].agent_id, "weather_agent[berlin]");
+    assert_eq!(
+        expanded[0].turns[0].user_input,
+        "What's the weather in Berlin?"
+    );
+    assert!(matches!(
+        &expanded[0].turns[0].expectations[1],
+        TurnExpectation::RespondContaining { text } if text == "Berlin"
+    ));
+
+    // Second variant
+    assert_eq!(expanded[1].agent_id, "weather_agent[tokyo]");
+    assert_eq!(
+        expanded[1].turns[0].user_input,
+        "What's the weather in Tokyo?"
+    );
+}
+
+#[test]
+fn parameterized_expansion_with_matrix() {
+    let template = AgentTest::new("agent")
+        .when_user_says("Hello {{name}} from {{city}}")
+        .then_agent_should()
+        .respond_containing("{{name}}")
+        .build()
+        .expect("template should build");
+
+    let sets = ParameterMatrix::new()
+        .dimension("name", vec!["Alice", "Bob"])
+        .dimension("city", vec!["Berlin", "Tokyo"])
+        .expand()
+        .expect("matrix should expand");
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert_eq!(expanded.len(), 4);
+}
+
+#[test]
+fn parameterized_empty_sets_fails() {
+    let template = make_template_scenario();
+    let param = ParameterizedScenario::new(template, vec![]);
+    let err = param.expand().expect_err("should fail with empty sets");
+
+    assert!(matches!(err, ParameterExpansionError::EmptyParameterSets));
+}
+
+#[test]
+fn parameterized_missing_variable_fails() {
+    let template = make_template_scenario();
+    let sets = vec![
+        ParameterSet::new("incomplete"), // missing "city"
+    ];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let err = param.expand().expect_err("should fail with missing variable");
+
+    assert!(matches!(
+        err,
+        ParameterExpansionError::MissingVariable {
+            set_name,
+            variable,
+        } if set_name == "incomplete" && variable == "city"
+    ));
+}
+
+#[test]
+fn parameterized_case_count() {
+    let template = make_template_scenario();
+    let sets = vec![
+        ParameterSet::new("a").with_var("city", "A"),
+        ParameterSet::new("b").with_var("city", "B"),
+        ParameterSet::new("c").with_var("city", "C"),
+    ];
+
+    let param = ParameterizedScenario::new(template, sets);
+    assert_eq!(param.case_count(), 3);
+}
+
+#[test]
+fn expanded_scenario_names_are_stable() {
+    let template = make_template_scenario();
+    let sets = vec![
+        ParameterSet::new("first").with_var("city", "Berlin"),
+        ParameterSet::new("second").with_var("city", "Tokyo"),
+    ];
+
+    let param = ParameterizedScenario::new(template.clone(), sets.clone());
+    let expanded1 = param.expand().expect("first expansion");
+
+    let param2 = ParameterizedScenario::new(template, sets);
+    let expanded2 = param2.expand().expect("second expansion");
+
+    for (a, b) in expanded1.iter().zip(expanded2.iter()) {
+        assert_eq!(a.agent_id, b.agent_id);
+    }
+}
+
+#[test]
+fn substitution_works_in_regex_patterns() {
+    let template = AgentTest::new("agent")
+        .when_user_says("test")
+        .then_agent_should()
+        .respond_matching_regex("(?i){{keyword}}")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("greeting").with_var("keyword", "hello")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert!(matches!(
+        &expanded[0].turns[0].expectations[0],
+        TurnExpectation::RespondMatchingRegex { pattern } if pattern == "(?i)hello"
+    ));
+}
+
+#[test]
+fn substitution_works_in_exact_response() {
+    let template = AgentTest::new("agent")
+        .when_user_says("test")
+        .then_agent_should()
+        .respond_exact("Hello, {{name}}!")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("alice").with_var("name", "Alice")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert!(matches!(
+        &expanded[0].turns[0].expectations[0],
+        TurnExpectation::RespondExact { text } if text == "Hello, Alice!"
+    ));
+}
+
+#[test]
+fn substitution_works_in_call_tool_with_arguments() {
+    let template = AgentTest::new("agent")
+        .when_user_says("check {{city}}")
+        .then_agent_should()
+        .call_tool_with("search", json!({"query": "{{city}}"}))
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("berlin").with_var("city", "Berlin")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert!(matches!(
+        &expanded[0].turns[0].expectations[0],
+        TurnExpectation::CallToolWith { arguments, .. }
+            if arguments == &json!({"query": "Berlin"})
+    ));
+}
+
+#[test]
+fn substitution_works_in_system_prompt() {
+    let template = AgentTest::new("agent")
+        .given_system_prompt("You help with {{topic}}")
+        .when_user_says("help")
+        .then_agent_should()
+        .respond_containing("{{topic}}")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("math").with_var("topic", "mathematics")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert_eq!(
+        expanded[0].system_prompt.as_deref(),
+        Some("You help with mathematics")
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ParameterizedScenario: execution tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn parameterized_scenarios_run_and_produce_reports() {
+    let template = make_template_scenario();
+    let sets = vec![
+        ParameterSet::new("berlin").with_var("city", "Berlin"),
+        ParameterSet::new("tokyo").with_var("city", "Tokyo"),
+    ];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    // Run first variant
+    let mut agent1 = ScriptedAgent::new(vec![Ok(
+        ScenarioTurnOutput::new("The weather in Berlin is sunny.")
+            .with_tool_call("weather_search", json!({})),
+    )]);
+    let report1 = expanded[0].run_with_agent(&mut agent1).await;
+    assert_eq!(report1.passed(), 1);
+    assert_eq!(report1.failed(), 0);
+
+    // Run second variant
+    let mut agent2 = ScriptedAgent::new(vec![Ok(
+        ScenarioTurnOutput::new("The weather in Tokyo is rainy.")
+            .with_tool_call("weather_search", json!({})),
+    )]);
+    let report2 = expanded[1].run_with_agent(&mut agent2).await;
+    assert_eq!(report2.passed(), 1);
+    assert_eq!(report2.failed(), 0);
+}
+
+#[tokio::test]
+async fn parameterized_scenario_detects_failure_in_variant() {
+    let template = make_template_scenario();
+    let sets = vec![ParameterSet::new("berlin").with_var("city", "Berlin")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    // Agent doesn't call the expected tool
+    let mut agent = ScriptedAgent::new(vec![Ok(ScenarioTurnOutput::new(
+        "I don't know about Berlin.",
+    ))]);
+
+    let report = expanded[0].run_with_agent(&mut agent).await;
+    assert_eq!(report.failed(), 1);
+    assert!(report.results[0]
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("weather_search"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// File-backed parameterized scenario loading
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn load_parameterized_scenario_from_yaml() {
+    let yaml = r#"
+template:
+  agent_id: weather_agent
+  tools:
+    - weather_search
+  turns:
+    - user: "What's the weather in {{city}}?"
+      expect:
+        - kind: call_tool
+          name: weather_search
+        - kind: respond_containing
+          text: "{{city}}"
+
+parameters:
+  - name: berlin
+    vars:
+      city: Berlin
+  - name: tokyo
+    vars:
+      city: Tokyo
+"#;
+
+    let param = ParameterizedScenarioFile::from_yaml_str(yaml)
+        .expect("yaml parameterized scenario should load");
+
+    assert_eq!(param.case_count(), 2);
+
+    let expanded = param.expand().expect("expansion should succeed");
+    assert_eq!(expanded[0].agent_id, "weather_agent[berlin]");
+    assert_eq!(expanded[1].agent_id, "weather_agent[tokyo]");
+}
+
+#[test]
+fn load_parameterized_scenario_with_matrix_from_yaml() {
+    let yaml = r#"
+template:
+  agent_id: weather_agent
+  turns:
+    - user: "Weather in {{city}} in {{unit}}"
+      expect:
+        - kind: respond_containing
+          text: "{{city}}"
+
+matrix:
+  dimensions:
+    city:
+      - Berlin
+      - Tokyo
+    unit:
+      - celsius
+      - fahrenheit
+"#;
+
+    let param = ParameterizedScenarioFile::from_yaml_str(yaml)
+        .expect("yaml matrix scenario should load");
+
+    assert_eq!(param.case_count(), 4);
+
+    let expanded = param.expand().expect("expansion should succeed");
+    assert_eq!(expanded.len(), 4);
+}
+
+#[test]
+fn load_parameterized_scenario_from_json() {
+    let json = r#"{
+  "template": {
+    "agent_id": "agent",
+    "turns": [
+      {
+        "user": "Hello {{name}}",
+        "expect": [
+          {"kind": "respond_containing", "text": "{{name}}"}
+        ]
+      }
+    ]
+  },
+  "parameters": [
+    {"name": "alice", "vars": {"name": "Alice"}},
+    {"name": "bob", "vars": {"name": "Bob"}}
+  ]
+}"#;
+
+    let param = ParameterizedScenarioFile::from_json_str(json)
+        .expect("json parameterized scenario should load");
+
+    assert_eq!(param.case_count(), 2);
+}
+
+#[test]
+fn load_parameterized_scenario_from_toml() {
+    let toml_input = r#"
+[template]
+agent_id = "support_agent"
+
+[[template.turns]]
+user = "Help with {{topic}}"
+
+[[template.turns.expect]]
+kind = "respond_containing"
+text = "{{topic}}"
+
+[[parameters]]
+name = "billing"
+
+[parameters.vars]
+topic = "billing"
+
+[[parameters]]
+name = "shipping"
+
+[parameters.vars]
+topic = "shipping"
+"#;
+
+    let param = ParameterizedScenarioFile::from_toml_str(toml_input)
+        .expect("toml parameterized scenario should load");
+
+    assert_eq!(param.case_count(), 2);
+
+    let expanded = param.expand().expect("expansion should succeed");
+    assert_eq!(expanded[0].turns[0].user_input, "Help with billing");
+    assert_eq!(expanded[1].turns[0].user_input, "Help with shipping");
+}
+
+#[test]
+fn parameterized_yaml_with_mixed_explicit_and_matrix() {
+    let yaml = r#"
+template:
+  agent_id: agent
+  turns:
+    - user: "Test {{x}}_{{y}}"
+      expect:
+        - kind: respond_containing
+          text: "{{x}}"
+
+parameters:
+  - name: manual_case
+    vars:
+      x: manual
+      y: override
+
+matrix:
+  dimensions:
+    x:
+      - a
+      - b
+    y:
+      - "1"
+      - "2"
+"#;
+
+    let param = ParameterizedScenarioFile::from_yaml_str(yaml)
+        .expect("mixed scenario should load");
+
+    // 1 explicit + 4 matrix = 5
+    assert_eq!(param.case_count(), 5);
+}
+
+#[test]
+fn matrix_limit_in_file_is_respected() {
+    let yaml = r#"
+template:
+  agent_id: agent
+  turns:
+    - user: "Test {{x}} {{y}} {{z}}"
+      expect:
+        - kind: respond_containing
+          text: "ok"
+
+matrix:
+  limit: 5
+  dimensions:
+    x: ["a", "b", "c"]
+    y: ["1", "2", "3"]
+    z: ["p", "q", "r"]
+"#;
+
+    let err = ParameterizedScenarioFile::from_yaml_str(yaml)
+        .expect_err("should fail with matrix limit exceeded");
+
+    assert!(matches!(
+        err,
+        ParameterExpansionError::MatrixExpansionLimit { .. }
+    ));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Edge cases and robustness
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn no_placeholders_still_works() {
+    let template = AgentTest::new("agent")
+        .when_user_says("Hello")
+        .then_agent_should()
+        .respond_containing("Hi")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![
+        ParameterSet::new("case_a"),
+        ParameterSet::new("case_b"),
+    ];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion without placeholders should succeed");
+
+    assert_eq!(expanded.len(), 2);
+    assert_eq!(expanded[0].turns[0].user_input, "Hello");
+    assert_eq!(expanded[1].turns[0].user_input, "Hello");
+}
+
+#[test]
+fn multiple_placeholders_in_single_field() {
+    let template = AgentTest::new("agent")
+        .when_user_says("From {{city}} to {{destination}} via {{mode}}")
+        .then_agent_should()
+        .respond_containing("route")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("trip")
+        .with_var("city", "Berlin")
+        .with_var("destination", "Tokyo")
+        .with_var("mode", "train")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert_eq!(
+        expanded[0].turns[0].user_input,
+        "From Berlin to Tokyo via train"
+    );
+}
+
+#[test]
+fn same_placeholder_used_multiple_times() {
+    let template = AgentTest::new("agent")
+        .when_user_says("Tell me about {{city}}")
+        .then_agent_should()
+        .respond_containing("{{city}}")
+        .build()
+        .expect("template should build");
+
+    let sets = vec![ParameterSet::new("berlin").with_var("city", "Berlin")];
+
+    let param = ParameterizedScenario::new(template, sets);
+    let expanded = param.expand().expect("expansion should succeed");
+
+    assert_eq!(expanded[0].turns[0].user_input, "Tell me about Berlin");
+    assert!(matches!(
+        &expanded[0].turns[0].expectations[0],
+        TurnExpectation::RespondContaining { text } if text == "Berlin"
+    ));
+}
+
+#[test]
+fn parameter_set_serialization_roundtrip() {
+    let ps = ParameterSet::new("test")
+        .with_var("city", "Berlin")
+        .with_var("unit", "C");
+
+    let json = serde_json::to_string(&ps).expect("serialize");
+    let deserialized: ParameterSet = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(ps.name, deserialized.name);
+    assert_eq!(ps.variables, deserialized.variables);
+}

--- a/tests/tests/semantic_tests.rs
+++ b/tests/tests/semantic_tests.rs
@@ -1,0 +1,537 @@
+use mofa_testing::{
+    ContainsAllFactsMatcher, ExcludesContentMatcher, IntentMatcher, RegexIntentMatcher,
+    SemanticAssertionError, SemanticAssertionSet, SemanticExpectation, SemanticMatchResult,
+    SemanticMatcher, SimilarityMatcher,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ContainsAllFactsMatcher tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn contains_all_facts_passes_when_all_present() {
+    let matcher = ContainsAllFactsMatcher::new(vec!["Berlin", "22C", "sunny"]);
+    let result = matcher.evaluate("The weather in Berlin is 22C and sunny today.");
+
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+    assert!(result.explanation.contains("3 facts found"));
+}
+
+#[test]
+fn contains_all_facts_fails_when_some_missing() {
+    let matcher = ContainsAllFactsMatcher::new(vec!["Berlin", "22C", "snowy"]);
+    let result = matcher.evaluate("The weather in Berlin is 22C and sunny.");
+
+    assert!(!result.passed);
+    assert!((result.confidence - 2.0 / 3.0).abs() < 0.01);
+    assert!(result.explanation.contains("snowy"));
+}
+
+#[test]
+fn contains_all_facts_case_insensitive() {
+    let matcher = ContainsAllFactsMatcher::new(vec!["berlin", "sunny"]);
+    let result = matcher.evaluate("BERLIN is SUNNY today");
+
+    assert!(result.passed);
+}
+
+#[test]
+fn contains_all_facts_empty_facts_passes() {
+    let matcher = ContainsAllFactsMatcher::new(Vec::<String>::new());
+    let result = matcher.evaluate("any response");
+
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+}
+
+#[test]
+fn contains_all_facts_no_facts_found() {
+    let matcher = ContainsAllFactsMatcher::new(vec!["xyzzy", "plugh"]);
+    let result = matcher.evaluate("nothing matches here");
+
+    assert!(!result.passed);
+    assert_eq!(result.confidence, 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ExcludesContentMatcher tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn excludes_content_passes_when_clean() {
+    let matcher = ExcludesContentMatcher::new(vec!["password", "SSN", "credit card"]);
+    let result = matcher.evaluate("Here is your account summary for March.");
+
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+}
+
+#[test]
+fn excludes_content_fails_when_banned_found() {
+    let matcher = ExcludesContentMatcher::new(vec!["password", "SSN"]);
+    let result = matcher.evaluate("Your password is abc123.");
+
+    assert!(!result.passed);
+    assert!(result.explanation.contains("password"));
+}
+
+#[test]
+fn excludes_content_case_insensitive() {
+    let matcher = ExcludesContentMatcher::new(vec!["secret"]);
+    let result = matcher.evaluate("This is a SECRET document.");
+
+    assert!(!result.passed);
+}
+
+#[test]
+fn excludes_content_multiple_violations() {
+    let matcher = ExcludesContentMatcher::new(vec!["password", "SSN", "credit card"]);
+    let result = matcher.evaluate("Your password is X and your SSN is Y.");
+
+    assert!(!result.passed);
+    assert!(result.explanation.contains("password"));
+    assert!(result.explanation.contains("SSN"));
+}
+
+#[test]
+fn excludes_content_empty_banned_passes() {
+    let matcher = ExcludesContentMatcher::new(Vec::<String>::new());
+    let result = matcher.evaluate("anything");
+
+    assert!(result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// IntentMatcher tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn intent_matches_single_intent() {
+    let matcher = IntentMatcher::new()
+        .expect_intent("greeting", vec!["hello", "hi", "welcome"]);
+
+    let result = matcher.evaluate("Hello! How can I help you?");
+    assert!(result.passed);
+    assert!(result.explanation.contains("greeting"));
+}
+
+#[test]
+fn intent_fails_when_no_intent_matches() {
+    let matcher = IntentMatcher::new()
+        .expect_intent("farewell", vec!["goodbye", "bye"]);
+
+    let result = matcher.evaluate("Hello there!");
+    assert!(!result.passed);
+}
+
+#[test]
+fn intent_any_mode_passes_with_one_match() {
+    let matcher = IntentMatcher::new()
+        .expect_intent("greeting", vec!["hello", "hi"])
+        .expect_intent("help", vec!["assist", "help"]);
+
+    let result = matcher.evaluate("Hi there!");
+    assert!(result.passed); // greeting matched, even though help didn't
+}
+
+#[test]
+fn intent_require_all_fails_with_partial() {
+    let matcher = IntentMatcher::new()
+        .require_all()
+        .expect_intent("greeting", vec!["hello", "hi"])
+        .expect_intent("help", vec!["assist", "help"]);
+
+    let result = matcher.evaluate("Hi there!");
+    assert!(!result.passed); // greeting matched, but help didn't
+    assert!(result.explanation.contains("help"));
+}
+
+#[test]
+fn intent_require_all_passes_when_all_match() {
+    let matcher = IntentMatcher::new()
+        .require_all()
+        .expect_intent("greeting", vec!["hello", "hi"])
+        .expect_intent("offer", vec!["help", "assist"]);
+
+    let result = matcher.evaluate("Hello! How can I help you?");
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+}
+
+#[test]
+fn intent_case_insensitive() {
+    let matcher = IntentMatcher::new()
+        .expect_intent("greeting", vec!["hello"]);
+
+    let result = matcher.evaluate("HELLO WORLD!");
+    assert!(result.passed);
+}
+
+#[test]
+fn intent_empty_intents_passes() {
+    let matcher = IntentMatcher::new();
+    let result = matcher.evaluate("anything");
+    assert!(result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimilarityMatcher tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn similarity_high_overlap_passes() {
+    let matcher = SimilarityMatcher::new(
+        "The temperature in Berlin is 22 degrees Celsius",
+        0.3,
+    )
+    .expect("valid threshold");
+
+    let result = matcher.evaluate("The temperature is 22 degrees in Berlin Celsius");
+    assert!(result.passed);
+    assert!(result.confidence > 0.5);
+}
+
+#[test]
+fn similarity_no_overlap_fails() {
+    let matcher = SimilarityMatcher::new("apples oranges bananas", 0.5).expect("valid");
+
+    let result = matcher.evaluate("cars trucks planes");
+    assert!(!result.passed);
+    assert_eq!(result.confidence, 0.0);
+}
+
+#[test]
+fn similarity_identical_text() {
+    let matcher = SimilarityMatcher::new("hello world", 0.9).expect("valid");
+
+    let result = matcher.evaluate("hello world");
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+}
+
+#[test]
+fn similarity_threshold_boundary() {
+    let matcher = SimilarityMatcher::new("alpha beta gamma delta", 0.5).expect("valid");
+
+    // 2 out of 4 tokens match = Jaccard depends on union
+    let result = matcher.evaluate("alpha beta epsilon zeta");
+    // Intersection: {alpha, beta} = 2, Union: {alpha, beta, gamma, delta, epsilon, zeta} = 6
+    // Jaccard = 2/6 ≈ 0.33
+    assert!(!result.passed);
+}
+
+#[test]
+fn similarity_invalid_threshold_below_zero() {
+    let err = SimilarityMatcher::new("test", -0.1).expect_err("should fail");
+    assert!(matches!(err, SemanticAssertionError::InvalidThreshold { .. }));
+}
+
+#[test]
+fn similarity_invalid_threshold_above_one() {
+    let err = SimilarityMatcher::new("test", 1.5).expect_err("should fail");
+    assert!(matches!(err, SemanticAssertionError::InvalidThreshold { .. }));
+}
+
+#[test]
+fn similarity_zero_threshold_always_passes() {
+    let matcher = SimilarityMatcher::new("reference", 0.0).expect("valid");
+    let result = matcher.evaluate("completely different text");
+    assert!(result.passed);
+}
+
+#[test]
+fn similarity_case_insensitive() {
+    let matcher = SimilarityMatcher::new("Hello World", 0.9).expect("valid");
+    let result = matcher.evaluate("hello world");
+    assert!(result.passed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// RegexIntentMatcher tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn regex_intent_matches_pattern() {
+    let matcher = RegexIntentMatcher::new(
+        "temperature_mentioned",
+        r"\d+\s*(°?[CF]|degrees|celsius|fahrenheit)",
+        "response mentions a temperature value",
+    )
+    .expect("valid regex");
+
+    let result = matcher.evaluate("The temperature is 22 degrees today.");
+    assert!(result.passed);
+    assert_eq!(result.confidence, 1.0);
+}
+
+#[test]
+fn regex_intent_fails_when_no_match() {
+    let matcher = RegexIntentMatcher::new(
+        "has_number",
+        r"\d+",
+        "response contains a number",
+    )
+    .expect("valid regex");
+
+    let result = matcher.evaluate("No numbers here at all.");
+    assert!(!result.passed);
+}
+
+#[test]
+fn regex_intent_invalid_pattern() {
+    let err = RegexIntentMatcher::new("bad", "[invalid", "test")
+        .expect_err("should fail");
+    assert!(matches!(err, SemanticAssertionError::InvalidPattern(_)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SemanticAssertionSet tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn assertion_set_all_pass() {
+    let set = SemanticAssertionSet::new()
+        .add(ContainsAllFactsMatcher::new(vec!["Berlin", "sunny"]))
+        .add(ExcludesContentMatcher::new(vec!["password"]))
+        .add(IntentMatcher::new().expect_intent("weather", vec!["weather", "temperature"]));
+
+    let report = set
+        .evaluate("The weather in Berlin is sunny and warm.")
+        .expect("evaluate");
+
+    assert!(report.passed);
+    assert_eq!(report.passed_count, 3);
+    assert_eq!(report.total_count, 3);
+}
+
+#[test]
+fn assertion_set_partial_failure() {
+    let set = SemanticAssertionSet::new()
+        .add(ContainsAllFactsMatcher::new(vec!["Berlin"]))
+        .add(ExcludesContentMatcher::new(vec!["password"]));
+
+    let report = set
+        .evaluate("Your Berlin password is abc123")
+        .expect("evaluate");
+
+    assert!(!report.passed);
+    assert_eq!(report.passed_count, 1); // facts passed, excludes failed
+    assert_eq!(report.total_count, 2);
+}
+
+#[test]
+fn assertion_set_empty_fails() {
+    let set = SemanticAssertionSet::new();
+    let err = set.evaluate("anything").expect_err("should fail");
+    assert!(matches!(err, SemanticAssertionError::EmptyMatcherSet));
+}
+
+#[test]
+fn assertion_set_single_matcher() {
+    let set = SemanticAssertionSet::new()
+        .add(ContainsAllFactsMatcher::new(vec!["hello"]));
+
+    let report = set.evaluate("hello world").expect("evaluate");
+    assert!(report.passed);
+    assert_eq!(report.total_count, 1);
+}
+
+#[test]
+fn assertion_set_average_confidence() {
+    let set = SemanticAssertionSet::new()
+        .add(ContainsAllFactsMatcher::new(vec!["present"])) // 1.0 confidence
+        .add(ContainsAllFactsMatcher::new(vec!["missing"])); // 0.0 confidence
+
+    let report = set
+        .evaluate("present but no other fact")
+        .expect("evaluate");
+
+    assert!(!report.passed);
+    assert!((report.average_confidence - 0.5).abs() < 0.01);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SemanticMatchResult tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn match_result_pass_constructor() {
+    let result = SemanticMatchResult::pass("test", 0.95, "looks good");
+    assert!(result.passed);
+    assert_eq!(result.confidence, 0.95);
+    assert_eq!(result.matcher_name, "test");
+}
+
+#[test]
+fn match_result_fail_constructor() {
+    let result = SemanticMatchResult::fail("test", 0.3, "not good");
+    assert!(!result.passed);
+    assert_eq!(result.confidence, 0.3);
+}
+
+#[test]
+fn match_result_serialization_roundtrip() {
+    let result = SemanticMatchResult::pass("contains_all_facts", 1.0, "all facts found");
+
+    let json = serde_json::to_string(&result).expect("serialize");
+    let deserialized: SemanticMatchResult = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(result, deserialized);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SemanticExpectation: file-backed loading
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn semantic_expectation_from_yaml() {
+    let yaml = r#"
+- kind: contains_all_facts
+  facts:
+    - Berlin
+    - sunny
+- kind: excludes_content
+  banned:
+    - password
+    - secret
+- kind: matches_intent
+  intents:
+    - name: weather
+      indicators: [weather, forecast, temperature]
+  require_all: false
+- kind: similar_to
+  reference: "The weather in Berlin is sunny"
+  threshold: 0.4
+- kind: matches_pattern
+  name: has_temperature
+  pattern: '\d+\s*degrees'
+  description: "response includes a temperature"
+"#;
+
+    let expectations = SemanticExpectation::from_yaml_str(yaml).expect("parse yaml");
+    assert_eq!(expectations.len(), 5);
+
+    let set = SemanticExpectation::into_assertion_set(expectations).expect("build set");
+    assert_eq!(set.len(), 5);
+
+    let report = set
+        .evaluate("The weather in Berlin is 22 degrees and sunny today.")
+        .expect("evaluate");
+
+    assert!(report.passed, "all expectations should pass: {:?}", report);
+}
+
+#[test]
+fn semantic_expectation_from_json() {
+    let json = r#"[
+  {"kind": "contains_all_facts", "facts": ["hello"]},
+  {"kind": "excludes_content", "banned": ["secret"]}
+]"#;
+
+    let expectations = SemanticExpectation::from_json_str(json).expect("parse json");
+    assert_eq!(expectations.len(), 2);
+}
+
+#[test]
+fn semantic_expectation_into_matcher_similarity() {
+    let exp = SemanticExpectation::SimilarTo {
+        reference: "hello world".to_string(),
+        threshold: 0.5,
+    };
+
+    let matcher = exp.into_matcher().expect("build matcher");
+    let result = matcher.evaluate("hello world");
+    assert!(result.passed);
+}
+
+#[test]
+fn semantic_expectation_into_matcher_invalid_pattern() {
+    let exp = SemanticExpectation::MatchesPattern {
+        name: "bad".to_string(),
+        pattern: "[invalid".to_string(),
+        description: "test".to_string(),
+    };
+
+    let err = exp.into_matcher().expect_err("should fail");
+    assert!(matches!(err, SemanticAssertionError::InvalidPattern(_)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Composite real-world scenarios
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn real_world_weather_agent_validation() {
+    let set = SemanticAssertionSet::new()
+        .add(ContainsAllFactsMatcher::new(vec!["Berlin", "temperature"]))
+        .add(ExcludesContentMatcher::new(vec![
+            "I don't know",
+            "error",
+            "unable",
+        ]))
+        .add(
+            IntentMatcher::new()
+                .require_all()
+                .expect_intent("weather_info", vec!["weather", "temperature", "forecast"])
+                .expect_intent("location_specific", vec!["Berlin"]),
+        )
+        .add(
+            SimilarityMatcher::new(
+                "The temperature in Berlin is around 22 degrees",
+                0.3,
+            )
+            .expect("valid"),
+        )
+        .add(
+            RegexIntentMatcher::new(
+                "has_temp_value",
+                r"\d+",
+                "includes a numeric temperature value",
+            )
+            .expect("valid"),
+        );
+
+    let response = "The current temperature in Berlin is 22 degrees Celsius with clear skies.";
+    let report = set.evaluate(response).expect("evaluate");
+
+    assert!(report.passed, "weather response should pass all matchers");
+    assert_eq!(report.passed_count, 5);
+}
+
+#[test]
+fn real_world_policy_violation_detection() {
+    let set = SemanticAssertionSet::new()
+        .add(ExcludesContentMatcher::new(vec![
+            "password",
+            "SSN",
+            "social security",
+            "credit card number",
+        ]))
+        .add(ContainsAllFactsMatcher::new(vec!["account", "summary"]));
+
+    let safe_response = "Here is your account summary for March 2026.";
+    let report = set.evaluate(safe_response).expect("evaluate");
+    assert!(report.passed);
+
+    let unsafe_response = "Your account summary: password is abc123.";
+    let report2 = set.evaluate(unsafe_response).expect("evaluate");
+    assert!(!report2.passed);
+}
+
+#[test]
+fn real_world_mixed_intent_and_facts() {
+    let set = SemanticAssertionSet::new()
+        .add(
+            IntentMatcher::new()
+                .expect_intent("acknowledgment", vec!["thank", "welcome", "glad"]),
+        )
+        .add(ContainsAllFactsMatcher::new(vec!["help"]));
+
+    let result = set
+        .evaluate("You're welcome! Glad I could help.")
+        .expect("evaluate");
+
+    assert!(result.passed);
+    assert_eq!(result.passed_count, 2);
+}


### PR DESCRIPTION
## 🔍 Description

Adds semantic assertion matchers to the `mofa-testing` crate. These validate **meaning and intent** rather than exact text, making tests resilient to harmless wording changes while maintaining strict policy and safety checks.

This is Issue 5 from the testing platform roadmap (Assertion Layer, Phase 3).

Closes #1605 
Depends on #1599

## 📌 Changes

### New: `tests/src/semantic.rs`

Core semantic assertion module with the following public components:

| Component | Purpose | Confidence Score |
|-----------|---------|-----------------|
| `SemanticMatcher` trait | Extensible base for all assertion types | — |
| `ContainsAllFactsMatcher` | Validates required facts are present (case-insensitive) | Fraction of facts found |
| `ExcludesContentMatcher` | Validates prohibited content is absent (policy/safety) | Fraction of clean terms |
| `IntentMatcher` | Keyword-based intent classification with any/all modes | Fraction of intents matched |
| `SimilarityMatcher` | Jaccard token-overlap with configurable threshold | Similarity coefficient |
| `RegexIntentMatcher` | Structural pattern validation via regex | 1.0 or 0.0 |
| `SemanticAssertionSet` | Composable bundle of matchers with aggregated reporting | — |
| `SemanticExpectation` | YAML/JSON file-backed assertion definitions | — |
| `SemanticMatchResult` | Per-matcher outcome with confidence and explanation | — |
| `SemanticReport` | Aggregated pass/fail with average confidence | — |
| `SemanticAssertionError` | Structured error type (invalid patterns, thresholds, empty sets) | — |

**Key design decisions:**
- All matchers are **deterministic** — no external API calls, safe for CI and offline environments
- All text matching is **case-insensitive** by default
- Every result includes a **confidence score** in [0.0, 1.0] for nuanced analysis
- Matchers are **composable** — combine any number in a `SemanticAssertionSet`
- **File-backed** YAML/JSON definitions enable non-Rust contributors to author assertions

### Modified: `tests/src/lib.rs`

- Added `pub mod semantic` module registration
- Added public re-exports for all semantic types

### New: `tests/tests/semantic_tests.rs`

35+ comprehensive tests covering:

- **ContainsAllFactsMatcher**: all present, some missing, case insensitivity, empty facts, none found
- **ExcludesContentMatcher**: clean response, single violation, multiple violations, case insensitivity, empty banned list
- **IntentMatcher**: single intent, no match, any-mode, require-all mode, all match, case insensitivity, empty intents
- **SimilarityMatcher**: high overlap, no overlap, identical text, threshold boundary, invalid thresholds, zero threshold, case insensitivity
- **RegexIntentMatcher**: pattern match, no match, invalid pattern
- **SemanticAssertionSet**: all pass, partial failure, empty set error, single matcher, average confidence
- **SemanticMatchResult**: constructors, serialization roundtrip
- **SemanticExpectation**: YAML loading (all 5 types), JSON loading, `into_matcher` conversions, invalid pattern error
- **Real-world scenarios**: weather agent (5 matchers), policy violation detection, mixed intent+facts

### New: `examples/semantic_assertions/`

| File | Description |
|------|-------------|
| `README.md` | Usage guide with Rust builder API, file-backed YAML, and design rationale |
| `weather_assertions.yaml` | 5-matcher weather agent validation: facts, intents, similarity, pattern, policy |
| `safety_assertions.yaml` | Safety-focused assertions: PII exclusion, acknowledgment intent, error exclusion |

## 🧪 Testing

All new functionality is covered by `tests/tests/semantic_tests.rs` with 35+ test cases.

Key test categories:
1. **Unit tests** — Each matcher type in isolation
2. **Composition tests** — SemanticAssertionSet with multiple matchers
3. **File loading tests** — YAML/JSON deserialization and conversion to matchers
4. **Error path tests** — Invalid patterns, out-of-bounds thresholds, empty sets
5. **Real-world tests** — Weather validation, policy compliance, mixed assertion scenarios
6. **Serialization tests** — SemanticMatchResult JSON roundtrip

## 💡 Usage Example

### Rust Builder API

```rust
use mofa_testing::{
    ContainsAllFactsMatcher, ExcludesContentMatcher, IntentMatcher,
    SemanticAssertionSet, SimilarityMatcher,
};

let assertions = SemanticAssertionSet::new()
    .add(ContainsAllFactsMatcher::new(vec!["Berlin", "temperature"]))
    .add(ExcludesContentMatcher::new(vec!["password", "error"]))
    .add(IntentMatcher::new()
        .expect_intent("weather", vec!["weather", "temperature"]))
    .add(SimilarityMatcher::new(
        "The temperature in Berlin is 22 degrees", 0.3
    ).unwrap());

let report = assertions.evaluate(
    "The current temperature in Berlin is 22 degrees Celsius."
).unwrap();

assert!(report.passed);
println!("confidence: {:.2}", report.average_confidence);
```

### File-backed (YAML)

```yaml
- kind: contains_all_facts
  facts: [Berlin, temperature]
- kind: excludes_content
  banned: [password, error]
- kind: matches_intent
  intents:
    - name: weather
      indicators: [weather, temperature, forecast]
  require_all: false
- kind: similar_to
  reference: "The temperature in Berlin is 22 degrees"
  threshold: 0.3
```

```rust
use mofa_testing::SemanticExpectation;

let yaml = std::fs::read_to_string("assertions.yaml")?;
let expectations = SemanticExpectation::from_yaml_str(&yaml)?;
let set = SemanticExpectation::into_assertion_set(expectations)?;
let report = set.evaluate("Berlin is 22 degrees and sunny.")?;
assert!(report.passed);
```

### Policy Compliance Check

```rust
let safety = SemanticAssertionSet::new()
    .add(ExcludesContentMatcher::new(vec![
        "password", "SSN", "credit card number"
    ]));

let report = safety.evaluate(&agent_response).unwrap();
assert!(report.passed, "agent leaked sensitive information");
```

## ✅ Checklist

- [x] Code follows project conventions and style
- [x] New module registered in `lib.rs` with public re-exports
- [x] Comprehensive tests added (`semantic_tests.rs`)
- [x] Examples added (`examples/semantic_assertions/`)
- [x] README with usage documentation included
- [x] All matchers are deterministic (no external API calls)
- [x] Structured error types with `SemanticAssertionError`
- [x] Confidence scores on all match results
- [x] File-backed YAML/JSON assertion definitions
- [x] No breaking changes to existing APIs
- [x] Builds on the DSL foundation from #1599
