### PR TITLE
feat(testing): add MockClock timeout/deadline helper APIs

### DIFF
--- a/tests/src/clock.rs
+++ b/tests/src/clock.rs
@@ -26,6 +26,10 @@ impl Default for MockClock {
 }
 
 impl MockClock {
+    fn current_millis(&self) -> u64 {
+        self.current_ms.load(Ordering::Relaxed)
+    }
+
     /// Create a clock starting at time zero.
     pub fn new() -> Self {
         Self {
@@ -63,6 +67,27 @@ impl MockClock {
     /// Disable auto-advance.
     pub fn clear_auto_advance(&self) {
         *self.auto_advance_ms.write().expect("lock poisoned") = None;
+    }
+
+    /// Return the current time without triggering auto-advance.
+    pub fn peek_millis(&self) -> u64 {
+        self.current_millis()
+    }
+
+    /// Compute an absolute deadline by adding `timeout` to the current time.
+    pub fn deadline_after(&self, timeout: Duration) -> u64 {
+        self.current_millis()
+            .saturating_add(timeout.as_millis() as u64)
+    }
+
+    /// Returns true when current time is at or past `deadline_ms`.
+    pub fn has_reached_deadline(&self, deadline_ms: u64) -> bool {
+        self.current_millis() >= deadline_ms
+    }
+
+    /// Return remaining time until `deadline_ms` (floored at zero).
+    pub fn remaining_until(&self, deadline_ms: u64) -> Duration {
+        Duration::from_millis(deadline_ms.saturating_sub(self.current_millis()))
     }
 }
 

--- a/tests/tests/clock_timeout_tests.rs
+++ b/tests/tests/clock_timeout_tests.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use mofa_testing::clock::{Clock, MockClock};
+
+#[test]
+fn deadline_after_uses_current_time() {
+    let clock = MockClock::starting_at(Duration::from_millis(1_000));
+    let deadline = clock.deadline_after(Duration::from_millis(250));
+    assert_eq!(deadline, 1_250);
+}
+
+#[test]
+fn has_reached_deadline_respects_manual_advance() {
+    let clock = MockClock::new();
+    let deadline = clock.deadline_after(Duration::from_millis(100));
+
+    assert!(!clock.has_reached_deadline(deadline));
+    clock.advance(Duration::from_millis(99));
+    assert!(!clock.has_reached_deadline(deadline));
+    clock.advance(Duration::from_millis(1));
+    assert!(clock.has_reached_deadline(deadline));
+}
+
+#[test]
+fn remaining_until_is_zero_after_deadline() {
+    let clock = MockClock::starting_at(Duration::from_millis(500));
+    let deadline = clock.deadline_after(Duration::from_millis(10));
+
+    assert_eq!(clock.remaining_until(deadline), Duration::from_millis(10));
+    clock.advance(Duration::from_millis(7));
+    assert_eq!(clock.remaining_until(deadline), Duration::from_millis(3));
+    clock.advance(Duration::from_millis(10));
+    assert_eq!(clock.remaining_until(deadline), Duration::ZERO);
+}
+
+#[test]
+fn peek_millis_does_not_trigger_auto_advance() {
+    let clock = MockClock::new();
+    clock.set_auto_advance(Duration::from_millis(50));
+
+    assert_eq!(clock.peek_millis(), 0);
+    assert_eq!(clock.peek_millis(), 0);
+
+    // now_millis reads current value and then auto-advances.
+    assert_eq!(clock.now_millis(), 0);
+    assert_eq!(clock.peek_millis(), 50);
+}


### PR DESCRIPTION
```mermaid
flowchart TD
    A["MockClock current_ms"] --> B["deadline_after(timeout)"]
    B --> C["deadline_ms"]

    A --> D["has_reached_deadline(deadline_ms)"]
    C --> D
    D --> E{"current_ms >= deadline_ms?"}
    E -->|Yes| F["true"]
    E -->|No| G["false"]

    A --> H["remaining_until(deadline_ms)"]
    C --> H
    H --> I["saturating_sub(deadline_ms - current_ms)"]
    I --> J["Duration::from_millis(remaining)"]

    A --> K["peek_millis()"]
    K --> L["read-only time check"]
    L --> M["no auto-advance side effect"]

```
## Summary
fixes #1618 

Add deterministic timeout/deadline helper APIs to `MockClock` to reduce repeated time math and improve test clarity for timeout-driven flows.

## What Changed

- Added helper methods in `tests/src/clock.rs`:
  - `peek_millis()`
  - `deadline_after(timeout: Duration)`
  - `has_reached_deadline(deadline_ms: u64)`
  - `remaining_until(deadline_ms: u64)`
- Added focused tests in `tests/tests/clock_timeout_tests.rs` covering:
  - deadline computation from current time
  - reached/not reached transition behavior
  - zero-floor remaining duration
  - non-advancing `peek_millis()` with auto-advance enabled

## Why

These helpers make timeout-oriented tests more expressive and consistent while preserving deterministic behavior.

## Testing

```bash
cargo test -p mofa-testing --test clock_timeout_tests
