### PR TITLE
feat(testing): add persisted memory testing path

### DIFF
--- a/crates/mofa-foundation/src/llm/client.rs
+++ b/crates/mofa-foundation/src/llm/client.rs
@@ -1688,6 +1688,10 @@ mod tests {
     use crate::llm::types::{Choice, EmbeddingData, EmbeddingInput, EmbeddingUsage, Role};
     use async_trait::async_trait;
     use std::sync::Mutex;
+    #[cfg(feature = "persistence-sqlite")]
+    use tempfile::tempdir;
+    #[cfg(feature = "persistence-sqlite")]
+    use crate::persistence::{PersistenceError, SqliteStore};
 
     struct MockProvider {
         default_model_name: String,
@@ -1912,6 +1916,22 @@ mod tests {
         // History contains the prior 5 + new user msg + assistant reply = 7
         assert!(session.messages().len() >= 6, "no messages should be dropped when trigger=0");
     }
+
+    #[cfg(feature = "persistence-sqlite")]
+    #[tokio::test]
+    async fn sqlite_invalid_persistence_setup_fails_clearly() {
+        let dir = tempdir().expect("tempdir");
+        let invalid_url = format!("sqlite:{}", dir.path().to_string_lossy());
+
+        let result = SqliteStore::connect(&invalid_url).await;
+
+        match result {
+            Err(PersistenceError::Connection(_)) => {}
+            Err(other) => panic!("expected connection error, got {other:?}"),
+            Ok(_) => panic!("connecting to a directory path should fail"),
+        }
+    }
+
 }
 
 // ============================================================================

--- a/crates/mofa-foundation/tests/persisted_memory_integration.rs
+++ b/crates/mofa-foundation/tests/persisted_memory_integration.rs
@@ -5,8 +5,8 @@
 mod support;
 
 use support::persisted_memory::{
-    PersistedMemoryFixture, assert_no_cross_session_leakage, assert_persisted_session_exists,
-    assert_reloaded_history_contains, assert_reloaded_history_len,
+    PersistedMemoryFixture, assert_missing_persisted_session, assert_no_cross_session_leakage,
+    assert_persisted_session_exists, assert_reloaded_history_contains, assert_reloaded_history_len,
 };
 
 #[tokio::test]
@@ -47,4 +47,44 @@ async fn persisted_memory_reload_keeps_expected_history_and_excludes_other_sessi
     assert_reloaded_history_contains(&reloaded_alpha, 0, "alpha: persisted question");
     assert_reloaded_history_contains(&reloaded_alpha, 1, "alpha: persisted answer");
     assert_no_cross_session_leakage(&reloaded_alpha, "beta:");
+}
+
+#[tokio::test]
+async fn persisted_memory_reload_missing_session_returns_not_found() {
+    let fixture = PersistedMemoryFixture::new("persisted-memory-missing-session.db");
+    let missing_session_id = fixture.new_session_id();
+
+    let result = fixture
+        .reload_session_result(fixture.open_store().await, missing_session_id)
+        .await;
+
+    assert_missing_persisted_session(result);
+}
+
+#[tokio::test]
+async fn persisted_memory_reopen_boundary_preserves_history() {
+    let fixture = PersistedMemoryFixture::new("persisted-memory-reopen-boundary.db");
+    let session_id = fixture.new_session_id();
+
+    let writer_store = fixture.open_store().await;
+    fixture
+        .write_session(
+            writer_store,
+            session_id,
+            &[
+                ("user", "boundary: first user message"),
+                ("assistant", "boundary: first assistant reply"),
+            ],
+        )
+        .await;
+
+    // Reopen through a fresh store handle to model a restart boundary.
+    let reloaded = fixture
+        .reload_session(fixture.open_store().await, session_id)
+        .await;
+
+    assert_persisted_session_exists(&reloaded);
+    assert_reloaded_history_len(&reloaded, 2);
+    assert_reloaded_history_contains(&reloaded, 0, "boundary: first user message");
+    assert_reloaded_history_contains(&reloaded, 1, "boundary: first assistant reply");
 }

--- a/crates/mofa-foundation/tests/persisted_memory_integration.rs
+++ b/crates/mofa-foundation/tests/persisted_memory_integration.rs
@@ -6,8 +6,9 @@ mod support;
 
 use support::persisted_memory::{
     PersistedMemoryFixture, assert_artifact_history_contains, assert_artifact_history_len,
-    assert_artifact_no_cross_session_leakage, assert_missing_persisted_session,
-    assert_persisted_session_exists, build_persisted_memory_artifact,
+    assert_artifact_json_output_has_core_fields, assert_artifact_no_cross_session_leakage,
+    assert_missing_persisted_session, assert_persisted_session_exists,
+    build_persisted_memory_artifact, render_artifact_json,
 };
 
 #[tokio::test]
@@ -45,11 +46,13 @@ async fn persisted_memory_reload_keeps_expected_history_and_excludes_other_sessi
 
     assert_persisted_session_exists(&reloaded_alpha);
     let artifact = build_persisted_memory_artifact(alpha_session_id, &reloaded_alpha);
-    assert_eq!(artifact.session_id, alpha_session_id);
+    assert_eq!(artifact.session_id, alpha_session_id.to_string());
     assert_artifact_history_len(&artifact, 2);
     assert_artifact_history_contains(&artifact, 0, "alpha: persisted question");
     assert_artifact_history_contains(&artifact, 1, "alpha: persisted answer");
     assert_artifact_no_cross_session_leakage(&artifact, "beta:");
+    let artifact_json = render_artifact_json(&artifact);
+    assert_artifact_json_output_has_core_fields(&artifact_json);
 }
 
 #[tokio::test]
@@ -88,8 +91,10 @@ async fn persisted_memory_reopen_boundary_preserves_history() {
 
     assert_persisted_session_exists(&reloaded);
     let artifact = build_persisted_memory_artifact(session_id, &reloaded);
-    assert_eq!(artifact.session_id, session_id);
+    assert_eq!(artifact.session_id, session_id.to_string());
     assert_artifact_history_len(&artifact, 2);
     assert_artifact_history_contains(&artifact, 0, "boundary: first user message");
     assert_artifact_history_contains(&artifact, 1, "boundary: first assistant reply");
+    let artifact_json = render_artifact_json(&artifact);
+    assert_artifact_json_output_has_core_fields(&artifact_json);
 }

--- a/crates/mofa-foundation/tests/persisted_memory_integration.rs
+++ b/crates/mofa-foundation/tests/persisted_memory_integration.rs
@@ -5,8 +5,9 @@
 mod support;
 
 use support::persisted_memory::{
-    PersistedMemoryFixture, assert_missing_persisted_session, assert_no_cross_session_leakage,
-    assert_persisted_session_exists, assert_reloaded_history_contains, assert_reloaded_history_len,
+    PersistedMemoryFixture, assert_artifact_history_contains, assert_artifact_history_len,
+    assert_artifact_no_cross_session_leakage, assert_missing_persisted_session,
+    assert_persisted_session_exists, build_persisted_memory_artifact,
 };
 
 #[tokio::test]
@@ -43,10 +44,12 @@ async fn persisted_memory_reload_keeps_expected_history_and_excludes_other_sessi
         .await;
 
     assert_persisted_session_exists(&reloaded_alpha);
-    assert_reloaded_history_len(&reloaded_alpha, 2);
-    assert_reloaded_history_contains(&reloaded_alpha, 0, "alpha: persisted question");
-    assert_reloaded_history_contains(&reloaded_alpha, 1, "alpha: persisted answer");
-    assert_no_cross_session_leakage(&reloaded_alpha, "beta:");
+    let artifact = build_persisted_memory_artifact(alpha_session_id, &reloaded_alpha);
+    assert_eq!(artifact.session_id, alpha_session_id);
+    assert_artifact_history_len(&artifact, 2);
+    assert_artifact_history_contains(&artifact, 0, "alpha: persisted question");
+    assert_artifact_history_contains(&artifact, 1, "alpha: persisted answer");
+    assert_artifact_no_cross_session_leakage(&artifact, "beta:");
 }
 
 #[tokio::test]
@@ -84,7 +87,9 @@ async fn persisted_memory_reopen_boundary_preserves_history() {
         .await;
 
     assert_persisted_session_exists(&reloaded);
-    assert_reloaded_history_len(&reloaded, 2);
-    assert_reloaded_history_contains(&reloaded, 0, "boundary: first user message");
-    assert_reloaded_history_contains(&reloaded, 1, "boundary: first assistant reply");
+    let artifact = build_persisted_memory_artifact(session_id, &reloaded);
+    assert_eq!(artifact.session_id, session_id);
+    assert_artifact_history_len(&artifact, 2);
+    assert_artifact_history_contains(&artifact, 0, "boundary: first user message");
+    assert_artifact_history_contains(&artifact, 1, "boundary: first assistant reply");
 }

--- a/crates/mofa-foundation/tests/persisted_memory_integration.rs
+++ b/crates/mofa-foundation/tests/persisted_memory_integration.rs
@@ -1,0 +1,50 @@
+//! Higher-level integration test for the persisted-memory SQLite testing path.
+
+#![cfg(feature = "persistence-sqlite")]
+
+mod support;
+
+use support::persisted_memory::{
+    PersistedMemoryFixture, assert_no_cross_session_leakage, assert_persisted_session_exists,
+    assert_reloaded_history_contains, assert_reloaded_history_len,
+};
+
+#[tokio::test]
+async fn persisted_memory_reload_keeps_expected_history_and_excludes_other_session_content() {
+    // This is the first higher-level persisted-memory test path outside module-scoped unit tests.
+    let fixture = PersistedMemoryFixture::new("persisted-memory-integration.db");
+    let alpha_session_id = fixture.new_session_id();
+    let beta_session_id = fixture.new_session_id();
+    let writer_store = fixture.open_store().await;
+
+    fixture
+        .write_session(
+            writer_store.clone(),
+            alpha_session_id,
+            &[
+                ("user", "alpha: persisted question"),
+                ("assistant", "alpha: persisted answer"),
+            ],
+        )
+        .await;
+    fixture
+        .write_session(
+            writer_store,
+            beta_session_id,
+            &[
+                ("user", "beta: separate session question"),
+                ("assistant", "beta: separate session answer"),
+            ],
+        )
+        .await;
+
+    let reloaded_alpha = fixture
+        .reload_session(fixture.open_store().await, alpha_session_id)
+        .await;
+
+    assert_persisted_session_exists(&reloaded_alpha);
+    assert_reloaded_history_len(&reloaded_alpha, 2);
+    assert_reloaded_history_contains(&reloaded_alpha, 0, "alpha: persisted question");
+    assert_reloaded_history_contains(&reloaded_alpha, 1, "alpha: persisted answer");
+    assert_no_cross_session_leakage(&reloaded_alpha, "beta:");
+}

--- a/crates/mofa-foundation/tests/support/mod.rs
+++ b/crates/mofa-foundation/tests/support/mod.rs
@@ -1,0 +1,4 @@
+//! Shared integration-test support modules for `mofa-foundation`.
+
+#[cfg(feature = "persistence-sqlite")]
+pub mod persisted_memory;

--- a/crates/mofa-foundation/tests/support/persisted_memory.rs
+++ b/crates/mofa-foundation/tests/support/persisted_memory.rs
@@ -1,0 +1,247 @@
+//! Shared persisted-memory test support for SQLite-backed integration paths.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use mofa_foundation::llm::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ChatSession, Choice,
+    EmbeddingData, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
+    LLMClient, LLMProvider, LLMResult, MessageContent, Role,
+};
+use mofa_foundation::persistence::{PersistenceError, PersistenceResult, SqliteStore};
+use tempfile::tempdir;
+
+pub struct PersistedMemoryFixture {
+    _dir: tempfile::TempDir,
+    database_url: String,
+    provider: Arc<FixtureMockProvider>,
+    user_id: uuid::Uuid,
+    tenant_id: uuid::Uuid,
+    agent_id: uuid::Uuid,
+}
+
+impl PersistedMemoryFixture {
+    pub fn new(name: &str) -> Self {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join(name);
+        std::fs::File::create(&path).expect("sqlite file should be created");
+
+        Self {
+            _dir: dir,
+            database_url: format!("sqlite:{}", path.to_string_lossy()),
+            provider: Arc::new(FixtureMockProvider::new("fixture-model", Some("ok"))),
+            user_id: uuid::Uuid::now_v7(),
+            tenant_id: uuid::Uuid::now_v7(),
+            agent_id: uuid::Uuid::now_v7(),
+        }
+    }
+
+    pub async fn open_store(&self) -> Arc<SqliteStore> {
+        // Open a fresh connection so tests can model restart/reload boundaries explicitly.
+        Arc::new(
+            SqliteStore::connect(&self.database_url)
+                .await
+                .expect("sqlite store should connect"),
+        )
+    }
+
+    pub fn new_session_id(&self) -> uuid::Uuid {
+        uuid::Uuid::now_v7()
+    }
+
+    pub async fn write_session(
+        &self,
+        store: Arc<SqliteStore>,
+        session_id: uuid::Uuid,
+        messages: &[(&str, &str)],
+    ) {
+        // Seed persisted session state through the real ChatSession + SQLite path.
+        let mut session = ChatSession::with_id_and_stores(
+            session_id,
+            LLMClient::new(self.provider.clone()),
+            self.user_id,
+            self.tenant_id,
+            self.agent_id,
+            store.clone(),
+            store,
+            None,
+        );
+
+        for (role, content) in messages {
+            match *role {
+                "user" => session.messages_mut().push(ChatMessage::user(*content)),
+                "assistant" => session.messages_mut().push(ChatMessage::assistant(*content)),
+                other => panic!("unsupported role in test fixture: {other}"),
+            }
+        }
+
+        session.save().await.expect("session should persist");
+    }
+
+    pub async fn reload_session(
+        &self,
+        store: Arc<SqliteStore>,
+        session_id: uuid::Uuid,
+    ) -> ChatSession {
+        // Reload persisted history as a fresh consumer would see it.
+        ChatSession::load(
+            session_id,
+            LLMClient::new(self.provider.clone()),
+            self.user_id,
+            self.tenant_id,
+            self.agent_id,
+            store.clone(),
+            store,
+            None,
+        )
+        .await
+        .expect("session should reload")
+    }
+
+    pub async fn reload_session_result(
+        &self,
+        store: Arc<SqliteStore>,
+        session_id: uuid::Uuid,
+    ) -> PersistenceResult<ChatSession> {
+        ChatSession::load(
+            session_id,
+            LLMClient::new(self.provider.clone()),
+            self.user_id,
+            self.tenant_id,
+            self.agent_id,
+            store.clone(),
+            store,
+            None,
+        )
+        .await
+    }
+}
+
+pub fn assert_persisted_session_exists(session: &ChatSession) {
+    // A persisted session should reload with some observable history.
+    assert!(
+        !session.messages().is_empty(),
+        "reloaded persisted session should contain message history"
+    );
+}
+
+pub fn assert_reloaded_history_len(session: &ChatSession, expected: usize) {
+    assert_eq!(session.messages().len(), expected);
+}
+
+pub fn assert_reloaded_history_contains(session: &ChatSession, index: usize, expected: &str) {
+    assert_eq!(message_text(&session.messages()[index]), Some(expected));
+}
+
+pub fn assert_no_cross_session_leakage(session: &ChatSession, forbidden_marker: &str) {
+    // This guards against session contamination within the same backing store.
+    assert!(
+        session
+            .messages()
+            .iter()
+            .all(|msg| message_text(msg).map(|text| !text.contains(forbidden_marker)).unwrap_or(true)),
+        "reloaded history should not contain content marked with {forbidden_marker}"
+    );
+}
+
+pub fn assert_missing_persisted_session(result: PersistenceResult<ChatSession>) {
+    // Missing persisted state should fail as NotFound, not as a silent empty history.
+    match result {
+        Err(PersistenceError::NotFound(_)) => {}
+        Err(other) => panic!("expected not found error, got {other:?}"),
+        Ok(_) => panic!("expected persisted session lookup to fail"),
+    }
+}
+
+fn message_text(message: &ChatMessage) -> Option<&str> {
+    match &message.content {
+        Some(MessageContent::Text(text)) => Some(text.as_str()),
+        _ => None,
+    }
+}
+
+pub struct FixtureMockProvider {
+    default_model_name: String,
+    last_request: Arc<Mutex<Option<ChatCompletionRequest>>>,
+    response_content: Option<String>,
+}
+
+impl FixtureMockProvider {
+    fn new(default_model_name: &str, response_content: Option<&str>) -> Self {
+        Self {
+            default_model_name: default_model_name.to_string(),
+            last_request: Arc::new(Mutex::new(None)),
+            response_content: response_content.map(|s| s.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for FixtureMockProvider {
+    fn name(&self) -> &str {
+        "fixture-mock"
+    }
+
+    fn default_model(&self) -> &str {
+        &self.default_model_name
+    }
+
+    async fn chat(&self, request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        *self.last_request.lock().expect("lock poisoned") = Some(request);
+
+        let message = ChatMessage {
+            role: Role::Assistant,
+            content: self
+                .response_content
+                .as_ref()
+                .map(|s| MessageContent::Text(s.clone())),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        };
+
+        Ok(ChatCompletionResponse {
+            id: "resp-1".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1,
+            model: self.default_model_name.clone(),
+            choices: vec![Choice {
+                index: 0,
+                message,
+                finish_reason: None,
+                logprobs: None,
+            }],
+            usage: None,
+            system_fingerprint: None,
+        })
+    }
+
+    async fn embedding(&self, request: EmbeddingRequest) -> LLMResult<EmbeddingResponse> {
+        let data = match request.input {
+            EmbeddingInput::Single(_) => vec![EmbeddingData {
+                object: "embedding".to_string(),
+                index: 0,
+                embedding: vec![0.1, 0.2],
+            }],
+            EmbeddingInput::Multiple(values) => values
+                .iter()
+                .enumerate()
+                .map(|(idx, _)| EmbeddingData {
+                    object: "embedding".to_string(),
+                    index: idx as u32,
+                    embedding: vec![idx as f32],
+                })
+                .collect(),
+        };
+
+        Ok(EmbeddingResponse {
+            object: "list".to_string(),
+            model: self.default_model_name.clone(),
+            data,
+            usage: EmbeddingUsage {
+                prompt_tokens: 1,
+                total_tokens: 1,
+            },
+        })
+    }
+}

--- a/crates/mofa-foundation/tests/support/persisted_memory.rs
+++ b/crates/mofa-foundation/tests/support/persisted_memory.rs
@@ -9,6 +9,7 @@ use mofa_foundation::llm::{
     LLMClient, LLMProvider, LLMResult, MessageContent, Role,
 };
 use mofa_foundation::persistence::{PersistenceError, PersistenceResult, SqliteStore};
+use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
 
 pub struct PersistedMemoryFixture {
@@ -20,9 +21,9 @@ pub struct PersistedMemoryFixture {
     agent_id: uuid::Uuid,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedMemoryArtifact {
-    pub session_id: uuid::Uuid,
+    pub session_id: String,
     pub history: Vec<String>,
 }
 
@@ -171,9 +172,25 @@ pub fn build_persisted_memory_artifact(
         .collect::<Vec<_>>();
 
     PersistedMemoryArtifact {
-        session_id,
+        session_id: session_id.to_string(),
         history,
     }
+}
+
+pub fn render_artifact_json(artifact: &PersistedMemoryArtifact) -> String {
+    serde_json::to_string_pretty(artifact).expect("artifact should serialize to json")
+}
+
+pub fn assert_artifact_json_output_has_core_fields(json: &str) {
+    let parsed: serde_json::Value = serde_json::from_str(json).expect("artifact json should parse");
+    assert!(
+        parsed.get("session_id").and_then(|v| v.as_str()).is_some(),
+        "artifact json should contain string session_id"
+    );
+    assert!(
+        parsed.get("history").and_then(|v| v.as_array()).is_some(),
+        "artifact json should contain history array"
+    );
 }
 
 pub fn assert_artifact_history_len(artifact: &PersistedMemoryArtifact, expected: usize) {

--- a/crates/mofa-foundation/tests/support/persisted_memory.rs
+++ b/crates/mofa-foundation/tests/support/persisted_memory.rs
@@ -20,6 +20,12 @@ pub struct PersistedMemoryFixture {
     agent_id: uuid::Uuid,
 }
 
+#[derive(Debug, Clone)]
+pub struct PersistedMemoryArtifact {
+    pub session_id: uuid::Uuid,
+    pub history: Vec<String>,
+}
+
 impl PersistedMemoryFixture {
     pub fn new(name: &str) -> Self {
         let dir = tempdir().expect("tempdir");
@@ -151,6 +157,48 @@ pub fn assert_missing_persisted_session(result: PersistenceResult<ChatSession>) 
         Err(other) => panic!("expected not found error, got {other:?}"),
         Ok(_) => panic!("expected persisted session lookup to fail"),
     }
+}
+
+pub fn build_persisted_memory_artifact(
+    session_id: uuid::Uuid,
+    session: &ChatSession,
+) -> PersistedMemoryArtifact {
+    let history = session
+        .messages()
+        .iter()
+        .filter_map(message_text)
+        .map(|s| s.to_string())
+        .collect::<Vec<_>>();
+
+    PersistedMemoryArtifact {
+        session_id,
+        history,
+    }
+}
+
+pub fn assert_artifact_history_len(artifact: &PersistedMemoryArtifact, expected: usize) {
+    assert_eq!(artifact.history.len(), expected);
+}
+
+pub fn assert_artifact_history_contains(
+    artifact: &PersistedMemoryArtifact,
+    index: usize,
+    expected: &str,
+) {
+    assert_eq!(artifact.history.get(index).map(String::as_str), Some(expected));
+}
+
+pub fn assert_artifact_no_cross_session_leakage(
+    artifact: &PersistedMemoryArtifact,
+    forbidden_marker: &str,
+) {
+    assert!(
+        artifact
+            .history
+            .iter()
+            .all(|text| !text.contains(forbidden_marker)),
+        "artifact history should not contain content marked with {forbidden_marker}"
+    );
 }
 
 fn message_text(message: &ChatMessage) -> Option<&str> {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "claw_demo",
     "swarm_orchestrator",
     "swarm_hitl_gate",
+    "persisted_memory_artifacts",
 ]
 
 [workspace.package]

--- a/examples/persisted_memory_artifacts/Cargo.toml
+++ b/examples/persisted_memory_artifacts/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "persisted_memory_artifacts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+uuid.workspace = true
+mofa-foundation = { path = "../../crates/mofa-foundation", features = ["persistence-sqlite"] }

--- a/examples/persisted_memory_artifacts/output_samples/persisted_memory_reload_artifact.example.json
+++ b/examples/persisted_memory_artifacts/output_samples/persisted_memory_reload_artifact.example.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "00000000-0000-7000-8000-000000000001",
+  "history": [
+    "session-alpha: I forgot my password and cannot log in.",
+    "session-alpha: I can help reset your password. Please confirm your email."
+  ]
+}

--- a/examples/persisted_memory_artifacts/output_samples/persisted_memory_reopen_artifact.example.json
+++ b/examples/persisted_memory_artifacts/output_samples/persisted_memory_reopen_artifact.example.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "00000000-0000-7000-8000-000000000002",
+  "history": [
+    "billing-session: I was charged twice for the same invoice.",
+    "billing-session: I checked invoice #INV-2049 and found a duplicate capture. I have initiated a refund and emailed confirmation."
+  ]
+}

--- a/examples/persisted_memory_artifacts/src/main.rs
+++ b/examples/persisted_memory_artifacts/src/main.rs
@@ -1,0 +1,209 @@
+//! Persisted-memory artifact example.
+//!
+//! Runs two sessions against a real SQLite store, reloads one session from a
+//! fresh store handle, and prints a JSON artifact similar to testing outputs.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use mofa_foundation::llm::{
+    ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ChatSession, Choice,
+    EmbeddingData, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
+    LLMClient, LLMProvider, LLMResult, MessageContent, Role,
+};
+use mofa_foundation::persistence::SqliteStore;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct PersistedMemoryArtifact {
+    session_id: String,
+    history: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Use a temp SQLite DB so the example stays local and isolated.
+    let tmp = tempfile::tempdir()?;
+    let db_path = tmp.path().join("persisted-memory-example.db");
+    std::fs::File::create(&db_path)?;
+    let database_url = format!("sqlite:{}", db_path.to_string_lossy());
+
+    let provider = Arc::new(ExampleMockProvider::new("fixture-model"));
+    let user_id = uuid::Uuid::now_v7();
+    let tenant_id = uuid::Uuid::now_v7();
+    let agent_id = uuid::Uuid::now_v7();
+
+    let alpha_session_id = uuid::Uuid::now_v7();
+    let beta_session_id = uuid::Uuid::now_v7();
+
+    let writer_store = Arc::new(SqliteStore::connect(&database_url).await?);
+
+    // Seed the primary session we will reload and print.
+    run_and_persist_single_turn(
+        provider.clone(),
+        writer_store.clone(),
+        user_id,
+        tenant_id,
+        agent_id,
+        alpha_session_id,
+        "session-alpha: I forgot my password and cannot log in.",
+    )
+    .await?;
+
+    // Seed a second session to show cross-session data can coexist safely.
+    run_and_persist_single_turn(
+        provider.clone(),
+        writer_store,
+        user_id,
+        tenant_id,
+        agent_id,
+        beta_session_id,
+        "session-beta: What is the refund policy for annual plans?",
+    )
+    .await?;
+
+    // Fresh connection simulates process/session restart before reload.
+    let reloaded_store = Arc::new(SqliteStore::connect(&database_url).await?);
+    let reloaded_alpha = ChatSession::load(
+        alpha_session_id,
+        LLMClient::new(provider),
+        user_id,
+        tenant_id,
+        agent_id,
+        reloaded_store.clone(),
+        reloaded_store,
+        None,
+    )
+    .await?;
+
+    let artifact = PersistedMemoryArtifact {
+        session_id: alpha_session_id.to_string(),
+        history: reloaded_alpha
+            .messages()
+            .iter()
+            .filter_map(|message| match &message.content {
+                Some(MessageContent::Text(text)) => Some(text.clone()),
+                _ => None,
+            })
+            .collect(),
+    };
+
+    // Print the artifact in the same shape used by persisted-memory tests.
+    println!("{}", serde_json::to_string_pretty(&artifact)?);
+    Ok(())
+}
+
+async fn run_and_persist_single_turn(
+    provider: Arc<ExampleMockProvider>,
+    store: Arc<SqliteStore>,
+    user_id: uuid::Uuid,
+    tenant_id: uuid::Uuid,
+    agent_id: uuid::Uuid,
+    session_id: uuid::Uuid,
+    prompt: &str,
+) -> Result<()> {
+    // Drive the real send() + save() path instead of manual message injection.
+    let mut session = ChatSession::with_id_and_stores(
+        session_id,
+        LLMClient::new(provider),
+        user_id,
+        tenant_id,
+        agent_id,
+        store.clone(),
+        store,
+        None,
+    );
+
+    let _ = session.send(prompt).await?;
+    session.save().await?;
+    Ok(())
+}
+
+struct ExampleMockProvider {
+    default_model_name: String,
+}
+
+impl ExampleMockProvider {
+    fn new(default_model_name: &str) -> Self {
+        Self {
+            default_model_name: default_model_name.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for ExampleMockProvider {
+    fn name(&self) -> &str {
+        "persisted-memory-example-mock"
+    }
+
+    fn default_model(&self) -> &str {
+        &self.default_model_name
+    }
+
+    async fn chat(&self, request: ChatCompletionRequest) -> LLMResult<ChatCompletionResponse> {
+        // Keep output deterministic by deriving it from the latest user prompt.
+        let response_content = request
+            .messages
+            .iter()
+            .rev()
+            .find_map(|msg| match (&msg.role, &msg.content) {
+                (Role::User, Some(MessageContent::Text(text))) => {
+                    Some(format!("I can help with this issue: {text}"))
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| "I can help with this issue.".to_string());
+
+        Ok(ChatCompletionResponse {
+            id: "resp-1".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1,
+            model: self.default_model_name.clone(),
+            choices: vec![Choice {
+                index: 0,
+                message: ChatMessage {
+                    role: Role::Assistant,
+                    content: Some(MessageContent::Text(response_content)),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: None,
+                logprobs: None,
+            }],
+            usage: None,
+            system_fingerprint: None,
+        })
+    }
+
+    async fn embedding(&self, request: EmbeddingRequest) -> LLMResult<EmbeddingResponse> {
+        let data = match request.input {
+            EmbeddingInput::Single(_) => vec![EmbeddingData {
+                object: "embedding".to_string(),
+                index: 0,
+                embedding: vec![0.1, 0.2],
+            }],
+            EmbeddingInput::Multiple(values) => values
+                .iter()
+                .enumerate()
+                .map(|(idx, _)| EmbeddingData {
+                    object: "embedding".to_string(),
+                    index: idx as u32,
+                    embedding: vec![idx as f32],
+                })
+                .collect(),
+        };
+
+        Ok(EmbeddingResponse {
+            object: "list".to_string(),
+            model: self.default_model_name.clone(),
+            data,
+            usage: EmbeddingUsage {
+                prompt_tokens: 1,
+                total_tokens: 1,
+            },
+        })
+    }
+}


### PR DESCRIPTION
## Summary

Adds a persisted memory testing path on top of real SQLite persistence and introduces artifact-backed assertions for persisted-memory behavior.
Also adds a runnable standalone example crate that demonstrates realistic persisted-memory artifact output.

This PR is intentionally scoped to establish a reusable, contributor facing testing surface for persisted state.

## Context

Persistence infrastructure already exists in MoFA. The missing piece was a clear testing path that:

- seeds persisted state
- reloads from a fresh store/session boundary
- asserts expected recalled history
- verifies non-leakage across sessions
- supports artifact-oriented assertions rather than only direct object checks

This PR provides that path.

## What Was Added

### 1) Integration Test Support Surface

Added shared support module for persisted-memory integration tests:

- `crates/mofa-foundation/tests/support/mod.rs`
- `crates/mofa-foundation/tests/support/persisted_memory.rs`

This support layer includes:

- `PersistedMemoryFixture`
  - isolated temp SQLite DB per test
  - helper to open/reopen store handles
  - session writer helper
  - reload helpers (`reload_session`, `reload_session_result`)
- reusable assertion helpers
  - persisted session exists
  - history length
  - expected content by index
  - no cross-session leakage marker
  - missing persisted session returns `NotFound`

### 2) Higher-Level Integration Tests

Added integration test target:

- `crates/mofa-foundation/tests/persisted_memory_integration.rs`

Current coverage:

- persisted reload keeps expected history and excludes unrelated session content
- missing session reload returns `NotFound`
- reopen-boundary persistence (write with one handle, reload with a fresh handle)

### 3) Artifact-Backed Persisted-Memory Assertions

Added first artifact layer in support module:

- `PersistedMemoryArtifact { session_id, history }`
- artifact builder:
  - `build_persisted_memory_artifact(...)`
- artifact output renderer:
  - `render_artifact_json(...)`
- artifact assertion helpers:
  - `assert_artifact_history_len(...)`
  - `assert_artifact_history_contains(...)`
  - `assert_artifact_no_cross_session_leakage(...)`
  - `assert_artifact_json_output_has_core_fields(...)`

Integration tests now assert behavior through this artifact layer and validate the JSON output shape.

### 4) Unit-Layer Scope Cleanup

Kept `llm/client.rs` unit-layer coverage minimal and low-level:

- retained only invalid SQLite setup failure check
- moved persisted-memory behavior checks to integration path

File touched:

- `crates/mofa-foundation/src/llm/client.rs`

### 5) Standalone Example

Added a full example crate:

- `examples/persisted_memory_artifacts/Cargo.toml`
- `examples/persisted_memory_artifacts/src/main.rs`
- `examples/persisted_memory_artifacts/output_samples/persisted_memory_reload_artifact.example.json`
- `examples/persisted_memory_artifacts/output_samples/persisted_memory_reopen_artifact.example.json`

and registered it in:

- `examples/Cargo.toml`

Run:

```bash
cd examples
cargo run -p persisted_memory_artifacts
```

The example uses real SQLite persistence and prints artifact JSON for a reloaded session.

## Why This Matters

This PR shifts persisted-memory verification from ad hoc module checks to a reusable testing path that is:

- real-backend (SQLite) and CI-friendly
- deterministic and isolated
- reusable for future memory tests
- aligned with Idea 6-style testing progression
- ready for next-step baseline/candidate comparison

## Execution Flow
<img width="2127" height="3560" alt="image" src="https://github.com/user-attachments/assets/94921027-3030-4a83-83ba-b9a6b5079eaf" />

Flow intent:

- fixture isolates backend state per test
- writes happen through real persistence path
- reload happens from a fresh store handle to model restart boundaries
- checks are done through artifact-backed assertions for persisted-memory behavior
- output is a machine-readable persisted-memory artifact JSON with validated core fields

## Verification

Ran:

```bash
cargo test -p mofa-foundation --features persistence-sqlite --test persisted_memory_integration
```

Result:

- 3 integration tests passed
- artifact JSON output path validated in integration tests

Example run:

```bash
cd examples
cargo run -p persisted_memory_artifacts
```

Observed output shape:
<img width="676" height="116" alt="image" src="https://github.com/user-attachments/assets/b9c41475-aa68-4e91-b0ce-d3ef04a15766" />

Also validated low-level guard:

```bash
cargo test -p mofa-foundation --features persistence-sqlite sqlite_invalid_persistence_setup_fails_clearly
```

Result:

- unit test passed


## Runtime Notes

- real: SQLite persistence path (`SqliteStore`), real SQL writes/reads, real save/reload flow
- mocked: LLM provider only (test fixture provider), to avoid external model dependencies