### PR TITLE
feat(testing): add JUnit formatter for test reports

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -15,7 +15,7 @@ pub use backend::MockLLMBackend;
 pub use bus::MockAgentBus;
 pub use clock::{Clock, MockClock, SystemClock};
 pub use report::{
-    JsonFormatter, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder, TestStatus,
-    TextFormatter,
+    JUnitFormatter, JsonFormatter, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
 pub use tools::MockTool;

--- a/tests/src/report/format.rs
+++ b/tests/src/report/format.rs
@@ -1,6 +1,25 @@
 //! Formatters that render a [`TestReport`] to a string.
 
-use crate::report::types::{TestReport, TestStatus};
+use crate::report::types::{TestCaseResult, TestReport, TestStatus};
+
+fn xml_escape(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn duration_secs(duration: std::time::Duration) -> String {
+    format!("{:.3}", duration.as_secs_f64())
+}
 
 /// Converts a [`TestReport`] into a displayable string.
 pub trait ReportFormatter: Send + Sync {
@@ -100,5 +119,61 @@ impl ReportFormatter for TextFormatter {
         ));
 
         buf
+    }
+}
+
+/// Renders a report as JUnit XML.
+pub struct JUnitFormatter;
+
+impl JUnitFormatter {
+    fn format_case(&self, report: &TestReport, case: &TestCaseResult) -> String {
+        let mut xml = String::new();
+        xml.push_str(&format!(
+            "  <testcase classname=\"{}\" name=\"{}\" time=\"{}\">\n",
+            xml_escape(&report.suite_name),
+            xml_escape(&case.name),
+            duration_secs(case.duration),
+        ));
+
+        match case.status {
+            TestStatus::Passed => {}
+            TestStatus::Failed => {
+                let message = case.error.as_deref().unwrap_or("test failed");
+                xml.push_str(&format!(
+                    "    <failure message=\"{}\">{}</failure>\n",
+                    xml_escape(message),
+                    xml_escape(message),
+                ));
+            }
+            TestStatus::Skipped => {
+                xml.push_str("    <skipped />\n");
+            }
+        }
+
+        xml.push_str("  </testcase>\n");
+        xml
+    }
+}
+
+impl ReportFormatter for JUnitFormatter {
+    fn format(&self, report: &TestReport) -> String {
+        let mut xml = String::new();
+        xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.push_str(&format!(
+            "<testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" skipped=\"{}\" time=\"{}\" timestamp=\"{}\">\n",
+            xml_escape(&report.suite_name),
+            report.total(),
+            report.failed(),
+            report.skipped(),
+            duration_secs(report.total_duration),
+            report.timestamp,
+        ));
+
+        for case in &report.results {
+            xml.push_str(&self.format_case(report, case));
+        }
+
+        xml.push_str("</testsuite>\n");
+        xml
     }
 }

--- a/tests/src/report/mod.rs
+++ b/tests/src/report/mod.rs
@@ -5,5 +5,5 @@ mod format;
 mod types;
 
 pub use builder::TestReportBuilder;
-pub use format::{JsonFormatter, ReportFormatter, TextFormatter};
+pub use format::{JUnitFormatter, JsonFormatter, ReportFormatter, TextFormatter};
 pub use types::{TestCaseResult, TestReport, TestStatus};

--- a/tests/tests/report_tests.rs
+++ b/tests/tests/report_tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use mofa_testing::{
-    JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport, TestReportBuilder,
-    TestStatus, TextFormatter,
+    JUnitFormatter, JsonFormatter, MockClock, ReportFormatter, TestCaseResult, TestReport,
+    TestReportBuilder, TestStatus, TextFormatter,
 };
 
 // ---------------------------------------------------------------------------
@@ -256,6 +256,32 @@ fn json_formatter_empty_report() {
     let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
     assert_eq!(parsed["summary"]["total"], 0);
     assert_eq!(parsed["results"].as_array().unwrap().len(), 0);
+}
+
+// ===========================================================================
+// JUnitFormatter
+// ===========================================================================
+
+#[test]
+fn junit_formatter_emits_expected_xml() {
+    let report = TestReport {
+        suite_name: "suite & special".into(),
+        results: vec![
+            make_result("pass<one>", TestStatus::Passed, 10, None),
+            make_result("fail\"two\"", TestStatus::Failed, 20, Some("boom & bust")),
+            make_result("skip'three'", TestStatus::Skipped, 0, None),
+        ],
+        total_duration: Duration::from_millis(30),
+        timestamp: 123,
+    };
+
+    let output = JUnitFormatter.format(&report);
+
+    assert!(output.contains(r#"<testsuite name="suite &amp; special" tests="3" failures="1" skipped="1" time="0.030" timestamp="123">"#));
+    assert!(output.contains(r#"<testcase classname="suite &amp; special" name="pass&lt;one&gt;" time="0.010">"#));
+    assert!(output.contains(r#"<failure message="boom &amp; bust">boom &amp; bust</failure>"#));
+    assert!(output.contains(r#"<testcase classname="suite &amp; special" name="skip&apos;three&apos;" time="0.000">"#));
+    assert!(output.contains("<skipped />"));
 }
 
 #[test]


### PR DESCRIPTION
Adds a JUnit XML formatter for TestReport plus coverage for escaping, counters, and skipped/failing cases.

Issue: #1567
