### PR TITLE
fix(plugins): prevent panic when sorting NaN importance in MemoryPlugin

### DIFF
--- a/crates/mofa-plugins/src/lib.rs
+++ b/crates/mofa-plugins/src/lib.rs
@@ -944,7 +944,7 @@ impl MemoryPlugin {
             // 按重要性降序排序
             // Sort by importance descending
             self.memories
-                .sort_by(|a, b| b.importance.partial_cmp(&a.importance).unwrap());
+                .sort_by(|a, b| b.importance.total_cmp(&a.importance));
             // 截断保留最重要的记忆
             // Truncate to keep most important ones
             self.memories.truncate(self.max_memories);


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a panic in `MemoryPlugin::add_memory` caused by sorting with `partial_cmp(...).unwrap()` when `importance` is `NaN`.
The change updates the sorting logic in `crates/mofa-plugins/src/lib.rs` to use a total ordering, ensuring safe behavior for all `f32` values.

---

## 2. FIX

```rust
// Before
.sort_by(|a, b| b.importance.partial_cmp(&a.importance).unwrap());

// After
.sort_by(|a, b| b.importance.total_cmp(&a.importance));
```

---

## 3. VERIFICATION

Fill the plugin with entries until `max_memories` is exceeded, then add one entry with `f32::NAN` as the importance. Before this change, the sort triggers a panic due to `partial_cmp(...).unwrap()`, while after the fix it completes without crashing. Additionally, normal float values continue to be sorted correctly in descending importance.

