### PR TITLE
fix(fallback): handle poisoned mutex in ProviderCircuitBreaker without panic

### DIFF
--- a/crates/mofa-foundation/src/llm/fallback.rs
+++ b/crates/mofa-foundation/src/llm/fallback.rs
@@ -234,7 +234,7 @@ impl ProviderCircuitBreaker {
     /// Returns `true` if the circuit is currently open (provider should be
     /// skipped).
     fn is_open(&self) -> bool {
-        let state = self.state.lock().expect("circuit breaker mutex poisoned");
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
         state
             .open_until
             .map(|until| Instant::now() < until)
@@ -244,7 +244,7 @@ impl ProviderCircuitBreaker {
     /// Record a successful call — resets the failure counter and closes the
     /// circuit.
     fn record_success(&self) {
-        let mut state = self.state.lock().expect("circuit breaker mutex poisoned");
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
         state.consecutive_failures = 0;
         state.open_until = None;
     }
@@ -252,7 +252,7 @@ impl ProviderCircuitBreaker {
     /// Record a failure that triggered a fallback.  Opens the circuit once the
     /// threshold is reached.
     fn record_failure(&self) {
-        let mut state = self.state.lock().expect("circuit breaker mutex poisoned");
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
         state.consecutive_failures = state.consecutive_failures.saturating_add(1);
         if state.consecutive_failures >= self.threshold {
             state.open_until = Some(Instant::now() + self.cooldown);


### PR DESCRIPTION
### SUMMARY

This PR prevents panics in `ProviderCircuitBreaker` by safely handling poisoned mutexes instead of crashing. It updates the locking logic in `is_open`, `record_success`, and `record_failure` within `crates/mofa-foundation/src/llm/fallback.rs` to recover the last valid state.

### FIX

```rust
// Before 
let state = self.state.lock().expect("circuit breaker mutex poisoned");

// After (recovers safely)
let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
```

### VERIFICATION

Triggered a panic while holding the lock to simulate mutex poisoning and confirmed subsequent calls no longer crash. Verified all three methods continue functioning and state updates correctly. Existing flows using the circuit breaker remain unaffected.
