### PR TITLE
feat(gateway): add InvocationTarget routing to /v1/chat/completions

### DIFF
--- a/crates/mofa-gateway/src/handlers/invocation.rs
+++ b/crates/mofa-gateway/src/handlers/invocation.rs
@@ -1,0 +1,329 @@
+//! InvocationTarget routing for the Gateway chat-completions endpoint.
+//!
+//! [`InvocationRouter`] resolves an incoming OpenAI-compatible request to an
+//! [`InvocationTarget`] by consulting the [`AgentRegistry`] first, then
+//! falling back to the local [`InferenceOrchestrator`] when no registered
+//! agent matches the requested model name.
+//!
+//! # Dispatch flow
+//!
+//! ```text
+//! POST /v1/chat/completions { "model": "my-agent" }
+//!            │
+//!            ▼
+//!   InvocationRouter::resolve("my-agent")
+//!            │
+//!   ┌────────┴────────────────────────────┐
+//!   │  AgentRegistry contains "my-agent"? │
+//!   └────────┬────────────────────────────┘
+//!            │ yes                 │ no
+//!            ▼                     ▼
+//!   InvocationTarget::Agent   InvocationTarget::LocalInference
+//!            │                     │
+//!            ▼                     ▼
+//!   [registry metadata]    InferenceBridge::run_chat_completion
+//! ```
+
+use std::sync::Arc;
+
+use mofa_kernel::gateway::InvocationTarget;
+use mofa_runtime::agent::registry::AgentRegistry;
+
+use crate::{
+    error::GatewayError,
+    inference_bridge::{ChatCompletionRequest, ChatCompletionResponse, InferenceBridge},
+};
+
+/// Routes `/v1/chat/completions` requests through [`InvocationTarget`] dispatch.
+///
+/// Constructed once at server startup and shared via [`axum::Extension`].
+pub struct InvocationRouter {
+    registry: Arc<AgentRegistry>,
+    bridge: Arc<InferenceBridge>,
+}
+
+impl InvocationRouter {
+    /// Create a new router backed by the given registry and inference bridge.
+    pub fn new(registry: Arc<AgentRegistry>, bridge: Arc<InferenceBridge>) -> Self {
+        Self { registry, bridge }
+    }
+
+    /// Resolve the [`InvocationTarget`] for the given model name.
+    ///
+    /// Resolution order:
+    /// 1. If the `AgentRegistry` contains an agent whose `agent_id` exactly
+    ///    matches `model`, return [`InvocationTarget::Agent`].
+    /// 2. Otherwise return [`InvocationTarget::LocalInference`] so the
+    ///    request falls through to the `InferenceOrchestrator`.
+    ///
+    /// This two-step fallback ensures that raw model names continue to work
+    /// without an explicit registry entry, while named agents always win when
+    /// present.
+    pub async fn resolve(&self, model: &str) -> InvocationTarget {
+        if self.registry.contains(model).await {
+            tracing::debug!(
+                target = "mofa_gateway::invocation",
+                model = model,
+                "InvocationTarget resolved → Agent"
+            );
+            InvocationTarget::Agent {
+                agent_id: model.to_string(),
+            }
+        } else {
+            tracing::debug!(
+                target = "mofa_gateway::invocation",
+                model = model,
+                "InvocationTarget resolved → LocalInference (no registry entry)"
+            );
+            InvocationTarget::LocalInference {
+                model: model.to_string(),
+            }
+        }
+    }
+
+    /// Execute the dispatch described by `target` and return an
+    /// OpenAI-compatible response.
+    ///
+    /// # Current behaviour
+    ///
+    /// * `Agent`          — look up agent metadata in the registry and include
+    ///   the agent description in the response.  Full agent invocation
+    ///   (streaming, tool calls) is planned for a follow-up PR once the
+    ///   agent execution protocol is finalised.
+    /// * `LocalInference` — delegates to [`InferenceBridge::run_chat_completion`].
+    /// * `Proxy`          — returns an internal error; Proxy dispatch is
+    ///   handled by the dedicated proxy module (`crates/mofa-gateway/src/proxy/`).
+    pub async fn dispatch(
+        &self,
+        target: InvocationTarget,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, GatewayError> {
+        tracing::info!(
+            target = "mofa_gateway::invocation",
+            invocation_target = %target,
+            model = %request.model,
+            "dispatching chat completion"
+        );
+
+        match target {
+            InvocationTarget::Agent { ref agent_id } => {
+                // Retrieve agent metadata from the registry.
+                let content = match self.registry.get_metadata(agent_id).await {
+                    Some(meta) => meta
+                        .description
+                        .unwrap_or_else(|| {
+                            format!(
+                                "Agent '{}' (name: '{}') is registered and ready.",
+                                agent_id, meta.name
+                            )
+                        }),
+                    None => {
+                        // Race condition: agent was present at resolve() time but
+                        // deregistered before dispatch.  Fall through to bridge.
+                        tracing::warn!(
+                            target = "mofa_gateway::invocation",
+                            agent_id = agent_id,
+                            "Agent disappeared between resolve and dispatch — falling back to LocalInference"
+                        );
+                        return self.bridge.run_chat_completion(request).await;
+                    }
+                };
+
+                let prompt_tokens: u32 = request
+                    .messages
+                    .iter()
+                    .map(|m| (m.content.len() as f32 / 4.0) as u32)
+                    .sum();
+                let completion_tokens = (content.len() as f32 / 4.0) as u32;
+
+                Ok(ChatCompletionResponse {
+                    id: format!("chatcmpl-{}", uuid::Uuid::new_v4()),
+                    object_type: "chat.completion".to_string(),
+                    created: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                    model: request.model,
+                    choices: vec![crate::inference_bridge::Choice {
+                        index: 0,
+                        message: crate::inference_bridge::Message {
+                            role: "assistant".to_string(),
+                            content,
+                        },
+                        finish_reason: "stop".to_string(),
+                    }],
+                    usage: crate::inference_bridge::Usage {
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens: prompt_tokens + completion_tokens,
+                    },
+                })
+            }
+
+            InvocationTarget::LocalInference { .. } => {
+                // Existing path: delegate entirely to the InferenceBridge.
+                self.bridge.run_chat_completion(request).await
+            }
+
+            InvocationTarget::Proxy { ref url } => {
+                // Proxy dispatch is handled by `crates/mofa-gateway/src/proxy/`.
+                Err(GatewayError::Internal(format!(
+                    "Proxy dispatch to '{}' is not supported through InvocationRouter; \
+                     use the dedicated proxy module instead.",
+                    url
+                )))
+            }
+
+            // Forward-compatibility: handle any future variants added to the
+            // non_exhaustive InvocationTarget without a panic.
+            _ => Err(GatewayError::Internal(
+                "Unknown InvocationTarget variant — upgrade mofa-gateway to support it."
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mofa_foundation::inference::OrchestratorConfig;
+    use mofa_kernel::agent::{
+        capabilities::AgentCapabilities,
+        context::AgentContext,
+        core::MoFAAgent,
+        error::AgentResult,
+        types::{AgentInput, AgentOutput, AgentState},
+    };
+    use mofa_runtime::agent::registry::AgentRegistry;
+    use async_trait::async_trait;
+    use tokio::sync::RwLock;
+
+    // ── Minimal in-process test agent ────────────────────────────────────────
+
+    struct StubAgent {
+        id: String,
+        name: String,
+        state: AgentState,
+        capabilities: AgentCapabilities,
+    }
+
+    impl StubAgent {
+        fn new(id: &str, name: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                name: name.to_string(),
+                state: AgentState::Created,
+                capabilities: AgentCapabilities::default(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl MoFAAgent for StubAgent {
+        fn id(&self) -> &str { &self.id }
+        fn name(&self) -> &str { &self.name }
+        fn capabilities(&self) -> &AgentCapabilities { &self.capabilities }
+        fn state(&self) -> AgentState { self.state.clone() }
+        async fn initialize(&mut self, _ctx: &AgentContext) -> AgentResult<()> {
+            self.state = AgentState::Ready;
+            Ok(())
+        }
+        async fn execute(&mut self, _input: AgentInput, _ctx: &AgentContext) -> AgentResult<AgentOutput> {
+            Ok(AgentOutput::text("stub"))
+        }
+        async fn shutdown(&mut self) -> AgentResult<()> {
+            self.state = AgentState::Shutdown;
+            Ok(())
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn make_bridge() -> Arc<InferenceBridge> {
+        Arc::new(InferenceBridge::new(OrchestratorConfig::default()))
+    }
+
+    async fn make_router_with_agent(agent_id: &str) -> InvocationRouter {
+        let registry = Arc::new(AgentRegistry::new());
+        let agent = Arc::new(RwLock::new(StubAgent::new(agent_id, agent_id)));
+        registry.register(agent).await.expect("registration should succeed");
+        InvocationRouter::new(registry, make_bridge())
+    }
+
+    fn make_router_empty() -> InvocationRouter {
+        InvocationRouter::new(Arc::new(AgentRegistry::new()), make_bridge())
+    }
+
+    fn make_request(model: &str) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: model.to_string(),
+            messages: vec![crate::inference_bridge::Message {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            }],
+            max_tokens: Some(64),
+            temperature: Some(0.7),
+            stream: Some(false),
+        }
+    }
+
+    // ── resolve() ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_known_agent_returns_agent_target() {
+        let router = make_router_with_agent("summariser").await;
+        let target = router.resolve("summariser").await;
+        assert_eq!(
+            target,
+            InvocationTarget::Agent { agent_id: "summariser".to_string() }
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_unknown_model_returns_local_inference() {
+        let router = make_router_empty();
+        let target = router.resolve("gpt-4o").await;
+        assert_eq!(
+            target,
+            InvocationTarget::LocalInference { model: "gpt-4o".to_string() }
+        );
+    }
+
+    // ── dispatch() ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dispatch_local_inference_returns_valid_response() {
+        let router = make_router_empty();
+        let target = InvocationTarget::LocalInference { model: "test-model".to_string() };
+        let resp = router.dispatch(target, make_request("test-model")).await.unwrap();
+        assert!(resp.id.starts_with("chatcmpl-"));
+        assert_eq!(resp.object_type, "chat.completion");
+        assert_eq!(resp.choices.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_agent_returns_valid_response() {
+        let router = make_router_with_agent("mofa-kernel").await;
+        let target = InvocationTarget::Agent { agent_id: "mofa-kernel".to_string() };
+        let resp = router.dispatch(target, make_request("mofa-kernel")).await.unwrap();
+        assert!(resp.id.starts_with("chatcmpl-"));
+        assert_eq!(resp.choices[0].message.role, "assistant");
+        // The content should mention the agent name
+        assert!(resp.choices[0].message.content.contains("mofa-kernel"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_proxy_returns_error() {
+        let router = make_router_empty();
+        let target = InvocationTarget::Proxy { url: "https://api.openai.com".to_string() };
+        let err = router.dispatch(target, make_request("gpt-4")).await;
+        assert!(err.is_err());
+        let msg = format!("{}", err.unwrap_err());
+        assert!(msg.contains("proxy") || msg.contains("dedicated"));
+    }
+}

--- a/crates/mofa-gateway/src/handlers/mod.rs
+++ b/crates/mofa-gateway/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod agents;
 pub mod chat;
 pub mod files;
 pub mod health;
+pub mod invocation;
 pub mod local_llm;
 pub mod openai;
 
@@ -11,5 +12,6 @@ pub use agents::agents_router;
 pub use chat::chat_router;
 pub use files::files_router;
 pub use health::health_router;
+pub use invocation::InvocationRouter;
 pub use local_llm::*;
 pub use openai::openai_router;

--- a/crates/mofa-gateway/src/handlers/openai.rs
+++ b/crates/mofa-gateway/src/handlers/openai.rs
@@ -1,29 +1,41 @@
 //! OpenAI-compatible API endpoints
 //!
 //! This module provides OpenAI-compatible chat completion endpoints
-//! that bridge to the InferenceOrchestrator.
+//! that route requests through [`InvocationTarget`] dispatch:
+//!
+//! 1. **Resolve** — check the [`AgentRegistry`] for a matching agent.
+//! 2. **Dispatch** — route to the registered agent OR fall back to the
+//!    [`InferenceOrchestrator`] when no agent is found.
+//!
+//! This replaces the previous mock response ("Hello from MoFA gateway!")
+//! with real routing logic aligned with the Gateway V2 design.
 
 use axum::{
-    extract::State,
-    http::{HeaderMap, StatusCode},
+    extract::Extension,
+    http::HeaderMap,
     response::IntoResponse,
     routing::post,
-    Json, Router, Extension,
+    Json, Router,
 };
 use std::sync::Arc;
 
 use crate::error::GatewayError;
-use crate::inference_bridge::{
-    ChatCompletionRequest, ChatCompletionResponse, InferenceBridge,
-};
+use crate::handlers::InvocationRouter;
+use crate::inference_bridge::ChatCompletionRequest;
 
-/// Create the OpenAI-compatible router
+/// Create the OpenAI-compatible router.
+///
+/// The router does not use axum `State` — all dependencies are injected
+/// via [`axum::Extension`] so the router can be merged into any parent
+/// without requiring a concrete state type.
 pub fn openai_router() -> Router {
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
 }
 
-/// Extract client key from request headers for rate-limiting
+/// Extract an opaque client key from request headers for logging/rate-limiting.
+///
+/// Uses `X-Forwarded-For` when available, otherwise falls back to `"unknown"`.
 fn client_key(headers: &HeaderMap) -> String {
     headers
         .get("x-forwarded-for")
@@ -32,25 +44,41 @@ fn client_key(headers: &HeaderMap) -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-/// POST /v1/chat/completions
+/// `POST /v1/chat/completions`
 ///
-/// OpenAI-compatible chat completion endpoint.
-/// Routes to InferenceOrchestrator for actual inference.
+/// OpenAI-compatible chat completion endpoint with [`InvocationTarget`] routing.
+///
+/// # Routing
+///
+/// 1. The `model` field in the request body is used as the agent lookup key.
+/// 2. If the [`AgentRegistry`] contains an entry for that key, the request is
+///    dispatched as [`InvocationTarget::Agent`] — the agent's metadata is
+///    returned until full agent invocation is implemented in a follow-up PR.
+/// 3. If no agent matches, the request falls through to the
+///    [`InferenceOrchestrator`] as [`InvocationTarget::LocalInference`].
 pub async fn chat_completions(
-    Extension(bridge): Extension<Arc<InferenceBridge>>,
+    Extension(router): Extension<Arc<InvocationRouter>>,
     headers: HeaderMap,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Result<impl IntoResponse, GatewayError> {
-    // Rate-limit check - simplified for now
     let client = client_key(&headers);
-    
-    // Demo logging
-    println!("Routing request via InferenceOrchestrator");
-    println!("  Model: {}", req.model);
+    tracing::info!(
+        target = "mofa_gateway::openai",
+        client = %client,
+        model = %req.model,
+        "POST /v1/chat/completions"
+    );
 
-    // Run chat completion via bridge
-    let response = bridge.run_chat_completion(req).await?;
+    // Step 1: resolve InvocationTarget from model name + registry
+    let target = router.resolve(&req.model).await;
+    tracing::debug!(
+        target = "mofa_gateway::openai",
+        invocation_target = %target,
+        "InvocationTarget resolved"
+    );
 
+    // Step 2: dispatch and return
+    let response = router.dispatch(target, req).await?;
     Ok(Json(response))
 }
 
@@ -58,31 +86,36 @@ pub async fn chat_completions(
 mod tests {
     use super::*;
     use mofa_foundation::inference::OrchestratorConfig;
+    use mofa_runtime::agent::registry::AgentRegistry;
+    use crate::inference_bridge::{InferenceBridge, Message};
 
-    #[tokio::test]
-    async fn test_chat_completions_endpoint() {
-        // Create bridge with default config
-        let config = OrchestratorConfig::default();
-        let bridge = InferenceBridge::new(config);
+    fn make_router_ext() -> Extension<Arc<InvocationRouter>> {
+        let registry = Arc::new(AgentRegistry::new());
+        let bridge = Arc::new(InferenceBridge::new(OrchestratorConfig::default()));
+        let router = Arc::new(InvocationRouter::new(registry, bridge));
+        Extension(router)
+    }
 
-        // Create a request
-        let request = ChatCompletionRequest {
-            model: "gpt-4".to_string(),
-            messages: vec![crate::inference_bridge::Message {
-                role: "user".to_string(),
-                content: "Hello".to_string(),
-            }],
-            max_tokens: Some(100),
+    fn make_request(model: &str) -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: model.to_string(),
+            messages: vec![Message { role: "user".to_string(), content: "Hello".to_string() }],
+            max_tokens: Some(64),
             temperature: Some(0.7),
             stream: Some(false),
-        };
+        }
+    }
 
-        // Run completion
-        let response = bridge.run_chat_completion(request).await.unwrap();
-
-        // Verify response format
-        assert!(response.id.starts_with("chatcmpl-"));
-        assert_eq!(response.object_type, "chat.completion");
-        assert_eq!(response.choices.len(), 1);
+    #[tokio::test]
+    async fn test_chat_completions_unknown_model_falls_back_to_inference() {
+        let router_ext = make_router_ext();
+        // No agent registered — should fall through to LocalInference
+        let result = chat_completions(
+            router_ext,
+            HeaderMap::new(),
+            Json(make_request("gpt-4")),
+        )
+        .await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/mofa-gateway/src/server.rs
+++ b/crates/mofa-gateway/src/server.rs
@@ -9,7 +9,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
-use crate::handlers::{agents_router, chat_router, health_router, openai_router};
+use crate::handlers::{agents_router, chat_router, health_router, openai_router, InvocationRouter};
 use crate::inference_bridge::InferenceBridge;
 use crate::middleware::RateLimiter;
 use crate::state::AppState;
@@ -225,13 +225,21 @@ impl GatewayServer {
                 .with_state(state);
             router = router.layer(sio_layer);
 
-            // Add OpenAI router if inference bridge is configured
-            if let Some(ref orch_config) = self.orchestrator_config {
-                let bridge = Arc::new(InferenceBridge::new(orch_config.clone()));
-                router = router
-                    .merge(openai_router())
-                    .layer(axum::Extension(bridge));
-            }
+            // Always add OpenAI router with InvocationTarget routing.
+            // InvocationRouter checks the registry first; if no agent matches
+            // it falls back to InferenceBridge → InferenceOrchestrator.
+            let bridge_config = self
+                .orchestrator_config
+                .clone()
+                .unwrap_or_default();
+            let bridge = Arc::new(InferenceBridge::new(bridge_config));
+            let invocation_router = Arc::new(InvocationRouter::new(
+                self.registry.clone(),
+                bridge,
+            ));
+            router = router
+                .merge(openai_router())
+                .layer(axum::Extension(invocation_router));
 
             if self.config.enable_tracing {
                 router = router.layer(TraceLayer::new_for_http());
@@ -260,13 +268,21 @@ impl GatewayServer {
             .merge(files_router())
             .with_state(state);
 
-        // Add OpenAI router if inference bridge is configured
-        if let Some(ref orch_config) = self.orchestrator_config {
-            let bridge = Arc::new(InferenceBridge::new(orch_config.clone()));
-            router = router
-                .merge(openai_router())
-                .layer(axum::Extension(bridge));
-        }
+        // Always add OpenAI router with InvocationTarget routing.
+        // InvocationRouter checks the registry first; if no agent matches
+        // it falls back to InferenceBridge → InferenceOrchestrator.
+        let bridge_config = self
+            .orchestrator_config
+            .clone()
+            .unwrap_or_default();
+        let bridge = Arc::new(InferenceBridge::new(bridge_config));
+        let invocation_router = Arc::new(InvocationRouter::new(
+            self.registry.clone(),
+            bridge,
+        ));
+        router = router
+            .merge(openai_router())
+            .layer(axum::Extension(invocation_router));
 
         if self.config.enable_tracing {
             router = router.layer(TraceLayer::new_for_http());

--- a/crates/mofa-kernel/src/gateway/mod.rs
+++ b/crates/mofa-kernel/src/gateway/mod.rs
@@ -22,6 +22,7 @@
 //! | [`RateLimitDecision`] | Outcome of a rate-limit check |
 //! | [`KeyStrategy`] | Keying dimension (per-agent or per-client) |
 //! | [`RateLimiterConfig`] | Shared rate limiter configuration |
+//! | [`InvocationTarget`] | Where a request dispatches: Agent, LocalInference, or Proxy |
 
 pub mod auth;
 pub mod rate_limiter;
@@ -40,4 +41,5 @@ pub use rate_limiter::{GatewayRateLimiter, KeyStrategy, RateLimitDecision, RateL
 pub use error::RegistryError;
 pub use route::{GatewayRoute, HttpMethod, RouteRegistry, RoutingContext};
 pub use config_error::GatewayConfigError;
-pub use types::{GatewayContext, GatewayRequest, GatewayResponse, RouteMatch};
+pub use types::{GatewayContext, GatewayRequest, GatewayResponse, InvocationTarget, RouteMatch};
+

--- a/crates/mofa-kernel/src/gateway/types.rs
+++ b/crates/mofa-kernel/src/gateway/types.rs
@@ -10,6 +10,78 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// InvocationTarget
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Specifies WHERE a Gateway request should be dispatched.
+///
+/// The Gateway resolves an `InvocationTarget` before forwarding every request.
+/// This allows routing decisions to be made at a single point (the dispatcher)
+/// and makes the policy explicit and testable independently of HTTP handling.
+///
+/// # Variants
+///
+/// * `Agent`          — dispatch to a registered agent adapter (by `agent_id`).
+/// * `LocalInference` — pass through to the built-in `InferenceOrchestrator`.
+/// * `Proxy`          — forward to an external OpenAI-compatible HTTP endpoint.
+///
+/// The enum is `#[non_exhaustive]` so that future variants (e.g. a gRPC
+/// backend, a Wasm sandbox) can be added without breaking existing match arms.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum InvocationTarget {
+    /// Dispatch to a named agent registered in the `AgentRegistry`.
+    ///
+    /// The `agent_id` must correspond to a live entry in the registry;
+    /// a missing entry causes dispatch to fall back to `LocalInference`.
+    Agent {
+        /// Identifier of the target agent (e.g. `"summariser"`, `"mofa-kernel"`).
+        agent_id: String,
+    },
+    /// Dispatch to the local `InferenceOrchestrator`.
+    ///
+    /// Used when no registered agent matches the request, or when the caller
+    /// explicitly names a raw model (e.g. `"llama-3-8b"`).
+    LocalInference {
+        /// Model identifier forwarded to the orchestrator.
+        model: String,
+    },
+    /// Forward to an external OpenAI-compatible HTTP endpoint.
+    ///
+    /// The gateway acts as a transparent proxy; the request body is sent
+    /// verbatim to `url` and the response is relayed back to the caller.
+    Proxy {
+        /// Base URL of the external endpoint (e.g. `"https://api.openai.com"`).
+        url: String,
+    },
+}
+
+impl InvocationTarget {
+    /// Returns a short human-readable label suitable for log lines and metrics.
+    pub fn label(&self) -> &str {
+        match self {
+            InvocationTarget::Agent { .. }          => "agent",
+            InvocationTarget::LocalInference { .. } => "local_inference",
+            InvocationTarget::Proxy { .. }          => "proxy",
+        }
+    }
+}
+
+impl std::fmt::Display for InvocationTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvocationTarget::Agent { agent_id } =>
+                write!(f, "Agent({})", agent_id),
+            InvocationTarget::LocalInference { model } =>
+                write!(f, "LocalInference({})", model),
+            InvocationTarget::Proxy { url } =>
+                write!(f, "Proxy({})", url),
+        }
+    }
+}
+
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Request / Response
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
This PR replaces the hard-coded mock response (`"Hello from MoFA gateway!"`) in the `/v1/chat/completions` endpoint with a robust, kernel-level **InvocationTarget** routing layer. 

By introducing the `InvocationRouter`, the gateway now resolves requests through the `AgentRegistry` first, providing a seamless "Agentic OS" experience where registered agents can overshadow or complement local model inference.

---

##  Architecture
The request flow is now explicitly decoupled from the HTTP handler:

```text
POST /v1/chat/completions { "model": "..." }
          │
          ▼
   InvocationRouter::resolve() 
          │
    ┌─────┴────────────────────────┐
    │ Is model a registered Agent? │
    └─────┬──────────────────┬─────┘
          │ yes              │ no (fallback)
          ▼                  ▼
  InvocationTarget::Agent   InvocationTarget::LocalInference
          │                  │
          ▼                  ▼
  [Registry Metadata]      InferenceOrchestrator
