### PR TITLE
fix(foundation): collapse nested if guards in parse_gemini_sse (clippy::collapsible_if #1295)

### DIFF
--- a/crates/mofa-foundation/src/llm/google.rs
+++ b/crates/mofa-foundation/src/llm/google.rs
@@ -446,21 +446,23 @@ fn parse_gemini_sse(resp: reqwest::Response, model: String) -> ChatStream {
                         buf.push_str(&String::from_utf8_lossy(&bytes));
                     }
                     Ok(None) => {
-                        // End of stream. If there is leftover data, try to parse it.
-                        if !buf.trim().is_empty() {
-                            if let Some(json_str) = buf.trim().strip_prefix("data: ") {
-                                if json_str.trim() != "[DONE]" {
-                                    if let Ok(chunk) =
-                                        serde_json::from_str::<GeminiStreamChunk>(json_str)
-                                    {
-                                        let completion =
-                                            gemini_chunk_to_completion(&chunk, &model, is_first);
-                                        return Some((
-                                            Ok(completion),
-                                            (resp, String::new(), model, false),
-                                        ));
-                                    }
-                                }
+                        // End of stream.  Try to parse any leftover data in the buffer.
+                        // Collapse nested `if` / `if let` into a flat chain (fixes
+                        // `clippy::collapsible_if` – issue #1295).
+                        if let Some(json_str) = buf
+                            .trim()
+                            .strip_prefix("data: ")
+                            .filter(|s| !s.trim().is_empty() && s.trim() != "[DONE]")
+                        {
+                            if let Ok(chunk) =
+                                serde_json::from_str::<GeminiStreamChunk>(json_str)
+                            {
+                                let completion =
+                                    gemini_chunk_to_completion(&chunk, &model, is_first);
+                                return Some((
+                                    Ok(completion),
+                                    (resp, String::new(), model, false),
+                                ));
                             }
                         }
                         return None;


### PR DESCRIPTION
## Summary

Fixes #1295.

Running \`cargo clippy --workspace --all-features -- -D warnings\` on
\`main\` produces three \`clippy::collapsible_if\` warnings in
\`crates/mofa-foundation/src/llm/google.rs\` inside the end-of-stream
branch of \`parse_gemini_sse\`:

```
warning: this if statement can be collapsed
  --> crates/mofa-foundation/src/llm/google.rs:450:25
```

## Root Cause

The end-of-stream arm of the SSE parser had three levels of nested
\`if\` / \`if let\` / \`if\` guards:

```rust
if !buf.trim().is_empty() {
    if let Some(json_str) = buf.trim().strip_prefix("data: ") {
        if json_str.trim() != "[DONE]" {
            if let Ok(chunk) = serde_json::from_str::<...>(json_str) { ... }
        }
    }
}
```

## Fix

Collapse the outer three guards into a single flat chain using
\`strip_prefix\` + \`.filter()\` so there is only **one** level of nesting
left (the inner \`if let Ok(chunk)\`):

```rust
if let Some(json_str) = buf
    .trim()
    .strip_prefix("data: ")
    .filter(|s| !s.trim().is_empty() && s.trim() != "[DONE]")
{
    if let Ok(chunk) = serde_json::from_str::<GeminiStreamChunk>(json_str) { ... }
}
```

Semantics are identical: the filter checks both the non-empty guard and
the `[DONE]` sentinel in one step.

## Verification

```bash
cargo clippy -p mofa-foundation -- -D warnings
cargo test   -p mofa-foundation
```

Both pass clean.

## Checklist
- [x] Clippy warning eliminated
- [x] Logic unchanged (covered by existing SSE round-trip tests)
- [x] Fixes #1295