### PR TITLE
perf(kernel): remove redundant String alloc in RetryCondition::OnTransient::matches()

### DIFF
--- a/crates/mofa-kernel/src/workflow/policy.rs
+++ b/crates/mofa-kernel/src/workflow/policy.rs
@@ -95,9 +95,13 @@ impl RetryCondition {
             Self::Never => false,
             Self::OnTransient(patterns) => {
                 let lower = error_message.to_lowercase();
+                // `p.to_lowercase()` already allocates a `String`; calling
+                // `.as_str().to_owned()` on top converts it back to `String`
+                // via a needless round-trip (issue #1466).  Use `.as_str()`
+                // directly to borrow the temporary and avoid the extra alloc.
                 patterns
                     .iter()
-                    .any(|p| lower.contains(&p.to_lowercase().as_str().to_owned()))
+                    .any(|p| lower.contains(p.to_lowercase().as_str()))
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1466.

`RetryCondition::OnTransient::matches()` is called on **every** error
in the retry hot-path.  The current implementation makes a redundant
heap allocation per pattern:

```rust
// BEFORE
.any(|p| lower.contains(&p.to_lowercase().as_str().to_owned()))
//                              ^^^^^^^^^^^^^^^^^^^
//           p.to_lowercase() → String (alloc #1)
//           .as_str()        → &str
//           .to_owned()      → String (alloc #2, pointless round-trip)
```

The `.as_str().to_owned()` call converts the already-allocated `String`
back to `String` via `&str`, doubling the allocation count for no
semantic benefit.

## Fix

Remove the redundant `.to_owned()` and borrow the `&str` directly:

```rust
// AFTER
.any(|p| lower.contains(p.to_lowercase().as_str()))
//                              ^^^^^^^^^^^^^^^^^^^
//           p.to_lowercase() → String (alloc #1, kept)
//           .as_str()        → &str  (no extra alloc)
```

This halves the number of heap allocations per pattern per call.  For
agents with long transient-pattern lists and high retry rates the
improvement is measurable.

## Verification

```bash
cargo test -p mofa-kernel workflow::policy::tests
```

All existing tests pass unchanged.

## Checklist
- [x] Hot-path allocation removed
- [x] All existing tests pass
- [x] Behaviour is identical
- [x] Fixes #1466