### PR TITLE
fix: remove space in FATAL match and use project_root for .env path

### DIFF
--- a/crates/mofa-cli/src/commands/agent/logs.rs
+++ b/crates/mofa-cli/src/commands/agent/logs.rs
@@ -165,7 +165,7 @@ async fn display_log_file(
 /// Colorize log line based on log level
 fn colorize_log_line(line: &str) -> String {
     let upper = line.to_uppercase();
-    if upper.contains("ERROR") || upper.contains(" FATAL ") {
+    if upper.contains("ERROR") || upper.contains("FATAL") {
         line.red().to_string()
     } else if upper.contains("WARN") || upper.contains(" WARNING ") {
         line.yellow().to_string()
@@ -404,5 +404,11 @@ mod tests {
     fn test_colorize_log_line_dims_bracketed_trace_prefix() {
         let line = "[TRACE] module::op starting";
         assert_eq!(colorize_log_line(line), line.bright_black().to_string());
+    }
+
+    #[test]
+    fn test_colorize_log_line_colors_fatal_prefix_without_spaces() {
+        let line = "FATAL: process crashed";
+        assert_eq!(colorize_log_line(line), line.red().to_string());
     }
 }

--- a/mofa/commands/vibe.py
+++ b/mofa/commands/vibe.py
@@ -118,7 +118,7 @@ def _check_and_setup_api_key():
 
             # Ask if they want to save it
             if click.confirm("\nSave to .env file?", default=True):
-                env_file = os.path.join(os.getcwd(), '.env')
+                env_file = os.path.join(project_root, '.env')
 
                 # Append to .env or create new one
                 with open(env_file, 'a') as f:


### PR DESCRIPTION
## 1. Problem
Fixes two bugs: FATAL log lines without surrounding spaces were not
colorized red, and the .env file was saved to the current working
directory instead of the project root.


## 2. Changes
- `crates/mofa-cli/src/commands/agent/logs.rs`: Removed extra space
  inside `"` FATAL`"` string so `FATAL:` prefixed lines are correctly
  colorized red
- `mofa/commands/vibe.py`: Changed `os.getcwd()` to `project_root` so
  `.env` is always saved in the correct project location
  