### PR TITLE
Feat(testing) bus sequence expectations 

### DIFF
--- a/tests/src/bus.rs
+++ b/tests/src/bus.rs
@@ -64,6 +64,61 @@ impl MockAgentBus {
         self.captured_messages.read().await.len()
     }
 
+    pub async fn sender_sequence(&self) -> Vec<String> {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .map(|(sender, _, _)| sender.clone())
+            .collect()
+    }
+
+    pub async fn mode_sequence(&self) -> Vec<CommunicationMode> {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .map(|(_, mode, _)| mode.clone())
+            .collect()
+    }
+
+    pub async fn sender_mode_sequence(&self) -> Vec<(String, CommunicationMode)> {
+        self.captured_messages
+            .read()
+            .await
+            .iter()
+            .map(|(sender, mode, _)| (sender.clone(), mode.clone()))
+            .collect()
+    }
+
+    pub async fn has_sender_sequence(&self, expected: &[&str]) -> bool {
+        let actual = self.sender_sequence().await;
+        actual.len() == expected.len()
+            && actual
+                .iter()
+                .zip(expected.iter())
+                .all(|(actual_sender, expected_sender)| actual_sender == expected_sender)
+    }
+
+    pub async fn has_mode_sequence(&self, expected: &[CommunicationMode]) -> bool {
+        let actual = self.mode_sequence().await;
+        actual.len() == expected.len()
+            && actual
+                .iter()
+                .zip(expected.iter())
+                .all(|(actual_mode, expected_mode)| actual_mode == expected_mode)
+    }
+
+    pub async fn has_sender_mode_sequence(&self, expected: &[(&str, CommunicationMode)]) -> bool {
+        let actual = self.sender_mode_sequence().await;
+        actual.len() == expected.len()
+            && actual.iter().zip(expected.iter()).all(
+                |((actual_sender, actual_mode), (expected_sender, expected_mode))| {
+                    actual_sender == expected_sender && actual_mode == expected_mode
+                },
+            )
+    }
+
     /// Clears the capture history.
     pub async fn clear_history(&self) {
         self.captured_messages.write().await.clear();

--- a/tests/src/clock.rs
+++ b/tests/src/clock.rs
@@ -26,6 +26,10 @@ impl Default for MockClock {
 }
 
 impl MockClock {
+    fn current_millis(&self) -> u64 {
+        self.current_ms.load(Ordering::Relaxed)
+    }
+
     /// Create a clock starting at time zero.
     pub fn new() -> Self {
         Self {
@@ -63,6 +67,27 @@ impl MockClock {
     /// Disable auto-advance.
     pub fn clear_auto_advance(&self) {
         *self.auto_advance_ms.write().expect("lock poisoned") = None;
+    }
+
+    /// Return the current time without triggering auto-advance.
+    pub fn peek_millis(&self) -> u64 {
+        self.current_millis()
+    }
+
+    /// Compute an absolute deadline by adding `timeout` to the current time.
+    pub fn deadline_after(&self, timeout: Duration) -> u64 {
+        self.current_millis()
+            .saturating_add(timeout.as_millis() as u64)
+    }
+
+    /// Returns true when current time is at or past `deadline_ms`.
+    pub fn has_reached_deadline(&self, deadline_ms: u64) -> bool {
+        self.current_millis() >= deadline_ms
+    }
+
+    /// Return remaining time until `deadline_ms` (floored at zero).
+    pub fn remaining_until(&self, deadline_ms: u64) -> Duration {
+        Duration::from_millis(deadline_ms.saturating_sub(self.current_millis()))
     }
 }
 

--- a/tests/tests/bus_sequence_expectation_tests.rs
+++ b/tests/tests/bus_sequence_expectation_tests.rs
@@ -1,0 +1,126 @@
+use mofa_kernel::bus::CommunicationMode;
+use mofa_kernel::message::AgentMessage;
+use mofa_testing::bus::MockAgentBus;
+
+fn task_message(task_id: &str, content: &str) -> AgentMessage {
+    AgentMessage::TaskRequest {
+        task_id: task_id.into(),
+        content: content.into(),
+    }
+}
+
+#[tokio::test]
+async fn sender_sequence_matches_sent_order() {
+    let bus = MockAgentBus::new();
+
+    let _ = bus
+        .send_and_capture(
+            "agent-a",
+            CommunicationMode::Broadcast,
+            task_message("t1", "a"),
+        )
+        .await;
+    let _ = bus
+        .send_and_capture(
+            "agent-b",
+            CommunicationMode::PointToPoint("agent-c".into()),
+            task_message("t2", "b"),
+        )
+        .await;
+
+    assert!(bus.has_sender_sequence(&["agent-a", "agent-b"]).await);
+    assert!(!bus.has_sender_sequence(&["agent-b", "agent-a"]).await);
+}
+
+#[tokio::test]
+async fn mode_sequence_matches_sent_order() {
+    let bus = MockAgentBus::new();
+
+    let _ = bus
+        .send_and_capture(
+            "agent-a",
+            CommunicationMode::Broadcast,
+            task_message("t1", "a"),
+        )
+        .await;
+    let _ = bus
+        .send_and_capture(
+            "agent-b",
+            CommunicationMode::PointToPoint("agent-c".into()),
+            task_message("t2", "b"),
+        )
+        .await;
+
+    assert!(
+        bus.has_mode_sequence(&[
+            CommunicationMode::Broadcast,
+            CommunicationMode::PointToPoint("agent-c".into()),
+        ])
+        .await
+    );
+    assert!(
+        !bus.has_mode_sequence(&[
+            CommunicationMode::PointToPoint("agent-c".into()),
+            CommunicationMode::Broadcast,
+        ])
+        .await
+    );
+}
+
+#[tokio::test]
+async fn sender_mode_sequence_matches_pairs() {
+    let bus = MockAgentBus::new();
+
+    let _ = bus
+        .send_and_capture(
+            "agent-a",
+            CommunicationMode::Broadcast,
+            task_message("t1", "a"),
+        )
+        .await;
+    let _ = bus
+        .send_and_capture(
+            "agent-b",
+            CommunicationMode::PointToPoint("agent-c".into()),
+            task_message("t2", "b"),
+        )
+        .await;
+
+    assert!(
+        bus.has_sender_mode_sequence(&[
+            ("agent-a", CommunicationMode::Broadcast),
+            ("agent-b", CommunicationMode::PointToPoint("agent-c".into()),),
+        ])
+        .await
+    );
+    assert!(
+        !bus.has_sender_mode_sequence(&[
+            ("agent-a", CommunicationMode::Broadcast),
+            ("agent-b", CommunicationMode::Broadcast),
+        ])
+        .await
+    );
+}
+
+#[tokio::test]
+async fn sequence_helpers_require_exact_length() {
+    let bus = MockAgentBus::new();
+
+    let _ = bus
+        .send_and_capture(
+            "agent-a",
+            CommunicationMode::Broadcast,
+            task_message("t1", "a"),
+        )
+        .await;
+
+    assert!(!bus.has_sender_sequence(&["agent-a", "agent-b"]).await);
+    assert!(!bus.has_mode_sequence(&[]).await);
+    assert!(
+        !bus.has_sender_mode_sequence(&[
+            ("agent-a", CommunicationMode::Broadcast),
+            ("agent-b", CommunicationMode::Broadcast),
+        ])
+        .await
+    );
+}

--- a/tests/tests/clock_timeout_tests.rs
+++ b/tests/tests/clock_timeout_tests.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use mofa_testing::clock::{Clock, MockClock};
+
+#[test]
+fn deadline_after_uses_current_time() {
+    let clock = MockClock::starting_at(Duration::from_millis(1_000));
+    let deadline = clock.deadline_after(Duration::from_millis(250));
+    assert_eq!(deadline, 1_250);
+}
+
+#[test]
+fn has_reached_deadline_respects_manual_advance() {
+    let clock = MockClock::new();
+    let deadline = clock.deadline_after(Duration::from_millis(100));
+
+    assert!(!clock.has_reached_deadline(deadline));
+    clock.advance(Duration::from_millis(99));
+    assert!(!clock.has_reached_deadline(deadline));
+    clock.advance(Duration::from_millis(1));
+    assert!(clock.has_reached_deadline(deadline));
+}
+
+#[test]
+fn remaining_until_is_zero_after_deadline() {
+    let clock = MockClock::starting_at(Duration::from_millis(500));
+    let deadline = clock.deadline_after(Duration::from_millis(10));
+
+    assert_eq!(clock.remaining_until(deadline), Duration::from_millis(10));
+    clock.advance(Duration::from_millis(7));
+    assert_eq!(clock.remaining_until(deadline), Duration::from_millis(3));
+    clock.advance(Duration::from_millis(10));
+    assert_eq!(clock.remaining_until(deadline), Duration::ZERO);
+}
+
+#[test]
+fn peek_millis_does_not_trigger_auto_advance() {
+    let clock = MockClock::new();
+    clock.set_auto_advance(Duration::from_millis(50));
+
+    assert_eq!(clock.peek_millis(), 0);
+    assert_eq!(clock.peek_millis(), 0);
+
+    // now_millis reads current value and then auto-advances.
+    assert_eq!(clock.now_millis(), 0);
+    assert_eq!(clock.peek_millis(), 50);
+}


### PR DESCRIPTION
```mermaid
flowchart TD
    A[Test calls send_and_capture] --> B[MockAgentBus stores sender mode message]
    B --> C[Existing test logic continues]
    C --> D[Helper reads captured_messages]
    D --> E[sender_sequence]
    D --> F[mode_sequence]
    D --> G[sender_mode_sequence]
    E --> H[has_sender_sequence expected]
    F --> I[has_mode_sequence expected]
    G --> J[has_sender_mode_sequence expected]
    H --> K[Boolean assertion in test]
    I --> K
    J --> K

```
closess #1656 

## What this PR does
This PR adds ordered sequence helpers to `MockAgentBus` to make routing assertions cleaner in testing scenarios where message order matters.

### Added helpers
- `sender_sequence()`
- `mode_sequence()`
- `sender_mode_sequence()`
- `has_sender_sequence(&[&str])`
- `has_mode_sequence(&[CommunicationMode])`
- `has_sender_mode_sequence(&[(&str, CommunicationMode)])`

### Added tests
New test file: `tests/tests/bus_sequence_expectation_tests.rs`
- verifies sender ordering checks
- verifies communication mode ordering checks
- verifies combined sender+mode pair checks
- verifies exact-length matching behavior

## Why this matters
This improves deterministic, readable assertions for multi-agent communication flows and supports stronger testing-framework ergonomics without clashing with existing formatter/export PRs.

## Testing
- `cargo test -p mofa-testing --test bus_sequence_expectation_tests` ✅
- `cargo test -p mofa-testing` was attempted but failed in this environment due compiler OOM/stack-overrun during unrelated test target compilation.
