### PR TITLE
feat(testing): add observability smoke checks for metrics, logs, traces, and dashboards

### DIFF
--- a/examples/monitoring_dashboard/src/main.rs
+++ b/examples/monitoring_dashboard/src/main.rs
@@ -56,6 +56,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Build the router (this also sets up WebSocket handler)
     let router = server.build_router();
 
+    // Prime and start Prometheus refresh worker
+    if let Some(exporter) = server.prometheus_exporter() {
+        let _ = exporter.refresh_once().await;
+        exporter.start();
+    }
+
     // Start metrics collection background task
     collector.clone().start_collection();
 

--- a/ops/observability/docker-compose.yml
+++ b/ops/observability/docker-compose.yml
@@ -1,0 +1,86 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: mofa-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts:/etc/prometheus/alerts:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - alertmanager
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: mofa-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+      - jaeger
+
+  loki:
+    image: grafana/loki:2.9.8
+    container_name: mofa-loki
+    command: -config.file=/etc/loki/local-config.yml
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/local-config.yml:ro
+
+  promtail:
+    image: grafana/promtail:2.9.8
+    container_name: mofa-promtail
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/log:/var/log:ro
+    depends_on:
+      - loki
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.59
+    container_name: mofa-jaeger
+    environment:
+      - COLLECTOR_ZIPKIN_HOST_PORT=:9411
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+      - "9411:9411"
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: mofa-alertmanager
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  alertmanager_data:

--- a/ops/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/ops/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: "MoFA Dashboards"
+    orgId: 1
+    folder: "MoFA"
+    type: file
+    allowUiUpdates: false
+    disableDeletion: true
+    editable: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/ops/observability/grafana/provisioning/datasources/datasources.yml
+++ b/ops/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,41 @@
+apiVersion: 1
+prune: true
+deleteDatasources: []
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      manageAlerts: true
+      prometheusType: Prometheus
+      prometheusVersion: 2.54.1
+      cacheLevel: High
+      disableRecordingRules: false
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+
+  - name: Jaeger
+    uid: jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        tags:
+          - key: trace_id
+            value: trace_id

--- a/ops/observability/smoke_check.sh
+++ b/ops/observability/smoke_check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local/CI observability stack smoke checks.
+# Usage:
+#   bash ops/observability/smoke_check.sh
+
+PROM_URL="${PROM_URL:-http://127.0.0.1:9090}"
+GRAFANA_URL="${GRAFANA_URL:-http://127.0.0.1:3000}"
+LOKI_URL="${LOKI_URL:-http://127.0.0.1:3100}"
+JAEGER_URL="${JAEGER_URL:-http://127.0.0.1:16686}"
+ZIPKIN_URL="${ZIPKIN_URL:-http://127.0.0.1:9411}"
+APP_METRICS_URL="${APP_METRICS_URL:-http://127.0.0.1:8080/metrics}"
+SMOKE_SERVICE_NAME="${SMOKE_SERVICE_NAME:-mofa-smoke}"
+
+wait_http_ok() {
+  local label="$1"
+  local url="$2"
+  local timeout_s="${3:-90}"
+  local start_ts now elapsed
+  start_ts="$(date +%s)"
+  echo "  - ${label}: waiting (timeout=${timeout_s}s)"
+  while true; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      now="$(date +%s)"
+      elapsed="$(( now - start_ts ))"
+      echo "    ${label}: ready in ${elapsed}s"
+      return 0
+    fi
+    now="$(date +%s)"
+    elapsed="$(( now - start_ts ))"
+    if (( elapsed >= timeout_s )); then
+      echo "    ${label}: timed out after ${elapsed}s (${url})" >&2
+      return 1
+    fi
+    echo "    ${label}: still waiting (${elapsed}s elapsed)"
+    sleep 2
+  done
+}
+
+run_check() {
+  local label="$1"
+  shift
+  echo "  - ${label}"
+  "$@"
+  echo "    ${label}: ok"
+}
+
+inject_zipkin_trace() {
+  local now_us trace_id span_id
+  now_us="$(( $(date +%s%N) / 1000 ))"
+  trace_id="$(hexdump -n 16 -e '16/1 "%02x"' /dev/urandom)"
+  span_id="$(hexdump -n 8 -e '8/1 "%02x"' /dev/urandom)"
+
+  if ! curl -fsS -X POST "${ZIPKIN_URL}/api/v2/spans" \
+    -H 'Content-Type: application/json' \
+    -d "[{\"traceId\":\"${trace_id}\",\"id\":\"${span_id}\",\"name\":\"observability-smoke\",\"timestamp\":${now_us},\"duration\":1000,\"localEndpoint\":{\"serviceName\":\"${SMOKE_SERVICE_NAME}\"},\"tags\":{\"smoke\":\"true\"}}]" >/dev/null; then
+    echo "Zipkin ingest failed at ${ZIPKIN_URL}/api/v2/spans." >&2
+    echo "Ensure Jaeger enables Zipkin collector (COLLECTOR_ZIPKIN_HOST_PORT=:9411) and restart the stack." >&2
+    return 1
+  fi
+}
+
+echo "[1/8] Waiting for service health"
+wait_http_ok "Prometheus health" "${PROM_URL}/-/healthy" 90
+wait_http_ok "Grafana health" "${GRAFANA_URL}/api/health" 90
+wait_http_ok "Loki readiness" "${LOKI_URL}/ready" 90
+wait_http_ok "Jaeger UI" "${JAEGER_URL}/" 90
+
+echo "[2/8] Metrics endpoint responds"
+wait_http_ok "App metrics endpoint" "${APP_METRICS_URL}" 120
+
+
+echo "[3/8] /metrics contains expected MoFA metric families"
+run_check "mofa_llm_requests_total HELP line exists" bash -c "curl -fsS '${APP_METRICS_URL}' | grep -q '^# HELP mofa_llm_requests_total'"
+run_check "mofa_llm_requests_total TYPE line exists" bash -c "curl -fsS '${APP_METRICS_URL}' | grep -q '^# TYPE mofa_llm_requests_total'"
+
+echo "[4/8] Prometheus can query scrape health"
+run_check "Prometheus query: up{job=\"mofa-app\"}" bash -c "curl -fsSG '${PROM_URL}/api/v1/query' --data-urlencode 'query=up{job=\"mofa-app\"}' | jq -e '.status == \"success\" and (.data.result | length >= 1)' >/dev/null"
+
+echo "[5/8] Prometheus can query mofa_llm_requests_total"
+run_check "Prometheus query: mofa_llm_requests_total" bash -c "curl -fsSG '${PROM_URL}/api/v1/query' --data-urlencode 'query=mofa_llm_requests_total' | jq -e '.status == \"success\"' >/dev/null"
+
+echo "[6/8] Loki has ingested logs"
+run_check "Loki query returns at least one stream" bash -c "curl -fsSG '${LOKI_URL}/loki/api/v1/query' --data-urlencode 'query={compose_service=~\".+\"}' | jq -e '.status == \"success\" and (.data.result | length > 0)' >/dev/null"
+
+echo "[7/8] Injecting one trace via Zipkin and validating Jaeger visibility"
+inject_zipkin_trace
+sleep 3
+run_check "Jaeger service list includes ${SMOKE_SERVICE_NAME}" bash -c "curl -fsS '${JAEGER_URL}/api/services' | jq -e --arg svc '${SMOKE_SERVICE_NAME}' '.data | index(\$svc) != null' >/dev/null"
+run_check "Jaeger trace query returns data" bash -c "curl -fsSG '${JAEGER_URL}/api/traces' --data-urlencode 'service=${SMOKE_SERVICE_NAME}' --data-urlencode 'limit=1' | jq -e '.data | length > 0' >/dev/null"
+
+echo "[8/8] Smoke check passed"

--- a/ops/observability/validate_dashboards.sh
+++ b/ops/observability/validate_dashboards.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate Grafana dashboard JSON payloads used by provisioning.
+shopt -s nullglob
+files=(ops/observability/grafana/dashboards/*.json)
+
+if (( ${#files[@]} == 0 )); then
+  echo "No dashboard JSON files found." >&2
+  exit 1
+fi
+
+for file in "${files[@]}"; do
+  jq -e '.title and (.panels | type == "array") and ((.panels | length) > 0)' "$file" >/dev/null
+  echo "validated: $file"
+done


### PR DESCRIPTION
## Summary
This PR strengthens the observability validation path by fixing metrics exporter startup in the monitoring dashboard example and hardening smoke checks for clearer diagnostics and deterministic Jaeger trace validation.

It keeps the current demo dashboard behavior, but ensures `/metrics` is reliably populated and makes the stack checks easier to debug when something is not ready.
<img width="808" height="151" alt="Screenshot from 2026-04-21 23-00-35" src="https://github.com/user-attachments/assets/00b4fc69-b468-4d55-9534-737442011556" />

<img width="523" height="931" alt="Screenshot from 2026-04-21 23-06-50" src="https://github.com/user-attachments/assets/852df52d-b360-4fab-acf0-2d33ce8f5f45" />

## Execution Flow
```mermaid
flowchart TD
    A["Start monitoring app"]
    B["Start observability stack"]
    C["Run smoke_check.sh"]

    A --> A1["Prime and start exporter"]
    A1 --> A2["metrics endpoint ready"]

    B --> B1["Prometheus healthy"]
    B --> B2["Loki ready"]
    B --> B3["Jaeger ready"]

    C --> C1["Check metrics families"]
    C --> C2["Check Prometheus queries"]
    C --> C3["Check Loki logs"]
    C --> C4["Inject and verify Jaeger trace"]

    A2 --> C1
    B1 --> C2
    B2 --> C3
    B3 --> C4

    C1 --> D["Smoke check passed"]
    C2 --> D
    C3 --> D
    C4 --> D
```
## What Changed

### 1) Prime/start Prometheus exporter in dashboard example
- **File:** `examples/monitoring_dashboard/src/main.rs`
- After `build_router()`, the example now:
  - calls `refresh_once().await` to prime the cached metrics payload
  - starts the exporter refresh worker
- This prevents empty `/metrics` output during startup and improves scrape reliability.

### 2) Enable Zipkin collector explicitly in Jaeger service
- **File:** `ops/observability/docker-compose.yml`
- Added:
  - `COLLECTOR_ZIPKIN_HOST_PORT=:9411`
- This ensures the smoke script’s trace injection path (`/api/v2/spans`) is available consistently.

### 3) Improve smoke check observability and failure messaging
- **File:** `ops/observability/smoke_check.sh`
- Added clearer step-level output:
  - per-service readiness labels
  - elapsed wait-time progress
  - explicit “ok” confirmations for query checks
- Improved Zipkin injection error handling:
  - clearer actionable message when Jaeger Zipkin ingest is unavailable.

## Validation Performed
- `cargo check --manifest-path examples/monitoring_dashboard/Cargo.toml` passed.
- `bash -n ops/observability/smoke_check.sh` passed.
- End-to-end run succeeded:
  - service health checks
  - `/metrics` family checks
  - Prometheus queries
  - Loki ingestion query
  - Jaeger service + trace visibility after injected smoke trace

## Notes
- This PR does not change telemetry semantics or metric schema.
- Dashboard tested data source in `examples/monitoring_dashboard/src/main.rs`.
- Stack/services/log/trace plumbing is real and validated end-to-end.
