### PR TITLE
feat(kernel): tool sandbox trait contracts and policy model (Task 34)

### DIFF
--- a/crates/mofa-kernel/src/agent/components/mod.rs
+++ b/crates/mofa-kernel/src/agent/components/mod.rs
@@ -9,6 +9,7 @@ pub mod coordinator;
 pub mod mcp;
 pub mod memory;
 pub mod reasoner;
+pub mod sandbox;
 pub mod tool;
 
 pub use context_compressor::{
@@ -18,4 +19,9 @@ pub use coordinator::{CoordinationPattern, Coordinator, DispatchResult, Task};
 pub use mcp::{McpClient, McpServerConfig, McpServerInfo, McpToolInfo, McpTransportConfig};
 pub use memory::{Embedder, Memory, MemoryItem, MemoryStats, MemoryValue, Message, MessageRole};
 pub use reasoner::{Decision, Reasoner, ReasoningResult, ThoughtStep};
+pub use sandbox::{
+    NetEndpoint, ObservationDecision, PathPattern, SandboxCapability, SandboxError,
+    SandboxExecutionStats, SandboxObserver, SandboxPolicy, SandboxPolicyBuilder, SandboxRequest,
+    SandboxResourceLimits, SandboxResponse, SandboxResult, SandboxTier, ToolSandbox,
+};
 pub use tool::{Tool, ToolDescriptor, ToolInput, ToolMetadata, ToolRegistry, ToolResult};

--- a/crates/mofa-kernel/src/agent/components/sandbox/error.rs
+++ b/crates/mofa-kernel/src/agent/components/sandbox/error.rs
@@ -1,0 +1,251 @@
+//! Sandbox errors
+//!
+//! Error types for tool sandbox construction, policy evaluation, and
+//! sandboxed execution.
+
+use std::time::Duration;
+use thiserror::Error;
+
+/// Errors raised by a tool sandbox layer.
+///
+/// `SandboxError` is kept distinct from [`crate::agent::error::AgentError`] so
+/// a sandboxed tool failure can be distinguished from a generic tool error —
+/// a policy denial is not the same class of event as a tool bug.
+///
+/// Downstream conversion into `AgentError` is provided via `From`.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SandboxError {
+    /// The requested capability is not present in the active policy.
+    #[error("capability denied: tool `{tool}` requested `{capability}` but policy only permits {allowed:?}")]
+    CapabilityDenied {
+        tool: String,
+        capability: String,
+        allowed: Vec<String>,
+    },
+
+    /// A filesystem path was accessed that falls outside the policy allow-list.
+    #[error("filesystem path `{path}` is outside the allow-list for tool `{tool}`")]
+    PathNotAllowed { tool: String, path: String },
+
+    /// A network destination was not permitted.
+    #[error("network destination `{host}:{port}` not permitted for tool `{tool}`")]
+    NetworkNotAllowed {
+        tool: String,
+        host: String,
+        port: u16,
+    },
+
+    /// An environment variable read/write was not permitted.
+    #[error("environment variable `{name}` not readable under current policy")]
+    EnvVarNotAllowed { name: String },
+
+    /// Subprocess spawning is disabled or the binary is not in the allow-list.
+    #[error("subprocess `{program}` not permitted for tool `{tool}`")]
+    SubprocessNotAllowed { tool: String, program: String },
+
+    /// CPU-time resource limit exhausted.
+    #[error("tool `{tool}` exceeded CPU time limit of {limit:?} (observed {observed:?})")]
+    CpuTimeExceeded {
+        tool: String,
+        limit: Duration,
+        observed: Duration,
+    },
+
+    /// Wall-clock timeout.
+    #[error("tool `{tool}` exceeded wall-clock timeout of {limit:?}")]
+    WallTimeout { tool: String, limit: Duration },
+
+    /// Memory usage exceeded the configured cap.
+    #[error("tool `{tool}` exceeded memory cap of {limit_bytes} bytes (observed {observed_bytes})")]
+    MemoryExceeded {
+        tool: String,
+        limit_bytes: u64,
+        observed_bytes: u64,
+    },
+
+    /// Output size from the sandbox exceeded the configured cap.
+    #[error(
+        "tool `{tool}` produced output of {observed_bytes} bytes, exceeding cap of {limit_bytes}"
+    )]
+    OutputTooLarge {
+        tool: String,
+        limit_bytes: u64,
+        observed_bytes: u64,
+    },
+
+    /// The sandboxed process terminated abnormally (signal, OOM-kill, etc).
+    #[error("tool `{tool}` crashed inside sandbox: {reason}")]
+    SandboxCrashed { tool: String, reason: String },
+
+    /// The sandbox backend itself failed to set up (fork failure, wasm engine
+    /// error, rlimit syscall error, etc).
+    #[error("sandbox backend error: {0}")]
+    BackendFailure(String),
+
+    /// Policy was malformed or internally inconsistent (e.g. conflicting
+    /// capability lists). Raised at construction time, not at execution.
+    #[error("invalid sandbox policy: {0}")]
+    InvalidPolicy(String),
+
+    /// Serialization of sandboxed I/O failed.
+    #[error("sandbox I/O serialization error: {0}")]
+    SerializationError(String),
+
+    /// Backend-specific I/O error that doesn't fit the categories above.
+    #[error("sandbox I/O error: {0}")]
+    IoError(String),
+}
+
+impl SandboxError {
+    /// Returns `true` if the error represents a policy denial (the tool
+    /// attempted something the policy forbids) as opposed to a backend
+    /// failure or resource-limit breach.
+    ///
+    /// Policy denials are generally *deterministic* — the same tool call
+    /// with the same policy will always be denied — so callers can use this
+    /// to decide whether a retry makes sense.
+    pub fn is_policy_denial(&self) -> bool {
+        matches!(
+            self,
+            SandboxError::CapabilityDenied { .. }
+                | SandboxError::PathNotAllowed { .. }
+                | SandboxError::NetworkNotAllowed { .. }
+                | SandboxError::EnvVarNotAllowed { .. }
+                | SandboxError::SubprocessNotAllowed { .. }
+        )
+    }
+
+    /// Returns `true` if the error is a resource-limit breach (CPU, memory,
+    /// wall time, output size). These are not retryable without adjusting
+    /// the policy or the tool's workload.
+    pub fn is_resource_limit(&self) -> bool {
+        matches!(
+            self,
+            SandboxError::CpuTimeExceeded { .. }
+                | SandboxError::WallTimeout { .. }
+                | SandboxError::MemoryExceeded { .. }
+                | SandboxError::OutputTooLarge { .. }
+        )
+    }
+
+    /// Returns `true` if the error indicates a backend-internal failure
+    /// rather than a user-visible policy outcome. Backend failures may be
+    /// retryable (e.g. transient fork EAGAIN).
+    pub fn is_backend_failure(&self) -> bool {
+        matches!(
+            self,
+            SandboxError::BackendFailure(_)
+                | SandboxError::IoError(_)
+                | SandboxError::SandboxCrashed { .. }
+        )
+    }
+}
+
+impl From<std::io::Error> for SandboxError {
+    fn from(e: std::io::Error) -> Self {
+        SandboxError::IoError(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for SandboxError {
+    fn from(e: serde_json::Error) -> Self {
+        SandboxError::SerializationError(e.to_string())
+    }
+}
+
+impl From<SandboxError> for crate::agent::error::AgentError {
+    fn from(e: SandboxError) -> Self {
+        use crate::agent::error::AgentError;
+        match e {
+            SandboxError::CapabilityDenied { .. }
+            | SandboxError::PathNotAllowed { .. }
+            | SandboxError::NetworkNotAllowed { .. }
+            | SandboxError::EnvVarNotAllowed { .. }
+            | SandboxError::SubprocessNotAllowed { .. } => AgentError::ValidationFailed(e.to_string()),
+
+            SandboxError::CpuTimeExceeded { limit, .. } | SandboxError::WallTimeout { limit, .. } => {
+                AgentError::Timeout {
+                    duration_ms: limit.as_millis() as u64,
+                }
+            }
+
+            SandboxError::MemoryExceeded { .. } | SandboxError::OutputTooLarge { .. } => {
+                AgentError::ResourceUnavailable(e.to_string())
+            }
+
+            SandboxError::SandboxCrashed { .. } | SandboxError::BackendFailure(_) => {
+                AgentError::ExecutionFailed(e.to_string())
+            }
+
+            SandboxError::InvalidPolicy(_) => AgentError::ConfigError(e.to_string()),
+            SandboxError::SerializationError(_) => AgentError::SerializationError(e.to_string()),
+            SandboxError::IoError(_) => AgentError::IoError(e.to_string()),
+        }
+    }
+}
+
+/// Convenient result alias for sandbox operations.
+pub type SandboxResult<T> = Result<T, SandboxError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_denial_classification() {
+        let e = SandboxError::CapabilityDenied {
+            tool: "curl".into(),
+            capability: "Net".into(),
+            allowed: vec!["Fs".into()],
+        };
+        assert!(e.is_policy_denial());
+        assert!(!e.is_resource_limit());
+        assert!(!e.is_backend_failure());
+    }
+
+    #[test]
+    fn resource_limit_classification() {
+        let e = SandboxError::WallTimeout {
+            tool: "slow".into(),
+            limit: Duration::from_secs(1),
+        };
+        assert!(e.is_resource_limit());
+        assert!(!e.is_policy_denial());
+        assert!(!e.is_backend_failure());
+    }
+
+    #[test]
+    fn backend_failure_classification() {
+        let e = SandboxError::BackendFailure("fork failed".into());
+        assert!(e.is_backend_failure());
+        assert!(!e.is_policy_denial());
+        assert!(!e.is_resource_limit());
+    }
+
+    #[test]
+    fn converts_to_agent_error_as_validation() {
+        let e = SandboxError::PathNotAllowed {
+            tool: "cat".into(),
+            path: "/etc/passwd".into(),
+        };
+        let ae: crate::agent::error::AgentError = e.into();
+        assert!(matches!(
+            ae,
+            crate::agent::error::AgentError::ValidationFailed(_)
+        ));
+    }
+
+    #[test]
+    fn converts_timeout_preserving_duration() {
+        let e = SandboxError::WallTimeout {
+            tool: "slow".into(),
+            limit: Duration::from_millis(500),
+        };
+        let ae: crate::agent::error::AgentError = e.into();
+        match ae {
+            crate::agent::error::AgentError::Timeout { duration_ms } => assert_eq!(duration_ms, 500),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+}

--- a/crates/mofa-kernel/src/agent/components/sandbox/mod.rs
+++ b/crates/mofa-kernel/src/agent/components/sandbox/mod.rs
@@ -1,0 +1,68 @@
+//! Tool execution sandbox — kernel-level trait contracts and policy model.
+//!
+//! This module defines the backend-agnostic interface for running untrusted
+//! tools with capability-based access control and resource limits. Concrete
+//! backends (`NullSandbox`, `ProcessSandbox`, `WasmtimeSandbox`) live in
+//! `mofa-foundation`; the kernel only owns the contracts.
+//!
+//! # Layered architecture
+//!
+//! ```text
+//!     ┌───────────────────────────────────────────────────────┐
+//!     │                     Agent Loop                         │
+//!     │  (mofa-foundation/src/llm/agent_loop.rs)               │
+//!     └────────────────────────┬──────────────────────────────┘
+//!                              │  ToolInput / ToolResult
+//!                              ▼
+//!     ┌───────────────────────────────────────────────────────┐
+//!     │                SandboxedTool<T: Tool>                  │
+//!     │  (mofa-foundation adapter, wraps any Tool impl)        │
+//!     └────────────────────────┬──────────────────────────────┘
+//!                              │  SandboxRequest
+//!                              ▼
+//!     ┌───────────────────────────────────────────────────────┐
+//!     │            trait ToolSandbox  (this module)            │
+//!     │                                                        │
+//!     │    .policy()   .tier()   .precheck()   .execute()      │
+//!     └────────────────────────┬──────────────────────────────┘
+//!                              │
+//!          ┌───────────────────┼────────────────────┐
+//!          ▼                   ▼                    ▼
+//!     ┌──────────┐      ┌──────────────┐     ┌─────────────┐
+//!     │ NullSbx  │      │ ProcessSbx   │     │ WasmtimeSbx │
+//!     │ (trusted)│      │ (fork+rlimit)│     │ (wasmtime)  │
+//!     │ Tier:None│      │ Tier:Process │     │ Tier:VM     │
+//!     └──────────┘      └──────────────┘     └─────────────┘
+//! ```
+//!
+//! # Policy model
+//!
+//! Policies are **default-deny**. The base capability set is empty except
+//! for implicit [`SandboxCapability::Compute`]; any other capability
+//! (`FsRead`/`FsWrite`, `Net`, `EnvRead`, `Subprocess`, `Clock`,
+//! `RandomRead`) must be explicitly listed along with a fine-grained
+//! allow-list when applicable (e.g. `fs_allow_list` of [`PathPattern`]s
+//! for filesystem access).
+//!
+//! # Error taxonomy
+//!
+//! [`SandboxError`] distinguishes three failure classes:
+//! - **Policy denial** — tool attempted a forbidden capability or access.
+//! - **Resource breach** — tool exceeded CPU/memory/wall/output caps.
+//! - **Backend failure** — sandbox infrastructure itself errored.
+//!
+//! This matters for retry semantics: only backend failures are plausibly
+//! retryable; policy denials and resource breaches are deterministic.
+
+pub mod error;
+pub mod policy;
+pub mod traits;
+
+pub use error::{SandboxError, SandboxResult};
+pub use policy::{
+    SandboxCapability, NetEndpoint, PathPattern, SandboxResourceLimits, SandboxPolicy, SandboxPolicyBuilder,
+};
+pub use traits::{
+    ObservationDecision, SandboxExecutionStats, SandboxObserver, SandboxRequest, SandboxResponse,
+    SandboxTier, ToolSandbox,
+};

--- a/crates/mofa-kernel/src/agent/components/sandbox/policy.rs
+++ b/crates/mofa-kernel/src/agent/components/sandbox/policy.rs
@@ -1,0 +1,763 @@
+//! Sandbox policy types
+//!
+//! Declarative capability and resource-limit model for sandboxed tool
+//! execution. Policies are backend-agnostic: the same `SandboxPolicy` is
+//! interpreted by a process-isolation backend, a wasmtime backend, or a
+//! passthrough no-op backend.
+//!
+//! # Design
+//!
+//! Policies are *default-deny*: any capability not explicitly listed in the
+//! `allowed_capabilities` set is refused. This matches the OWASP Tool
+//! Sandbox design pattern and keeps the security posture predictable across
+//! backends that may have different native default behaviors.
+//!
+//! ```text
+//!                 ┌──────────────────────────┐
+//!                 │       SandboxPolicy      │
+//!                 │                          │
+//!                 │  allowed_capabilities    │───► SandboxCapability set
+//!                 │  fs_allow_list           │───► Vec<PathPattern>
+//!                 │  net_allow_list          │───► Vec<NetEndpoint>
+//!                 │  env_allow_list          │───► Vec<String>
+//!                 │  subprocess_allow_list   │───► Vec<String>
+//!                 │  resource_limits         │───► SandboxResourceLimits
+//!                 └──────────────────────────┘
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::error::{SandboxError, SandboxResult};
+
+/// SandboxCapability categories that a sandboxed tool may request.
+///
+/// A sandbox *policy* lists which of these are granted; anything not listed
+/// is denied. Capabilities are deliberately coarse-grained — the fine-grained
+/// allow-lists (`fs_allow_list`, `net_allow_list`, etc.) further constrain
+/// *what* may be accessed within a granted capability.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[non_exhaustive]
+pub enum SandboxCapability {
+    /// Read-only filesystem access to paths in `fs_allow_list`.
+    FsRead,
+    /// Read-write filesystem access to paths in `fs_allow_list`.
+    FsWrite,
+    /// Outbound network to endpoints in `net_allow_list`.
+    Net,
+    /// Read process environment variables in `env_allow_list`.
+    EnvRead,
+    /// Spawn subprocesses whose program name is in `subprocess_allow_list`.
+    Subprocess,
+    /// Read-only CPU-bound compute with no external I/O.
+    ///
+    /// This is always granted implicitly — compute capability is the base
+    /// state of any sandboxed tool. Listing it is a no-op but is accepted
+    /// for explicitness in policy definitions.
+    Compute,
+    /// Read wall-clock time, monotonic clocks, and system-time APIs.
+    Clock,
+    /// Draw from the host cryptographic RNG.
+    RandomRead,
+}
+
+impl SandboxCapability {
+    /// Human-readable identifier used in error messages.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SandboxCapability::FsRead => "FsRead",
+            SandboxCapability::FsWrite => "FsWrite",
+            SandboxCapability::Net => "Net",
+            SandboxCapability::EnvRead => "EnvRead",
+            SandboxCapability::Subprocess => "Subprocess",
+            SandboxCapability::Compute => "Compute",
+            SandboxCapability::Clock => "Clock",
+            SandboxCapability::RandomRead => "RandomRead",
+        }
+    }
+
+    /// `Compute` is implicitly granted and need not appear in a policy.
+    pub fn is_implicit(&self) -> bool {
+        matches!(self, SandboxCapability::Compute)
+    }
+
+    /// Iterate over every defined capability in sorted order. Useful for
+    /// combinatorial policy tests and admin UIs that need to surface the
+    /// full capability set.
+    pub fn iter_all() -> impl Iterator<Item = SandboxCapability> {
+        [
+            SandboxCapability::FsRead,
+            SandboxCapability::FsWrite,
+            SandboxCapability::Net,
+            SandboxCapability::EnvRead,
+            SandboxCapability::Subprocess,
+            SandboxCapability::Compute,
+            SandboxCapability::Clock,
+            SandboxCapability::RandomRead,
+        ]
+        .into_iter()
+    }
+}
+
+impl std::fmt::Display for SandboxCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A filesystem path pattern — either an exact path or a directory prefix
+/// that the tool may read/write recursively underneath.
+///
+/// Patterns are checked by canonicalised-prefix match; globs are not
+/// supported here to keep the policy model analyzable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PathPattern {
+    /// Exact canonical path; the tool may touch *only* this path.
+    Exact(PathBuf),
+    /// Directory subtree — tool may touch `prefix/*` recursively.
+    Prefix(PathBuf),
+}
+
+impl PathPattern {
+    /// Returns `true` if `candidate` is covered by this pattern.
+    pub fn matches(&self, candidate: &std::path::Path) -> bool {
+        match self {
+            PathPattern::Exact(p) => p == candidate,
+            PathPattern::Prefix(p) => candidate.starts_with(p),
+        }
+    }
+}
+
+/// A permitted outbound network endpoint.
+///
+/// Either a specific `host:port` pair or a host wildcard (`*`) for any port
+/// on a given host. No CIDR/subnet support in the kernel model — backends
+/// may extend this internally but the policy surface is kept minimal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum NetEndpoint {
+    /// Host + specific port (e.g. `api.openai.com:443`).
+    HostPort { host: String, port: u16 },
+    /// Host with any port permitted.
+    HostAnyPort { host: String },
+}
+
+impl NetEndpoint {
+    /// Returns `true` if a connection attempt to `(host, port)` is
+    /// permitted by this endpoint rule.
+    pub fn matches(&self, host: &str, port: u16) -> bool {
+        match self {
+            NetEndpoint::HostPort { host: h, port: p } => h == host && *p == port,
+            NetEndpoint::HostAnyPort { host: h } => h == host,
+        }
+    }
+}
+
+/// Resource limits applied during sandboxed execution.
+///
+/// Limits are *upper bounds*; a backend may enforce tighter limits (e.g.
+/// a wasmtime backend may cap memory more aggressively by default). A
+/// limit of `None` means "no explicit cap" — but backends are still free
+/// to apply a safety default.
+///
+/// ```text
+///                  ┌──────────────────────┐
+///                  │   SandboxResourceLimits     │
+///                  │                      │
+///                  │  wall_timeout        │── Duration
+///                  │  cpu_time_limit      │── Duration
+///                  │  memory_limit_bytes  │── u64
+///                  │  output_limit_bytes  │── u64
+///                  │  max_open_files      │── u32
+///                  └──────────────────────┘
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxResourceLimits {
+    /// Maximum wall-clock time the sandboxed tool may run.
+    pub wall_timeout: Option<Duration>,
+    /// Maximum CPU time (user+sys) the process may accumulate.
+    pub cpu_time_limit: Option<Duration>,
+    /// Maximum resident memory in bytes.
+    pub memory_limit_bytes: Option<u64>,
+    /// Maximum output size the sandbox will capture and return.
+    pub output_limit_bytes: Option<u64>,
+    /// Maximum open file descriptors (ignored by backends where it doesn't
+    /// apply, e.g. a pure wasmtime in-memory sandbox).
+    pub max_open_files: Option<u32>,
+}
+
+impl Default for SandboxResourceLimits {
+    /// Conservative defaults appropriate for untrusted tool execution:
+    /// 30-second wall clock, 10-second CPU, 256 MiB memory, 1 MiB output,
+    /// 64 file descriptors.
+    fn default() -> Self {
+        Self {
+            wall_timeout: Some(Duration::from_secs(30)),
+            cpu_time_limit: Some(Duration::from_secs(10)),
+            memory_limit_bytes: Some(256 * 1024 * 1024),
+            output_limit_bytes: Some(1024 * 1024),
+            max_open_files: Some(64),
+        }
+    }
+}
+
+impl SandboxResourceLimits {
+    /// Unrestricted limits. Use only for trusted tools wrapped in
+    /// `NullSandbox` where the sandbox model still requires a value.
+    pub fn unlimited() -> Self {
+        Self {
+            wall_timeout: None,
+            cpu_time_limit: None,
+            memory_limit_bytes: None,
+            output_limit_bytes: None,
+            max_open_files: None,
+        }
+    }
+
+    /// Validate that limits are internally consistent. Called implicitly
+    /// by [`SandboxPolicy::validate`].
+    pub fn validate(&self) -> SandboxResult<()> {
+        if let (Some(wall), Some(cpu)) = (self.wall_timeout, self.cpu_time_limit) {
+            if cpu > wall {
+                return Err(SandboxError::InvalidPolicy(format!(
+                    "cpu_time_limit ({cpu:?}) exceeds wall_timeout ({wall:?})"
+                )));
+            }
+        }
+        if let Some(mem) = self.memory_limit_bytes {
+            if mem == 0 {
+                return Err(SandboxError::InvalidPolicy(
+                    "memory_limit_bytes must be > 0".into(),
+                ));
+            }
+        }
+        if let Some(out) = self.output_limit_bytes {
+            if out == 0 {
+                return Err(SandboxError::InvalidPolicy(
+                    "output_limit_bytes must be > 0".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A complete declarative sandbox policy.
+///
+/// Construct with [`SandboxPolicy::builder`] for the common case, or
+/// directly for the two canned policies:
+/// - [`SandboxPolicy::denied_by_default`] — deny everything except `Compute`
+/// - [`SandboxPolicy::trusted`] — grant everything (equivalent to no
+///   sandboxing; intended for `NullSandbox`)
+///
+/// ```
+/// use std::path::PathBuf;
+/// use std::time::Duration;
+/// use mofa_kernel::agent::components::sandbox::{
+///     SandboxCapability, NetEndpoint, PathPattern, SandboxResourceLimits, SandboxPolicy,
+/// };
+///
+/// let policy = SandboxPolicy::builder()
+///     .allow(SandboxCapability::FsRead)
+///     .allow_fs(PathPattern::Prefix(PathBuf::from("/tmp/tool-scratch")))
+///     .allow(SandboxCapability::Net)
+///     .allow_net(NetEndpoint::HostPort { host: "api.openai.com".into(), port: 443 })
+///     .resource_limits(SandboxResourceLimits {
+///         wall_timeout: Some(Duration::from_secs(10)),
+///         ..Default::default()
+///     })
+///     .build()
+///     .unwrap();
+///
+/// assert!(policy.grants(SandboxCapability::FsRead));
+/// assert!(policy.grants(SandboxCapability::Net));
+/// assert!(!policy.grants(SandboxCapability::Subprocess));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxPolicy {
+    allowed_capabilities: BTreeSet<SandboxCapability>,
+    fs_allow_list: Vec<PathPattern>,
+    net_allow_list: Vec<NetEndpoint>,
+    env_allow_list: Vec<String>,
+    subprocess_allow_list: Vec<String>,
+    resource_limits: SandboxResourceLimits,
+}
+
+impl SandboxPolicy {
+    /// Start building a policy.
+    pub fn builder() -> SandboxPolicyBuilder {
+        SandboxPolicyBuilder::default()
+    }
+
+    /// Deny-everything policy (only implicit `Compute` capability is
+    /// available). Use this as a base for untrusted tools.
+    pub fn denied_by_default() -> Self {
+        Self {
+            allowed_capabilities: BTreeSet::new(),
+            fs_allow_list: Vec::new(),
+            net_allow_list: Vec::new(),
+            env_allow_list: Vec::new(),
+            subprocess_allow_list: Vec::new(),
+            resource_limits: SandboxResourceLimits::default(),
+        }
+    }
+
+    /// Unrestricted policy. Equivalent to running with no sandbox at all;
+    /// use only with [`crate::agent::components::sandbox::SandboxTier::None`]
+    /// backends, never in production on untrusted tools.
+    pub fn trusted() -> Self {
+        Self {
+            allowed_capabilities: [
+                SandboxCapability::FsRead,
+                SandboxCapability::FsWrite,
+                SandboxCapability::Net,
+                SandboxCapability::EnvRead,
+                SandboxCapability::Subprocess,
+                SandboxCapability::Compute,
+                SandboxCapability::Clock,
+                SandboxCapability::RandomRead,
+            ]
+            .into_iter()
+            .collect(),
+            fs_allow_list: Vec::new(),
+            net_allow_list: Vec::new(),
+            env_allow_list: Vec::new(),
+            subprocess_allow_list: Vec::new(),
+            resource_limits: SandboxResourceLimits::unlimited(),
+        }
+    }
+
+    pub fn allowed_capabilities(&self) -> &BTreeSet<SandboxCapability> {
+        &self.allowed_capabilities
+    }
+
+    pub fn fs_allow_list(&self) -> &[PathPattern] {
+        &self.fs_allow_list
+    }
+
+    pub fn net_allow_list(&self) -> &[NetEndpoint] {
+        &self.net_allow_list
+    }
+
+    pub fn env_allow_list(&self) -> &[String] {
+        &self.env_allow_list
+    }
+
+    pub fn subprocess_allow_list(&self) -> &[String] {
+        &self.subprocess_allow_list
+    }
+
+    pub fn resource_limits(&self) -> &SandboxResourceLimits {
+        &self.resource_limits
+    }
+
+    /// Returns `true` if the policy grants `cap`. `Compute` is always
+    /// granted implicitly regardless of whether it was listed.
+    pub fn grants(&self, cap: SandboxCapability) -> bool {
+        cap.is_implicit() || self.allowed_capabilities.contains(&cap)
+    }
+
+    /// Check whether a filesystem access is permitted.
+    ///
+    /// Requires the caller-appropriate capability (`FsRead` for reads,
+    /// `FsWrite` for writes) and that `path` matches some entry in the
+    /// allow-list.
+    pub fn check_fs(
+        &self,
+        tool: &str,
+        path: &std::path::Path,
+        write: bool,
+    ) -> SandboxResult<()> {
+        let required = if write {
+            SandboxCapability::FsWrite
+        } else {
+            SandboxCapability::FsRead
+        };
+        if !self.grants(required) {
+            return Err(SandboxError::CapabilityDenied {
+                tool: tool.into(),
+                capability: required.as_str().into(),
+                allowed: self.capability_names(),
+            });
+        }
+        if !self.fs_allow_list.iter().any(|p| p.matches(path)) {
+            return Err(SandboxError::PathNotAllowed {
+                tool: tool.into(),
+                path: path.display().to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Check whether a network connection is permitted.
+    pub fn check_net(&self, tool: &str, host: &str, port: u16) -> SandboxResult<()> {
+        if !self.grants(SandboxCapability::Net) {
+            return Err(SandboxError::CapabilityDenied {
+                tool: tool.into(),
+                capability: SandboxCapability::Net.as_str().into(),
+                allowed: self.capability_names(),
+            });
+        }
+        if !self.net_allow_list.iter().any(|e| e.matches(host, port)) {
+            return Err(SandboxError::NetworkNotAllowed {
+                tool: tool.into(),
+                host: host.into(),
+                port,
+            });
+        }
+        Ok(())
+    }
+
+    /// Check whether reading an environment variable is permitted.
+    pub fn check_env(&self, name: &str) -> SandboxResult<()> {
+        if !self.grants(SandboxCapability::EnvRead) {
+            return Err(SandboxError::EnvVarNotAllowed { name: name.into() });
+        }
+        if !self.env_allow_list.iter().any(|n| n == name) {
+            return Err(SandboxError::EnvVarNotAllowed { name: name.into() });
+        }
+        Ok(())
+    }
+
+    /// Check whether spawning `program` as a subprocess is permitted.
+    pub fn check_subprocess(&self, tool: &str, program: &str) -> SandboxResult<()> {
+        if !self.grants(SandboxCapability::Subprocess) {
+            return Err(SandboxError::SubprocessNotAllowed {
+                tool: tool.into(),
+                program: program.into(),
+            });
+        }
+        if !self.subprocess_allow_list.iter().any(|p| p == program) {
+            return Err(SandboxError::SubprocessNotAllowed {
+                tool: tool.into(),
+                program: program.into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Consistency check over the whole policy.
+    pub fn validate(&self) -> SandboxResult<()> {
+        // FS allow list entries are only meaningful if an FS capability is granted.
+        if !self.fs_allow_list.is_empty()
+            && !self.grants(SandboxCapability::FsRead)
+            && !self.grants(SandboxCapability::FsWrite)
+        {
+            return Err(SandboxError::InvalidPolicy(
+                "fs_allow_list provided but no FsRead/FsWrite capability granted".into(),
+            ));
+        }
+        // Net allow list requires Net capability.
+        if !self.net_allow_list.is_empty() && !self.grants(SandboxCapability::Net) {
+            return Err(SandboxError::InvalidPolicy(
+                "net_allow_list provided but Net capability not granted".into(),
+            ));
+        }
+        // Env allow list requires EnvRead.
+        if !self.env_allow_list.is_empty() && !self.grants(SandboxCapability::EnvRead) {
+            return Err(SandboxError::InvalidPolicy(
+                "env_allow_list provided but EnvRead capability not granted".into(),
+            ));
+        }
+        // Subprocess allow list requires Subprocess.
+        if !self.subprocess_allow_list.is_empty() && !self.grants(SandboxCapability::Subprocess) {
+            return Err(SandboxError::InvalidPolicy(
+                "subprocess_allow_list provided but Subprocess capability not granted".into(),
+            ));
+        }
+        self.resource_limits.validate()
+    }
+
+    fn capability_names(&self) -> Vec<String> {
+        self.allowed_capabilities
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect()
+    }
+}
+
+/// Builder for [`SandboxPolicy`].
+#[derive(Debug, Default)]
+pub struct SandboxPolicyBuilder {
+    allowed_capabilities: BTreeSet<SandboxCapability>,
+    fs_allow_list: Vec<PathPattern>,
+    net_allow_list: Vec<NetEndpoint>,
+    env_allow_list: Vec<String>,
+    subprocess_allow_list: Vec<String>,
+    resource_limits: Option<SandboxResourceLimits>,
+}
+
+impl SandboxPolicyBuilder {
+    #[must_use]
+    pub fn allow(mut self, cap: SandboxCapability) -> Self {
+        self.allowed_capabilities.insert(cap);
+        self
+    }
+
+    #[must_use]
+    pub fn allow_many<I: IntoIterator<Item = SandboxCapability>>(mut self, caps: I) -> Self {
+        self.allowed_capabilities.extend(caps);
+        self
+    }
+
+    #[must_use]
+    pub fn allow_fs(mut self, pattern: PathPattern) -> Self {
+        self.fs_allow_list.push(pattern);
+        self
+    }
+
+    #[must_use]
+    pub fn allow_net(mut self, endpoint: NetEndpoint) -> Self {
+        self.net_allow_list.push(endpoint);
+        self
+    }
+
+    #[must_use]
+    pub fn allow_env(mut self, name: impl Into<String>) -> Self {
+        self.env_allow_list.push(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn allow_subprocess(mut self, program: impl Into<String>) -> Self {
+        self.subprocess_allow_list.push(program.into());
+        self
+    }
+
+    #[must_use]
+    pub fn resource_limits(mut self, limits: SandboxResourceLimits) -> Self {
+        self.resource_limits = Some(limits);
+        self
+    }
+
+    pub fn build(self) -> SandboxResult<SandboxPolicy> {
+        let policy = SandboxPolicy {
+            allowed_capabilities: self.allowed_capabilities,
+            fs_allow_list: self.fs_allow_list,
+            net_allow_list: self.net_allow_list,
+            env_allow_list: self.env_allow_list,
+            subprocess_allow_list: self.subprocess_allow_list,
+            resource_limits: self.resource_limits.unwrap_or_default(),
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn tmp_path() -> PathBuf {
+        PathBuf::from("/tmp/mofa-sandbox-test")
+    }
+
+    #[test]
+    fn denied_by_default_grants_only_compute() {
+        let p = SandboxPolicy::denied_by_default();
+        assert!(p.grants(SandboxCapability::Compute));
+        for c in [
+            SandboxCapability::FsRead,
+            SandboxCapability::FsWrite,
+            SandboxCapability::Net,
+            SandboxCapability::EnvRead,
+            SandboxCapability::Subprocess,
+            SandboxCapability::Clock,
+            SandboxCapability::RandomRead,
+        ] {
+            assert!(!p.grants(c), "{c:?} should be denied");
+        }
+    }
+
+    #[test]
+    fn trusted_grants_everything() {
+        let p = SandboxPolicy::trusted();
+        for c in [
+            SandboxCapability::FsRead,
+            SandboxCapability::FsWrite,
+            SandboxCapability::Net,
+            SandboxCapability::EnvRead,
+            SandboxCapability::Subprocess,
+            SandboxCapability::Compute,
+            SandboxCapability::Clock,
+            SandboxCapability::RandomRead,
+        ] {
+            assert!(p.grants(c));
+        }
+    }
+
+    #[test]
+    fn fs_allow_list_requires_capability() {
+        let err = SandboxPolicy::builder()
+            .allow_fs(PathPattern::Exact(tmp_path()))
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SandboxError::InvalidPolicy(_)));
+    }
+
+    #[test]
+    fn fs_check_denies_unlisted_path() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::FsRead)
+            .allow_fs(PathPattern::Exact(tmp_path()))
+            .build()
+            .unwrap();
+        let err = p
+            .check_fs("cat", Path::new("/etc/passwd"), false)
+            .unwrap_err();
+        assert!(matches!(err, SandboxError::PathNotAllowed { .. }));
+    }
+
+    #[test]
+    fn fs_check_accepts_listed_path() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::FsRead)
+            .allow_fs(PathPattern::Exact(tmp_path()))
+            .build()
+            .unwrap();
+        assert!(p.check_fs("cat", &tmp_path(), false).is_ok());
+    }
+
+    #[test]
+    fn fs_prefix_covers_subtree() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::FsRead)
+            .allow_fs(PathPattern::Prefix(PathBuf::from("/tmp/scratch")))
+            .build()
+            .unwrap();
+        assert!(
+            p.check_fs("cat", Path::new("/tmp/scratch/nested/file"), false)
+                .is_ok()
+        );
+        assert!(
+            p.check_fs("cat", Path::new("/tmp/other"), false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn fs_write_without_write_cap_is_denied() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::FsRead)
+            .allow_fs(PathPattern::Exact(tmp_path()))
+            .build()
+            .unwrap();
+        let err = p.check_fs("writer", &tmp_path(), true).unwrap_err();
+        assert!(matches!(err, SandboxError::CapabilityDenied { .. }));
+    }
+
+    #[test]
+    fn net_allow_host_port() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::Net)
+            .allow_net(NetEndpoint::HostPort {
+                host: "api.openai.com".into(),
+                port: 443,
+            })
+            .build()
+            .unwrap();
+        assert!(p.check_net("http", "api.openai.com", 443).is_ok());
+        assert!(p.check_net("http", "api.openai.com", 80).is_err());
+        assert!(p.check_net("http", "evil.com", 443).is_err());
+    }
+
+    #[test]
+    fn net_host_any_port() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::Net)
+            .allow_net(NetEndpoint::HostAnyPort {
+                host: "localhost".into(),
+            })
+            .build()
+            .unwrap();
+        assert!(p.check_net("http", "localhost", 8080).is_ok());
+        assert!(p.check_net("http", "localhost", 22).is_ok());
+        assert!(p.check_net("http", "other", 8080).is_err());
+    }
+
+    #[test]
+    fn env_check_requires_allow_list_entry() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::EnvRead)
+            .allow_env("OPENAI_API_KEY")
+            .build()
+            .unwrap();
+        assert!(p.check_env("OPENAI_API_KEY").is_ok());
+        assert!(p.check_env("SECRET").is_err());
+    }
+
+    #[test]
+    fn subprocess_check_enforces_allow_list() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::Subprocess)
+            .allow_subprocess("python3")
+            .build()
+            .unwrap();
+        assert!(p.check_subprocess("runner", "python3").is_ok());
+        assert!(p.check_subprocess("runner", "bash").is_err());
+    }
+
+    #[test]
+    fn resource_limits_reject_cpu_exceeding_wall() {
+        let err = SandboxPolicy::builder()
+            .resource_limits(SandboxResourceLimits {
+                wall_timeout: Some(Duration::from_secs(5)),
+                cpu_time_limit: Some(Duration::from_secs(10)),
+                ..Default::default()
+            })
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SandboxError::InvalidPolicy(_)));
+    }
+
+    #[test]
+    fn resource_limits_reject_zero_memory() {
+        let err = SandboxPolicy::builder()
+            .resource_limits(SandboxResourceLimits {
+                memory_limit_bytes: Some(0),
+                ..Default::default()
+            })
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, SandboxError::InvalidPolicy(_)));
+    }
+
+    #[test]
+    fn path_pattern_exact_match() {
+        let p = PathPattern::Exact(PathBuf::from("/a/b"));
+        assert!(p.matches(Path::new("/a/b")));
+        assert!(!p.matches(Path::new("/a/b/c")));
+    }
+
+    #[test]
+    fn path_pattern_prefix_match() {
+        let p = PathPattern::Prefix(PathBuf::from("/a"));
+        assert!(p.matches(Path::new("/a")));
+        assert!(p.matches(Path::new("/a/b/c")));
+        assert!(!p.matches(Path::new("/b")));
+    }
+
+    #[test]
+    fn compute_implicit_even_without_listing() {
+        let p = SandboxPolicy::denied_by_default();
+        assert!(p.grants(SandboxCapability::Compute));
+    }
+
+    #[test]
+    fn policy_json_roundtrip() {
+        let p = SandboxPolicy::builder()
+            .allow(SandboxCapability::FsRead)
+            .allow_fs(PathPattern::Exact(tmp_path()))
+            .build()
+            .unwrap();
+        let s = serde_json::to_string(&p).unwrap();
+        let parsed: SandboxPolicy = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, p);
+    }
+}

--- a/crates/mofa-kernel/src/agent/components/sandbox/traits.rs
+++ b/crates/mofa-kernel/src/agent/components/sandbox/traits.rs
@@ -1,0 +1,499 @@
+//! Sandbox trait contracts
+//!
+//! Backend-agnostic interface for sandboxed tool execution.
+//!
+//! ```text
+//!            ┌────────────────────────────────────────┐
+//!            │                Tool                     │
+//!            │  (from agent::components::tool::Tool)   │
+//!            └──────────────────┬─────────────────────┘
+//!                               │
+//!                               │ wrapped by
+//!                               ▼
+//!            ┌────────────────────────────────────────┐
+//!            │          SandboxedTool<T>               │
+//!            │                                         │
+//!            │  ┌─────────┐   ┌──────────────────┐    │
+//!            │  │  tool   │──▶│   ToolSandbox    │    │
+//!            │  └─────────┘   │   (trait obj)    │    │
+//!            │                └─────────┬────────┘    │
+//!            │                          │              │
+//!            │                          ▼              │
+//!            │          ┌───────────────────────┐     │
+//!            │          │    SandboxPolicy      │     │
+//!            │          └───────────────────────┘     │
+//!            └────────────────────────────────────────┘
+//!                               │
+//!                               │ dispatches to one of
+//!                               ▼
+//!          ┌───────────┬───────────────┬────────────┐
+//!          │           │               │            │
+//!          ▼           ▼               ▼            ▼
+//!      NullSandbox  ProcessSandbox  WasmtimeSbx   (custom)
+//!       (trusted)   (foundation)    (foundation)  (user)
+//! ```
+
+use super::error::{SandboxError, SandboxResult};
+use super::policy::SandboxPolicy;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A tiered classification of the isolation strength offered by a backend.
+///
+/// This is advisory metadata — callers can surface it in audit logs or use
+/// it to refuse a particular backend for high-risk tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum SandboxTier {
+    /// No isolation at all. Pass-through execution; policy is checked but
+    /// never enforced on the tool's host-side syscalls.
+    None,
+    /// OS-level isolation via a separate process with resource limits.
+    /// Defends against accidental misuse; not a hermetic boundary against
+    /// sophisticated adversaries without additional kernel-level isolation.
+    Process,
+    /// Hermetic language-VM isolation (wasmtime).  Denies all syscalls by
+    /// default and requires explicit host function imports for I/O.
+    LanguageVm,
+    /// Full OS-level virtualization (containers, microVMs). Reserved for
+    /// downstream backends; the in-tree backends stop at `LanguageVm`.
+    Virtualized,
+}
+
+impl SandboxTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SandboxTier::None => "None",
+            SandboxTier::Process => "Process",
+            SandboxTier::LanguageVm => "LanguageVm",
+            SandboxTier::Virtualized => "Virtualized",
+        }
+    }
+}
+
+/// Metrics captured by a sandbox for a single tool invocation.
+///
+/// Backends populate the fields they can observe; unsupported fields stay
+/// `None`. This is the observability surface that downstream audit logs
+/// and telemetry exporters consume.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SandboxExecutionStats {
+    /// Wall-clock time elapsed in the sandbox.
+    pub wall_time_ms: Option<u64>,
+    /// CPU time (user+sys) consumed inside the sandbox.
+    pub cpu_time_ms: Option<u64>,
+    /// Peak resident memory observed.
+    pub peak_memory_bytes: Option<u64>,
+    /// Bytes read from stdin / inputs.
+    pub input_bytes: Option<u64>,
+    /// Bytes of captured output.
+    pub output_bytes: Option<u64>,
+    /// Count of capability-denial events intercepted during execution.
+    /// Useful for flagging misbehaving tools that consistently probe the
+    /// policy boundary.
+    pub denials: u32,
+}
+
+/// A structured, capability-annotated request to run a tool inside a sandbox.
+///
+/// This is the *input* half of the sandbox contract. The tool's business
+/// arguments travel as opaque JSON; the sandbox only cares about
+/// identifying the tool and knowing which capabilities the invocation will
+/// exercise (hint — backends may use this for up-front denial before
+/// entering the isolate at all).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxRequest {
+    /// The tool's unique name (matches `Tool::name()`).
+    pub tool_name: String,
+    /// Serialized JSON arguments passed through to the tool unchanged.
+    pub arguments: serde_json::Value,
+    /// Capabilities the invocation is declared to require.
+    ///
+    /// This is a hint to the sandbox for fast-path denial. If a tool
+    /// attempts an operation it did not declare here and the policy does
+    /// not grant that capability, the sandbox still denies at runtime.
+    pub declared_capabilities: Vec<super::policy::SandboxCapability>,
+}
+
+impl SandboxRequest {
+    pub fn new(tool_name: impl Into<String>, arguments: serde_json::Value) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            arguments,
+            declared_capabilities: Vec::new(),
+        }
+    }
+
+    pub fn with_capability(mut self, cap: super::policy::SandboxCapability) -> Self {
+        self.declared_capabilities.push(cap);
+        self
+    }
+}
+
+/// Successful output of a sandboxed tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxResponse {
+    /// Tool output (opaque JSON, shape defined by the tool).
+    pub output: serde_json::Value,
+    /// Execution statistics from the sandbox.
+    pub stats: SandboxExecutionStats,
+}
+
+/// The core backend-agnostic trait implemented by every sandbox backend.
+///
+/// Implementors are typically concrete types in `mofa-foundation` such as
+/// `NullSandbox`, `ProcessSandbox`, and `WasmtimeSandbox`. The kernel only
+/// defines the contract here.
+#[async_trait]
+pub trait ToolSandbox: Send + Sync {
+    /// A short name for the backend (used in telemetry and logs).
+    fn name(&self) -> &str;
+
+    /// Declared isolation tier.  Implementations must not overstate this —
+    /// a pass-through `NullSandbox` must return [`SandboxTier::None`].
+    fn tier(&self) -> SandboxTier;
+
+    /// The policy this backend will enforce.
+    fn policy(&self) -> &SandboxPolicy;
+
+    /// Run a single tool invocation through the sandbox.
+    ///
+    /// The sandbox is responsible for:
+    /// 1. Applying fast-path capability denial based on
+    ///    `req.declared_capabilities`.
+    /// 2. Entering the isolate (fork, wasmtime instantiation, ...).
+    /// 3. Passing `req.arguments` to the tool and capturing the output.
+    /// 4. Enforcing resource limits during execution.
+    /// 5. Returning either `SandboxResponse` with stats, or a
+    ///    categorised `SandboxError`.
+    async fn execute(&self, req: SandboxRequest) -> SandboxResult<SandboxResponse>;
+
+    /// Best-effort precheck — returns `Ok(())` if the declared capabilities
+    /// on `req` are all permitted by this backend's policy, otherwise the
+    /// specific denial. This does not run the tool.
+    ///
+    /// Default implementation walks `req.declared_capabilities` against
+    /// [`SandboxPolicy::grants`].
+    fn precheck(&self, req: &SandboxRequest) -> SandboxResult<()> {
+        for cap in &req.declared_capabilities {
+            if !self.policy().grants(*cap) {
+                return Err(SandboxError::CapabilityDenied {
+                    tool: req.tool_name.clone(),
+                    capability: cap.as_str().into(),
+                    allowed: self
+                        .policy()
+                        .allowed_capabilities()
+                        .iter()
+                        .map(|c| c.as_str().to_string())
+                        .collect(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Decision emitted by a [`SandboxObserver`] for a single request.
+///
+/// Observers are read-mostly: they receive notifications and can emit an
+/// advisory `Decision` for audit trails, but the sandbox backend does the
+/// actual allow/deny.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservationDecision {
+    Allowed,
+    Denied,
+    ResourceBreach,
+    BackendError,
+}
+
+/// Hook invoked before and after every sandboxed execution.
+///
+/// Intended for audit logging, metrics export, and policy-drift detection.
+/// Implementors must be fast — observers run on the critical path.
+#[async_trait]
+pub trait SandboxObserver: Send + Sync {
+    /// Called before the sandbox attempts to run `req`.
+    async fn before(&self, backend: &str, tier: SandboxTier, req: &SandboxRequest);
+
+    /// Called after execution (success or failure).
+    async fn after(
+        &self,
+        backend: &str,
+        tier: SandboxTier,
+        req: &SandboxRequest,
+        decision: ObservationDecision,
+        stats: &SandboxExecutionStats,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::policy::{SandboxCapability, SandboxPolicy};
+    use super::*;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Minimal in-kernel sandbox implementation used solely to exercise
+    /// the trait contract end-to-end in tests. Real backends live in
+    /// `mofa-foundation` per the microkernel layering rule.
+    struct PassthroughSandbox {
+        policy: SandboxPolicy,
+    }
+
+    #[async_trait]
+    impl ToolSandbox for PassthroughSandbox {
+        fn name(&self) -> &str {
+            "passthrough-test"
+        }
+        fn tier(&self) -> SandboxTier {
+            SandboxTier::None
+        }
+        fn policy(&self) -> &SandboxPolicy {
+            &self.policy
+        }
+        async fn execute(&self, req: SandboxRequest) -> SandboxResult<SandboxResponse> {
+            self.precheck(&req)?;
+            // Echo arguments as output; populate realistic stats so
+            // downstream observability hooks have something to record.
+            let size = req.arguments.to_string().len() as u64;
+            Ok(SandboxResponse {
+                output: req.arguments.clone(),
+                stats: SandboxExecutionStats {
+                    wall_time_ms: Some(1),
+                    cpu_time_ms: Some(1),
+                    input_bytes: Some(size),
+                    output_bytes: Some(size),
+                    ..Default::default()
+                },
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingObserver {
+        before: AtomicU32,
+        after: AtomicU32,
+        last_decision: Mutex<Option<ObservationDecision>>,
+    }
+
+    #[async_trait]
+    impl SandboxObserver for CountingObserver {
+        async fn before(&self, _: &str, _: SandboxTier, _: &SandboxRequest) {
+            self.before.fetch_add(1, Ordering::SeqCst);
+        }
+        async fn after(
+            &self,
+            _: &str,
+            _: SandboxTier,
+            _: &SandboxRequest,
+            decision: ObservationDecision,
+            _: &SandboxExecutionStats,
+        ) {
+            self.after.fetch_add(1, Ordering::SeqCst);
+            *self.last_decision.lock().unwrap() = Some(decision);
+        }
+    }
+
+    // ---------- request / response shaping ----------
+
+    #[test]
+    fn sandbox_request_builder_adds_capabilities() {
+        let req = SandboxRequest::new("calc", serde_json::json!({"x": 1}))
+            .with_capability(SandboxCapability::Compute)
+            .with_capability(SandboxCapability::Clock);
+        assert_eq!(req.declared_capabilities.len(), 2);
+        assert_eq!(req.tool_name, "calc");
+    }
+
+    #[test]
+    fn sandbox_request_is_json_roundtrippable() {
+        let req = SandboxRequest::new("t", serde_json::json!({"a": 1}))
+            .with_capability(SandboxCapability::Compute);
+        let s = serde_json::to_string(&req).unwrap();
+        let parsed: SandboxRequest = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.tool_name, req.tool_name);
+        assert_eq!(parsed.declared_capabilities, req.declared_capabilities);
+    }
+
+    // ---------- precheck ----------
+
+    #[test]
+    fn precheck_rejects_undeclared_capability() {
+        let sb = PassthroughSandbox {
+            policy: SandboxPolicy::denied_by_default(),
+        };
+        let req = SandboxRequest::new("bad", serde_json::json!({}))
+            .with_capability(SandboxCapability::Net);
+        let err = sb.precheck(&req).unwrap_err();
+        assert!(matches!(err, SandboxError::CapabilityDenied { .. }));
+    }
+
+    #[test]
+    fn precheck_allows_implicit_compute() {
+        let sb = PassthroughSandbox {
+            policy: SandboxPolicy::denied_by_default(),
+        };
+        let req = SandboxRequest::new("good", serde_json::json!({}))
+            .with_capability(SandboxCapability::Compute);
+        assert!(sb.precheck(&req).is_ok());
+    }
+
+    #[test]
+    fn precheck_allows_explicit_granted() {
+        let policy = SandboxPolicy::builder()
+            .allow(SandboxCapability::EnvRead)
+            .allow_env("HOME")
+            .build()
+            .unwrap();
+        let sb = PassthroughSandbox { policy };
+        let req = SandboxRequest::new("env", serde_json::json!({}))
+            .with_capability(SandboxCapability::EnvRead);
+        assert!(sb.precheck(&req).is_ok());
+    }
+
+    #[test]
+    fn precheck_reports_allowed_set_in_denial() {
+        let policy = SandboxPolicy::builder()
+            .allow(SandboxCapability::Clock)
+            .build()
+            .unwrap();
+        let sb = PassthroughSandbox { policy };
+        let req = SandboxRequest::new("bad", serde_json::json!({}))
+            .with_capability(SandboxCapability::Net);
+        let err = sb.precheck(&req).unwrap_err();
+        match err {
+            SandboxError::CapabilityDenied { allowed, .. } => {
+                assert!(allowed.contains(&"Clock".to_string()));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // ---------- end-to-end execute round-trip ----------
+
+    #[tokio::test]
+    async fn execute_round_trip_returns_response_with_stats() {
+        let policy = SandboxPolicy::builder()
+            .allow(SandboxCapability::Clock)
+            .build()
+            .unwrap();
+        let sb = PassthroughSandbox { policy };
+        let req = SandboxRequest::new("echo", serde_json::json!({"msg": "hello"}))
+            .with_capability(SandboxCapability::Clock);
+        let resp = sb.execute(req.clone()).await.expect("must succeed");
+        assert_eq!(resp.output, req.arguments);
+        assert_eq!(resp.stats.wall_time_ms, Some(1));
+        assert!(resp.stats.input_bytes.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_denies_undeclared_capability_through_precheck() {
+        let sb = PassthroughSandbox {
+            policy: SandboxPolicy::denied_by_default(),
+        };
+        let req = SandboxRequest::new("evil", serde_json::json!({}))
+            .with_capability(SandboxCapability::Subprocess);
+        let err = sb.execute(req).await.unwrap_err();
+        assert!(err.is_policy_denial());
+    }
+
+    // ---------- observer hook wiring ----------
+
+    #[tokio::test]
+    async fn observer_fires_before_and_after_success() {
+        let observer = CountingObserver::default();
+        let policy = SandboxPolicy::builder()
+            .allow(SandboxCapability::Clock)
+            .build()
+            .unwrap();
+        let sb = PassthroughSandbox { policy };
+        let req = SandboxRequest::new("t", serde_json::json!({}))
+            .with_capability(SandboxCapability::Clock);
+
+        observer.before(sb.name(), sb.tier(), &req).await;
+        let resp = sb.execute(req.clone()).await.unwrap();
+        observer
+            .after(
+                sb.name(),
+                sb.tier(),
+                &req,
+                ObservationDecision::Allowed,
+                &resp.stats,
+            )
+            .await;
+
+        assert_eq!(observer.before.load(Ordering::SeqCst), 1);
+        assert_eq!(observer.after.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *observer.last_decision.lock().unwrap(),
+            Some(ObservationDecision::Allowed)
+        );
+    }
+
+    #[tokio::test]
+    async fn observer_records_denial() {
+        let observer = CountingObserver::default();
+        let sb = PassthroughSandbox {
+            policy: SandboxPolicy::denied_by_default(),
+        };
+        let req = SandboxRequest::new("t", serde_json::json!({}))
+            .with_capability(SandboxCapability::Net);
+
+        observer.before(sb.name(), sb.tier(), &req).await;
+        let err = sb.execute(req.clone()).await.unwrap_err();
+        observer
+            .after(
+                sb.name(),
+                sb.tier(),
+                &req,
+                ObservationDecision::Denied,
+                &SandboxExecutionStats::default(),
+            )
+            .await;
+
+        assert!(err.is_policy_denial());
+        assert_eq!(
+            *observer.last_decision.lock().unwrap(),
+            Some(ObservationDecision::Denied)
+        );
+    }
+
+    // ---------- tier semantics ----------
+
+    #[test]
+    fn tier_ordering_reflects_isolation_strength() {
+        assert!(SandboxTier::None < SandboxTier::Process);
+        assert!(SandboxTier::Process < SandboxTier::LanguageVm);
+        assert!(SandboxTier::LanguageVm < SandboxTier::Virtualized);
+    }
+
+    #[test]
+    fn tier_as_str_is_non_empty_for_every_variant() {
+        for t in [
+            SandboxTier::None,
+            SandboxTier::Process,
+            SandboxTier::LanguageVm,
+            SandboxTier::Virtualized,
+        ] {
+            assert!(!t.as_str().is_empty());
+        }
+    }
+
+    // ---------- combinatorial capability coverage ----------
+
+    #[test]
+    fn every_capability_has_consistent_display_and_as_str() {
+        for cap in SandboxCapability::iter_all() {
+            let s1 = cap.as_str();
+            let s2 = format!("{cap}");
+            assert_eq!(s1, s2);
+        }
+    }
+
+    #[test]
+    fn capability_iter_all_is_comprehensive() {
+        // If a new capability is added, iter_all must be updated and this
+        // test re-counted.  Currently 8 concrete variants.
+        assert_eq!(SandboxCapability::iter_all().count(), 8);
+    }
+}

--- a/docs/tool-sandbox.md
+++ b/docs/tool-sandbox.md
@@ -1,0 +1,292 @@
+# Tool Execution Sandbox
+
+Capability-scoped, resource-limited execution for untrusted tools invoked by
+LLMs. Tracks GSoC ideas-list Task 34. This document covers the kernel-level
+trait contracts and policy model; concrete backends live in
+`mofa-foundation`.
+
+---
+
+## Motivation
+
+LLM-called tools execute inside the agent process. Today, a compromised or
+malicious tool has the same privileges as the agent: it can read any file
+the user can read, open outbound network connections, spawn subprocesses,
+and exfiltrate environment variables. That posture is unsustainable once
+tools arrive from third-party plugin registries, MCP servers, or prompt-
+induced code paths.
+
+The sandbox mediates three questions at every tool call:
+
+```mermaid
+flowchart LR
+    A[Tool invocation] --> Q1{May tool<br/>read/write<br/>this path?}
+    A --> Q2{May tool<br/>reach<br/>this host:port?}
+    A --> Q3{Within CPU,<br/>memory, and<br/>wall-time caps?}
+    Q1 -- no --> D1[PathNotAllowed]
+    Q2 -- no --> D2[NetworkNotAllowed]
+    Q3 -- no --> D3[Resource breach]
+    Q1 -- yes --> X[Proceed]
+    Q2 -- yes --> X
+    Q3 -- yes --> X
+```
+
+---
+
+## Layered architecture
+
+The kernel owns trait contracts only; foundation owns concrete backends.
+
+```mermaid
+flowchart TB
+    subgraph Agent [mofa-foundation]
+        AL[Agent Loop]
+        ST[SandboxedTool&lt;T&gt;]
+        AL -->|ToolInput| ST
+    end
+
+    subgraph Kernel [mofa-kernel]
+        TSB[trait ToolSandbox<br/><br/>policy / tier<br/>precheck / execute]
+        ST -->|SandboxRequest| TSB
+    end
+
+    subgraph Backends [mofa-foundation backends]
+        NB[NullSandbox<br/>Tier: None]
+        PB[ProcessSandbox<br/>Tier: Process]
+        WB[WasmtimeSandbox<br/>Tier: LanguageVm]
+    end
+
+    TSB --> NB
+    TSB --> PB
+    TSB --> WB
+```
+
+---
+
+## Policy model
+
+Policies are default-deny. The base capability set is empty except for
+implicit `Compute`; every other capability must be listed and, where
+applicable, combined with a fine-grained allow-list.
+
+```mermaid
+classDiagram
+    class SandboxPolicy {
+        +allowed_capabilities: BTreeSet~SandboxCapability~
+        +fs_allow_list: Vec~PathPattern~
+        +net_allow_list: Vec~NetEndpoint~
+        +env_allow_list: Vec~String~
+        +subprocess_allow_list: Vec~String~
+        +resource_limits: SandboxResourceLimits
+        +grants(cap) bool
+        +check_fs(tool, path, write) Result
+        +check_net(tool, host, port) Result
+        +check_env(name) Result
+        +check_subprocess(tool, program) Result
+        +validate() Result
+    }
+    class SandboxCapability {
+        <<enumeration>>
+        FsRead
+        FsWrite
+        Net
+        EnvRead
+        Subprocess
+        Compute
+        Clock
+        RandomRead
+    }
+    class PathPattern {
+        <<enumeration>>
+        Exact(PathBuf)
+        Prefix(PathBuf)
+    }
+    class NetEndpoint {
+        <<enumeration>>
+        HostPort
+        HostAnyPort
+    }
+    class SandboxResourceLimits {
+        +wall_timeout: Option~Duration~
+        +cpu_time_limit: Option~Duration~
+        +memory_limit_bytes: Option~u64~
+        +output_limit_bytes: Option~u64~
+        +max_open_files: Option~u32~
+    }
+    SandboxPolicy --> SandboxCapability
+    SandboxPolicy --> PathPattern
+    SandboxPolicy --> NetEndpoint
+    SandboxPolicy --> SandboxResourceLimits
+```
+
+### Capability gating
+
+| Capability | Fine-grained gate |
+|------------|-------------------|
+| `FsRead` | `fs_allow_list` (`Vec<PathPattern>`) |
+| `FsWrite` | `fs_allow_list` |
+| `Net` | `net_allow_list` (`Vec<NetEndpoint>`) |
+| `EnvRead` | `env_allow_list` (`Vec<String>`) |
+| `Subprocess` | `subprocess_allow_list` (`Vec<String>`) |
+| `Compute` | implicit, always granted |
+| `Clock` | — |
+| `RandomRead` | — |
+
+---
+
+## Execution flow
+
+```mermaid
+sequenceDiagram
+    participant Caller as SandboxedTool
+    participant SB as ToolSandbox impl
+    participant Policy as SandboxPolicy
+    participant Tool as Tool
+
+    Caller->>SB: execute(SandboxRequest)
+    SB->>Policy: precheck(declared_capabilities)
+    alt undeclared capability
+        Policy-->>SB: Err(CapabilityDenied)
+        SB-->>Caller: SandboxError
+    else granted
+        Policy-->>SB: Ok
+        SB->>Tool: run inside isolate
+        Tool-->>SB: output
+        SB->>Policy: check_fs / check_net / check_env
+        alt policy violation
+            Policy-->>SB: Err(PathNotAllowed | ...)
+            SB-->>Caller: SandboxError
+        else resource breach
+            SB-->>Caller: Err(WallTimeout | MemoryExceeded | ...)
+        else success
+            SB-->>Caller: Ok(SandboxResponse { output, stats })
+        end
+    end
+```
+
+---
+
+## Error taxonomy
+
+Three disjoint failure classes with distinct retry semantics.
+
+```mermaid
+flowchart LR
+    E[SandboxError] --> PD[Policy denial]
+    E --> RB[Resource breach]
+    E --> BF[Backend failure]
+
+    PD --> PD1[CapabilityDenied]
+    PD --> PD2[PathNotAllowed]
+    PD --> PD3[NetworkNotAllowed]
+    PD --> PD4[EnvVarNotAllowed]
+    PD --> PD5[SubprocessNotAllowed]
+
+    RB --> RB1[CpuTimeExceeded]
+    RB --> RB2[WallTimeout]
+    RB --> RB3[MemoryExceeded]
+    RB --> RB4[OutputTooLarge]
+
+    BF --> BF1[BackendFailure]
+    BF --> BF2[SandboxCrashed]
+    BF --> BF3[IoError]
+
+    PD -.->|not retryable| X[Retry?]
+    RB -.->|not retryable| X
+    BF -.->|maybe retryable| X
+```
+
+`SandboxError::is_policy_denial()`, `is_resource_limit()`, and
+`is_backend_failure()` let retry middleware branch on error class.
+
+---
+
+## Tiers of isolation
+
+```mermaid
+flowchart TB
+    T0[Tier: None<br/>Pass-through<br/>policy checked but not enforced]
+    T1[Tier: Process<br/>OS process + rlimit]
+    T2[Tier: LanguageVm<br/>Hermetic wasmtime]
+    T3[Tier: Virtualized<br/>Containers / microVMs<br/><i>downstream backends</i>]
+
+    T0 --> T1 --> T2 --> T3
+```
+
+`SandboxTier` derives `Ord`; callers can reject backends below a required
+isolation threshold in a single comparison.
+
+---
+
+## Usage
+
+```rust
+use std::path::PathBuf;
+use std::time::Duration;
+use mofa_kernel::agent::components::sandbox::{
+    NetEndpoint, PathPattern, SandboxCapability, SandboxPolicy,
+    SandboxResourceLimits,
+};
+
+let policy = SandboxPolicy::builder()
+    .allow(SandboxCapability::FsRead)
+    .allow_fs(PathPattern::Prefix(PathBuf::from("/tmp/tool-scratch")))
+    .allow(SandboxCapability::Net)
+    .allow_net(NetEndpoint::HostPort {
+        host: "api.openai.com".into(),
+        port: 443,
+    })
+    .resource_limits(SandboxResourceLimits {
+        wall_timeout: Some(Duration::from_secs(10)),
+        memory_limit_bytes: Some(128 * 1024 * 1024),
+        ..Default::default()
+    })
+    .build()
+    .unwrap();
+```
+
+---
+
+## Observability
+
+Every sandboxed call yields `SandboxExecutionStats`:
+
+```mermaid
+classDiagram
+    class SandboxExecutionStats {
+        +wall_time_ms: Option~u64~
+        +cpu_time_ms: Option~u64~
+        +peak_memory_bytes: Option~u64~
+        +input_bytes: Option~u64~
+        +output_bytes: Option~u64~
+        +denials: u32
+    }
+    class SandboxObserver {
+        <<trait>>
+        +before(backend, tier, request) async
+        +after(backend, tier, request, decision, stats) async
+    }
+    SandboxObserver ..> SandboxExecutionStats
+```
+
+`SandboxObserver` is an async hook fired before and after every execution,
+suitable for audit-log append, Prometheus metric emission, and policy-drift
+detection.
+
+---
+
+## Status
+
+- Kernel trait contracts and policy model — this change
+- Foundation backends (`NullSandbox`, `ProcessSandbox`, `WasmtimeSandbox`),
+  `SandboxedTool<T>` wrapper, integration tests, runnable example —
+  follow-up
+- Prometheus sandbox metrics exporter — follow-up
+
+---
+
+## References
+
+- `mofa-kernel::agent::components::sandbox`
+- OWASP Tool Sandbox design pattern
+- Capability-based security (principle of least authority)


### PR DESCRIPTION
## Summary

Kernel-layer trait contracts and policy model for tool-execution sandboxing (Task 34).  LLM-called tools presently run with full host privilege; this PR introduces the capability-scoped, resource-limited execution contract that concrete backends (`NullSandbox`, `ProcessSandbox`, `WasmtimeSandbox`) will implement in `mofa-foundation` in a follow-up.

The existing `mofa-plugins::wasm_runtime` isolates *plugins*.  This work isolates *tools* — the distinction matters because tool invocations are driven by LLM output at runtime and therefore cross a trust boundary on every call.

## Layered architecture

<img width="615" height="536" alt="Screenshot 2026-04-22 at 12 24 23 AM" src="https://github.com/user-attachments/assets/2dd643eb-5c2e-4472-a288-e37879dfa528" />

## Policy model

Policies are default-deny.  The base capability set is empty except for implicit `Compute`.

<img width="1055" height="648" alt="Screenshot 2026-04-22 at 12 26 21 AM" src="https://github.com/user-attachments/assets/4e4c96a9-5c9a-49c8-b28e-86405f260a61" />

Coarse capabilities are combined with fine-grained allow-lists — e.g. `FsRead` only grants access to paths listed in `fs_allow_list` as `Exact(p)` or `Prefix(dir)`.  Capabilities and allow-list types are deliberately scope-prefixed (`SandboxCapability`, `SandboxResourceLimits`) to avoid collision with `PluginCapability` and `ResourceLimits` that already exist in `mofa-plugins::wasm_runtime` for a different domain.

## Execution flow

<img width="702" height="645" alt="Screenshot 2026-04-22 at 12 27 12 AM" src="https://github.com/user-attachments/assets/d574a6b0-105a-4053-aea9-9eb19f21c845" />


## Error taxonomy

Three disjoint failure classes with distinct retry semantics.

<img width="612" height="676" alt="Screenshot 2026-04-22 at 12 28 05 AM" src="https://github.com/user-attachments/assets/5a54606f-892a-4328-89d5-4de77668803a" />

`SandboxError` exposes `is_policy_denial()`, `is_resource_limit()`, and `is_backend_failure()` so retry middleware can branch on class without pattern-matching every variant.

## Isolation tiers

<img width="505" height="601" alt="Screenshot 2026-04-22 at 12 29 17 AM" src="https://github.com/user-attachments/assets/8ee1201d-13dc-4ee9-97a3-172da9086f9b" />

`SandboxTier` derives `Ord`, so callers can require a minimum tier in a single comparison.

## Observability surface

Every sandboxed call yields `SandboxExecutionStats`.  A `SandboxObserver` async hook fires before and after every execution for audit logging, metric emission, and policy-drift detection.

<img width="649" height="612" alt="Screenshot 2026-04-22 at 12 36 13 AM" src="https://github.com/user-attachments/assets/09adfb05-0c28-48be-b8bb-926798767063" />

## Architecture adherence

Follows the project microkernel layering rules:

- Kernel layer holds trait definitions and data types only; no concrete backends.
- `#[non_exhaustive]` on every public enum.
- Unified error system via `thiserror`; `From<SandboxError> for AgentError` preserves the policy / resource / backend classification.
- `#[must_use]` on every builder method; builder `.build()` runs full policy validation and returns `Result`.
- `SandboxCapability` / `SandboxResourceLimits` are scope-prefixed to avoid collision with the plugin-runtime domain types.

## Test coverage

- Policy invariants: capability gating, fine-grained allow-lists for FS / Net / Env / Subprocess, resource-limit consistency, JSON round-trip.
- Error classification: `is_policy_denial` / `is_resource_limit` / `is_backend_failure` partitioning, `From<SandboxError> for AgentError` mapping including timeout duration preservation.
- Trait contract: in-test `PassthroughSandbox` exercises `precheck` and `execute` round-trip; `CountingObserver` verifies observer hook ordering on both success and denial paths.
- Tier ordering and combinatorial capability walk via `SandboxCapability::iter_all()`.
- Runnable doctest on `SandboxPolicy::builder`.

## Follow-ups

- [ ] `nityam/tool-sandbox-foundation` — `NullSandbox` / `ProcessSandbox` / `WasmtimeSandbox`, `SandboxedTool<T>` wrapper, integration tests, runnable example demonstrating an untrusted tool being blocked from network and filesystem exfiltration.
- [ ] Prometheus exporter for sandbox denial and resource-breach counters.

## Test plan

- [x] `cargo check -p mofa-kernel`
- [x] `cargo test -p mofa-kernel sandbox` — unit tests
- [x] `cargo test -p mofa-kernel --doc sandbox` — doctest
- [ ] `cargo test` workspace (CI)
- [ ] `cargo clippy` (CI)