### PR TITLE
Refactor ssrf implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,6 +5968,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/mofa-foundation/src/agent/tools/builtin.rs
+++ b/crates/mofa-foundation/src/agent/tools/builtin.rs
@@ -29,13 +29,23 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use mofa_kernel::agent::components::tool::{ToolInput, ToolMetadata, ToolResult};
 use serde_json::json;
+use std::sync::LazyLock;
 use tokio::io::AsyncWriteExt as _;
 
 use crate::agent::components::tool::{SimpleTool, ToolCategory};
+use mofa_kernel::security::network::NetworkSecurity;
 
 // ============================================================================
 // HttpTool
 // ============================================================================
+
+static HTTP_TOOL_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        // Avoid following redirects to internal/private networks.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("failed to build HttpTool HTTP client")
+});
 
 /// Make HTTP GET or POST requests and return the response body.
 ///
@@ -95,8 +105,14 @@ impl SimpleTool for HttpTool {
             None => return ToolResult::failure("missing required parameter: url"),
         };
 
+        if !NetworkSecurity::is_url_allowed(&url) {
+            return ToolResult::failure(format!(
+                "access denied: URL '{url}' targets a blocked address (private/internal network or disallowed scheme)"
+            ));
+        }
+
         let method = input.get_str("method").unwrap_or("GET").to_uppercase();
-        let client = reqwest::Client::new();
+        let client = &*HTTP_TOOL_CLIENT;
 
         let mut builder = match method.as_str() {
             "GET" => client.get(&url),

--- a/crates/mofa-foundation/src/coordination/tests.rs
+++ b/crates/mofa-foundation/src/coordination/tests.rs
@@ -97,6 +97,15 @@ mod tests {
         .unwrap();
     }
 
+    async fn subscribe_peer(bus: &AgentBus, id: &str) -> mofa_kernel::bus::MessageReceiver {
+        bus.subscribe(
+            id,
+            CommunicationMode::PointToPoint("coordinator".to_string()),
+        )
+        .await
+        .unwrap()
+    }
+
     // Receive one message for a peer
     async fn receive_peer(
         bus: &AgentBus,

--- a/crates/mofa-foundation/src/hitl/webhook.rs
+++ b/crates/mofa-foundation/src/hitl/webhook.rs
@@ -3,6 +3,7 @@
 //! Reliable webhook delivery with retries and HMAC signatures
 
 use crate::hitl::error::FoundationHitlError;
+use mofa_kernel::security::network::NetworkSecurity;
 use mofa_kernel::hitl::{ReviewRequest, ReviewRequestId};
 use serde_json::json;
 use std::sync::Arc;
@@ -55,6 +56,8 @@ impl WebhookDelivery {
     pub fn new(config: WebhookConfig) -> Self {
         let client = reqwest::Client::builder()
             .timeout(config.timeout)
+            // Avoid following redirects to internal/private networks.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to create HTTP client");
 
@@ -71,6 +74,13 @@ impl WebhookDelivery {
         review: &ReviewRequest,
         event_type: &str,
     ) -> Result<(), FoundationHitlError> {
+        if !NetworkSecurity::is_url_allowed(&self.config.url) {
+            return Err(FoundationHitlError::InvalidConfig(format!(
+                "Access denied: webhook URL '{}' targets a blocked address (private/internal network or disallowed scheme)",
+                self.config.url
+            )));
+        }
+
         let payload = self.create_payload(review, event_type)?;
         let signature = self.create_signature(&payload)?;
 

--- a/crates/mofa-kernel/Cargo.toml
+++ b/crates/mofa-kernel/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 futures.workspace = true
 base64.workspace = true
 chrono.workspace = true
+url = "2.5"
 
 
 # Config parsing

--- a/crates/mofa-kernel/src/security/mod.rs
+++ b/crates/mofa-kernel/src/security/mod.rs
@@ -39,6 +39,7 @@
 //! ```
 
 pub mod moderation;
+pub mod network;
 pub mod policy;
 pub mod rbac;
 pub mod redaction;
@@ -49,6 +50,7 @@ pub use moderation::{ContentModerator, PromptGuard};
 pub use policy::{PolicyBuilder, SecurityPolicy};
 pub use rbac::{AuthorizationResult, Authorizer};
 pub use redaction::{PiiDetector, PiiRedactor, RedactionAuditLog};
+pub use network::NetworkSecurity;
 pub use types::{
     ContentPolicy, ModerationCategory, ModerationVerdict, RedactionMatch, RedactionResult,
     RedactionStrategy, SecurityError, SecurityResult, SensitiveDataCategory,

--- a/crates/mofa-kernel/src/security/network.rs
+++ b/crates/mofa-kernel/src/security/network.rs
@@ -1,0 +1,139 @@
+/// Network security utilities (SSRF prevention).
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+use url::Url;
+
+#[derive(Debug, Clone, Copy)]
+pub struct NetworkSecurity;
+
+impl NetworkSecurity {
+    /// This performs DNS resolution using
+    /// `ToSocketAddrs`. If resolution fails or yields no addresses, the URL is denied.
+    pub fn is_url_allowed(url: &str) -> bool {
+        let parsed = match Url::parse(url) {
+            Ok(u) => u,
+            Err(_) => return false,
+        };
+
+        match parsed.scheme() {
+            "http" | "https" => {}
+            _ => return false,
+        }
+
+        let host = match parsed.host_str() {
+            Some(h) => h,
+            None => return false,
+        };
+
+        if host.eq_ignore_ascii_case("metadata.google.internal") {
+            return false;
+        }
+
+        // IP-literal URLs don't need DNS resolution.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return !Self::is_blocked_ip(&ip);
+        }
+
+        let port = parsed
+            .port()
+            .unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
+
+        let addrs = match (host, port).to_socket_addrs() {
+            Ok(it) => it.collect::<Vec<SocketAddr>>(),
+            Err(_) => return false,
+        };
+
+        if addrs.is_empty() {
+            return false;
+        }
+
+        for addr in addrs {
+            if Self::is_blocked_ip(&addr.ip()) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Returns `true` if the IP is considered unsafe for outbound requests.
+    pub fn is_blocked_ip(ip: &IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(ipv4) => {
+                ipv4.is_private()
+                    || ipv4.is_loopback()
+                    || ipv4.is_unspecified()
+                    || ipv4.is_multicast()
+                    || ipv4.is_link_local()
+                    || ipv4.is_broadcast()
+                    || ipv4.is_documentation()
+                    || Self::is_cgnat_ipv4(*ipv4)
+            }
+            IpAddr::V6(ipv6) => {
+                // Handle IPv4-mapped IPv6 addresses, e.g. ::ffff:127.0.0.1.
+                if let Some(mapped) = ipv6.to_ipv4_mapped() {
+                    return Self::is_blocked_ip(&IpAddr::V4(mapped));
+                }
+
+                ipv6.is_loopback()
+                    || ipv6.is_unspecified()
+                    || ipv6.is_multicast()
+                    || ipv6.is_unique_local()
+                    || ipv6.is_unicast_link_local()
+                    || Self::is_documentation_ipv6(*ipv6)
+            }
+        }
+    }
+
+    fn is_cgnat_ipv4(ipv4: Ipv4Addr) -> bool {
+        // 100.64.0.0/10
+        let [a, b, ..] = ipv4.octets();
+        a == 100 && (64..=127).contains(&b)
+    }
+
+    fn is_documentation_ipv6(ipv6: std::net::Ipv6Addr) -> bool {
+        // 2001:db8::/32
+        let seg = ipv6.segments();
+        seg[0] == 0x2001 && seg[1] == 0x0db8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_loopback_ipv4_url() {
+        assert!(!NetworkSecurity::is_url_allowed("http://127.0.0.1:8080/"));
+    }
+
+    #[test]
+    fn blocks_loopback_ipv6_url() {
+        assert!(!NetworkSecurity::is_url_allowed("http://[::1]:8080/"));
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_loopback_ip() {
+        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        assert!(NetworkSecurity::is_blocked_ip(&ip));
+    }
+
+    #[test]
+    fn blocks_link_local_metadata_ip() {
+        assert!(!NetworkSecurity::is_url_allowed("http://169.254.169.254/latest/meta-data/"));
+    }
+
+    #[test]
+    fn blocks_metadata_hostname_case_insensitively() {
+        assert!(!NetworkSecurity::is_url_allowed(
+            "http://METADATA.GOOGLE.INTERNAL/"
+        ));
+    }
+
+    #[test]
+    fn blocks_non_http_scheme() {
+        assert!(!NetworkSecurity::is_url_allowed("file:///etc/passwd"));
+        assert!(!NetworkSecurity::is_url_allowed("ftp://example.com/"));
+    }
+}
+

--- a/crates/mofa-plugins/src/tools/http.rs
+++ b/crates/mofa-plugins/src/tools/http.rs
@@ -1,8 +1,7 @@
 use super::*;
+use mofa_kernel::security::network::NetworkSecurity;
 use reqwest::Client;
 use serde_json::json;
-use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
-use url::Url;
 
 /// HTTP 请求工具 - 发送网络请求
 /// HTTP request utilities - Send network requests
@@ -70,92 +69,6 @@ impl HttpRequestTool {
         }
         &s[..end]
     }
-
-    /// Validate that a URL is safe to request (not targeting internal/private networks).
-    fn is_url_allowed(url_str: &str) -> bool {
-        let parsed = match Url::parse(url_str) {
-            Ok(u) => u,
-            Err(_) => return false,
-        };
-
-        // Only allow http and https schemes
-        match parsed.scheme() {
-            "http" | "https" => {}
-            _ => return false,
-        }
-
-        let host = match parsed.host_str() {
-            Some(h) => h,
-            None => return false,
-        };
-
-        // Block well-known dangerous hostnames
-        if host.eq_ignore_ascii_case("metadata.google.internal") {
-            return false;
-        }
-
-        // Resolve hostname and check all resulting IPs
-        let port = parsed
-            .port()
-            .unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
-        let socket_addrs = format!("{}:{}", host, port);
-        let addrs: Vec<_> = match socket_addrs.to_socket_addrs() {
-            Ok(a) => a.collect(),
-            Err(_) => return false, // Deny if hostname cannot be resolved
-        };
-
-        if addrs.is_empty() {
-            return false; // Deny if no addresses resolved
-        }
-
-        for addr in addrs {
-            if Self::is_blocked_ip(&addr.ip()) {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Check if an IP address is blocked for security reasons.
-    fn is_blocked_ip(ip: &IpAddr) -> bool {
-        match ip {
-            IpAddr::V4(ipv4) => {
-                ipv4.is_private()
-                    || ipv4.is_loopback()
-                    || ipv4.is_unspecified()
-                    || ipv4.is_multicast()
-                    || ipv4.is_link_local()
-                    || ipv4.is_broadcast()
-                    || ipv4.is_documentation()
-                    || Self::is_cgnat_ipv4(*ipv4)
-            }
-            IpAddr::V6(ipv6) => {
-                // Handle IPv4-mapped IPv6 addresses, e.g. ::ffff:127.0.0.1.
-                if let Some(mapped) = ipv6.to_ipv4_mapped() {
-                    return Self::is_blocked_ip(&IpAddr::V4(mapped));
-                }
-
-                ipv6.is_loopback()
-                    || ipv6.is_unspecified()
-                    || ipv6.is_multicast()
-                    || ipv6.is_unique_local()
-                    || ipv6.is_unicast_link_local()
-                    || Self::is_documentation_ipv6(*ipv6)
-            }
-        }
-    }
-
-    fn is_cgnat_ipv4(ipv4: Ipv4Addr) -> bool {
-        let octets = ipv4.octets();
-        octets[0] == 100 && (64..=127).contains(&octets[1])
-    }
-
-    fn is_documentation_ipv6(ipv6: std::net::Ipv6Addr) -> bool {
-        let segments = ipv6.segments();
-        // 2001:db8::/32
-        segments[0] == 0x2001 && segments[1] == 0x0db8
-    }
 }
 
 #[async_trait::async_trait]
@@ -171,7 +84,7 @@ impl ToolExecutor for HttpRequestTool {
         })?;
 
         // Validate URL to prevent SSRF attacks
-        if !Self::is_url_allowed(url) {
+        if !NetworkSecurity::is_url_allowed(url) {
             return Err(mofa_kernel::plugin::PluginError::ExecutionFailed(format!(
                 "Access denied: URL '{}' targets a blocked address (private/internal network or disallowed scheme)",
                 url
@@ -278,29 +191,21 @@ mod tests {
         assert!(result.is_char_boundary(result.len()));
     }
 
-    #[test]
-    fn blocks_ipv4_mapped_loopback() {
-        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
-        assert!(HttpRequestTool::is_blocked_ip(&ip));
-    }
-
-    #[test]
-    fn blocks_localhost_url() {
-        assert!(!HttpRequestTool::is_url_allowed("http://127.0.0.1:8080/"));
-    }
-
-    #[test]
-    fn blocks_ipv4_mapped_loopback_url() {
-        assert!(!HttpRequestTool::is_url_allowed(
-            "http://[::ffff:127.0.0.1]:8080/"
-        ));
-    }
-
-    #[test]
-    fn blocks_metadata_hostname_case_insensitively() {
-        assert!(!HttpRequestTool::is_url_allowed(
-            "http://METADATA.GOOGLE.INTERNAL/"
-        ));
+    // This test checks if `HttpRequestTool` actually enforces the shared ssrf policy .
+    #[tokio::test]
+    async fn denies_blocked_url_via_execute() {
+        let tool = HttpRequestTool::new();
+        let err = tool
+            .execute(json!({
+                "method": "GET",
+                "url": "http://127.0.0.1:8080/"
+            }))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("access denied"),
+            "err={err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
📋 Summary
Previously only mofa plugins had ssrf prevention, Httptool directly executed any passed urls, WebhookDelivery posted to config.url  without  checking if internal services were being targeted.  I've added the existing ssrf code to mofa-kernel and it is now being called by mofa-foundation and mofa-plugin and can be easily called by any future paths. 

 ⚠️ Breaking Changes
None

 Code Quality
- Code follows Rust idioms and project conventions
- `cargo fmt` run
- `cargo clippy` passes without warnings

Testing
-  Tests added/updated - Yes
-  `cargo test` passes locally without any error - Yes

PR Hygiene
-  PR is small and focused (one logical change)
-  Branch is up to date with `main`
-  No unrelated commits

🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->