### PR TITLE
Fix coordination peer subscription test

### DIFF
--- a/crates/mofa-foundation/src/coordination/tests.rs
+++ b/crates/mofa-foundation/src/coordination/tests.rs
@@ -97,6 +97,15 @@ mod tests {
         .unwrap();
     }
 
+    async fn subscribe_peer(bus: &AgentBus, id: &str) -> mofa_kernel::bus::MessageReceiver {
+        bus.subscribe(
+            id,
+            CommunicationMode::PointToPoint("coordinator".to_string()),
+        )
+        .await
+        .unwrap()
+    }
+
     // Receive one message for a peer
     async fn receive_peer(
         bus: &AgentBus,


### PR DESCRIPTION
Add the missing subscribe_peer test helper so the peer-to-peer coordination test can subscribe to coordinator-to-peer point-to-point channels.

## 📋 Summary

<!--
Explain WHAT this PR does and WHY.
Focus on the motivation and impact rather than implementation details.
-->

## 🔗 Related Issues

Closes #

Related to #

---

## 🧠 Context

<!--
Why is this change needed?
What problem does it solve?
Any relevant background or design decisions.
-->

---

## 🛠️ Changes

<!--
High-level list of changes.
Avoid low-level diffs — reviewers can see those.
-->

- 
- 
- 

---

## 🧪 How you Tested

<!--
Provide clear steps for reviewers to validate the change.
Include commands, endpoints, or scenarios.
-->

1. 
2. 
3. 

---

## 📸 Screenshots / Logs (if applicable)

<!-- CLI output, logs, or UI screenshots -->

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking change (describe below)

If breaking:

---

## 🧹 Checklist

### Code Quality
- [ ] Code follows Rust idioms and project conventions
- [ ] `cargo fmt` run
- [ ] `cargo clippy` passes without warnings

### Testing
- [ ] Tests added/updated
- [ ] `cargo test` passes locally without any error

### Documentation
- [ ] Public APIs documented
- [ ] README / docs updated (if needed)

### PR Hygiene
- [ ] PR is small and focused (one logical change)
- [ ] Branch is up to date with `main`
- [ ] No unrelated commits
- [ ] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

<!-- migrations, config changes, env vars, rollout steps -->

---

## 🧩 Additional Notes for Reviewers

<!-- Anything reviewers should pay attention to -->