### PR TITLE
test(foundation): replace no-op test_register_role with a meaningful …

### DIFF
--- a/crates/mofa-foundation/src/coordination/tests.rs
+++ b/crates/mofa-foundation/src/coordination/tests.rs
@@ -123,7 +123,57 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_role() {
-        assert!(true);
+        let bus = Arc::new(AgentBus::new());
+        let coordinator =
+            AgentCoordinator::new(bus.clone(), CoordinationStrategy::PeerToPeer).await;
+
+        // Registering a new role should succeed
+        assert!(
+            coordinator.register_role("agent_1", "worker").await.is_ok(),
+            "first register_role call should succeed"
+        );
+
+        // The role mapping should contain the registered agent
+        {
+            let role_map = coordinator.role_mapping.read().await;
+            let workers = role_map.get("worker").expect("worker role should exist");
+            assert!(
+                workers.contains(&"agent_1".to_string()),
+                "agent_1 should be registered under worker"
+            );
+        }
+
+        // Registering a second agent under the same role should accumulate, not overwrite
+        coordinator
+            .register_role("agent_2", "worker")
+            .await
+            .unwrap();
+        {
+            let role_map = coordinator.role_mapping.read().await;
+            let workers = role_map.get("worker").unwrap();
+            assert_eq!(workers.len(), 2, "both agents should be under worker role");
+            assert!(workers.contains(&"agent_1".to_string()));
+            assert!(workers.contains(&"agent_2".to_string()));
+        }
+
+        // Registering under a different role must not affect existing roles
+        coordinator
+            .register_role("agent_3", "manager")
+            .await
+            .unwrap();
+        {
+            let role_map = coordinator.role_mapping.read().await;
+            assert_eq!(
+                role_map.get("worker").unwrap().len(),
+                2,
+                "worker role should still have 2 agents"
+            );
+            assert_eq!(
+                role_map.get("manager").unwrap().len(),
+                1,
+                "manager role should have exactly 1 agent"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 📋 Summary

Replaces the no-op `assert!(true)` body in `test_register_role` with a test that actually exercises `AgentCoordinator::register_role` and verifies its behaviour.

## 🔗 Related Issues

Closes #1673

---

## 🧠 Context

`test_register_role` existed only as a placeholder — `assert!(true)` always passes unconditionally regardless of whether `register_role` works or is broken. Since `register_role` is called before every coordination strategy (PeerToPeer, Pipeline, MasterSlave), a regression there would go silently undetected.

---

## 🛠️ Changes

- Replaced `assert!(true)` with a real async test in `crates/mofa-foundation/src/coordination/tests.rs`
- Test verifies: first registration succeeds, second registration under the same role accumulates (not overwrites), and registering under a different role does not affect existing roles

---

## 🧪 How you Tested

1. `cargo test -p mofa-foundation coordination::tests --lib` — all 5 tests pass including the new `test_register_role`
2. `cargo fmt --check` — passes
3. `cargo clippy` — no new warnings

---

## 📸 Screenshots / Logs (if applicable)

```
running 5 tests
test coordination::tests::tests::test_register_role ... ok
test coordination::tests::tests::test_peer_to_peer_coordination ... ok
test coordination::tests::tests::test_pipeline_returns_stage_failure ... ok
test coordination::tests::tests::test_pipeline_preserves_root_task_id_across_stages ... ok
test coordination::tests::tests::test_pipeline_times_out_when_stage_never_responds ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; finished in 5.01s
```

---

## ⚠️ Breaking Changes

- [x] No breaking changes

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy` passes without warnings

### Testing
- [x] Tests added/updated
- [x] `cargo test` passes locally without any error

### Documentation
- [x] Public APIs documented
- [x] README / docs updated (if needed)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

None — test-only change.

---

## 🧩 Additional Notes for Reviewers

The test accesses `coordinator.role_mapping` directly (a private field) which is valid here because the `tests` module is a declared child of the `coordination` module in `mod.rs`, and Rust allows child modules to access private items of their parent.
